### PR TITLE
Ensure_managers_zone wasn't being called on update

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -16,7 +16,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
           :dependent   => :destroy
 
   before_create :ensure_managers
-  before_create :ensure_managers_zone
+  before_update :ensure_managers_zone
 
   supports :provisioning
 
@@ -25,9 +25,9 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
   end
 
   def ensure_managers
-    ensure_managers_zone
     ensure_network_manager
     ensure_storage_manager
+    ensure_managers_zone
   end
 
   def ensure_managers_zone


### PR DESCRIPTION
The ensure_managers_zone method wasn't being called on update, only on before_create which meant that a zone change on the parent manager wasn't being propegated to the child managers.