### PR TITLE
Use rubocop-0-69 for codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,3 +28,4 @@ plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
+    channel: rubocop-0-69


### PR DESCRIPTION
Codeclimate needs the rubocop 0.69 version to use rubocop-performance