### PR TITLE
Use "ibm" image_name for all managers

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -21,7 +21,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
   supports :provisioning
 
   def image_name
-    "ibm_cloud_powervs"
+    "ibm"
   end
 
   def ensure_managers

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
@@ -25,6 +25,10 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager < Manag
            :to        => :parent_manager,
            :allow_nil => true
 
+  def image_name
+    "ibm"
+  end
+
   def self.validate_authentication_args(params)
     # return args to be used in raw_connect
     [params[:default_userid], ManageIQ::Password.encrypt(params[:default_password])]

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
@@ -23,6 +23,10 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager < Manag
            :to        => :parent_manager,
            :allow_nil => true
 
+  def image_name
+    "ibm"
+  end
+
   def self.ems_type
     @ems_type ||= "ibm_cloud_storage".freeze
   end


### PR DESCRIPTION
All of the IBM Cloud managers use the same icon image. In our recently
submitted PR to manageiq-decorators
(https://github.com/ManageIQ/manageiq-decorators/pull/31) the
CloudManager symlink name isn't correct.

A more straightforward approach is to set each manager's 'image_name'
method to return common image name: "ibm".