### PR TITLE
The ems_type is supposed to be singular

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
@@ -36,7 +36,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager < Manag
   end
 
   def self.ems_type
-    @ems_type ||= "ibm_cloud_networks".freeze
+    @ems_type ||= "ibm_cloud_network".freeze
   end
 
   def self.description


### PR DESCRIPTION
E.g. [Amazon::NetworkManager](https://github.com/ManageIQ/manageiq-providers-amazon/blob/master/app/models/manageiq/providers/amazon/network_manager.rb#L37-L39) and [Azure::NetworkManager](https://github.com/ManageIQ/manageiq-providers-azure/blob/master/app/models/manageiq/providers/azure/network_manager.rb#L39-L41)

https://github.com/ManageIQ/manageiq/pull/20483/files