### PR TITLE
 Add VM spec

### DIFF
--- a/spec/factories/vm.rb
+++ b/spec/factories/vm.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :vm_ibm_cloud_power_virtual_servers, :class => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm", :parent => :vm_cloud do
+    vendor { "ibm" }
+
+    trait :with_provider do
+      after(:create) do |x|
+        FactoryBot.create(:ems_ibm_cloud_power_virtual_servers_cloud, :vms => [x])
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
@@ -1,0 +1,36 @@
+describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm do
+  let(:ems) do
+    FactoryBot.create(:ems_ibm_cloud_power_virtual_servers_cloud, :provider_region => "us-south")
+  end
+  let(:vm) { FactoryBot.create(:vm_ibm_cloud_power_virtual_servers, :ext_management_system => ems) }
+
+  context "is_available?" do
+    let(:power_state_on)        { "ACTIVE" }
+    let(:power_state_suspended) { "NOT_ACTIVE" }
+
+    context "with :start" do
+      let(:state) { :start }
+      include_examples "Vm operation is available when not powered on"
+    end
+
+    context "with :stop" do
+      let(:state) { :stop }
+      include_examples "Vm operation is available when powered on"
+    end
+
+    context "with :shutdown_guest" do
+      let(:state) { :shutdown_guest }
+      include_examples "Vm operation is not available"
+    end
+
+    context "with :standby_guest" do
+      let(:state) { :standby_guest }
+      include_examples "Vm operation is not available"
+    end
+
+    context "with :reset" do
+      let(:state) { :reset }
+      include_examples "Vm operation is not available"
+    end
+  end
+end


### PR DESCRIPTION
Work in progress i can made some changes but getting errors 

```

  1) ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm is_available? with :stop when powered on
     Failure/Error: expect(vm.is_available?(state)).to be_truthy
     
       expected: truthy value
            got: false
     Shared Example Group: "Vm operation is available when powered on" called from ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb:22
     # ./spec/manageiq/spec/support/examples_group/shared_examples_for_vm_or_template_is_available.rb:27:in `block (2 levels) in <top (required)>'

  2) ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm is_available? with :start when powered on
     Failure/Error: expect(vm.public_send("supports_#{state}?")).to be_falsey
     
       expected: falsey value
            got: true
     Shared Example Group: "Vm operation is available when not powered on" called from ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb:17
     # ./spec/manageiq/spec/support/examples_group/shared_examples_for_vm_or_template_is_available.rb:5:in `block (2 levels) in <top (required)>'

  3) ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm supports_terminate? when connected to a provider returns true
     Failure/Error: expect(vm.supports_terminate?).to be_truthy
     
       expected: truthy value
            got: false
     # ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb:42:in `block (4 levels) in <top (required)>'

  4) ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm supports_terminate? when not connected to a provider returns false
     Failure/Error: expect(archived_vm.unsupported_reason(:terminate)).to eq("The VM is not connected to an active Provider")
     
       expected: "The VM is not connected to an active Provider"
            got: "Feature not available/supported"
     
       (compared using ==)
     # ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb:51:in `block (4 levels) in <top (required)>'

Finished in 14.27 seconds (files took 13.85 seconds to load)
9 examples, 4 failures

Failed examples:

rspec ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb[1:1:2:1] # ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm is_available? with :stop when powered on
rspec ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb[1:1:1:1] # ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm is_available? with :start when powered on
rspec ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb:41 # ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm supports_terminate? when connected to a provider returns true
rspec ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb:49 # ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm supports_terminate? when not connected to a provider returns false

Randomized with seed 28006

```