### PR TITLE
Cleanup Template#provider_object method

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
@@ -7,8 +7,8 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template
     end
   end
 
-  def provider_object(connection = nil)
-    connection ||= ext_management_system.connect
+  def provider_object(_connection = nil)
+    ext_management_system.connect
   end
 
   def destroy


### PR DESCRIPTION
`connection` variable was being passed in, but never used

Found via [CodeClimate Issutes](https://codeclimate.com/github/ManageIQ/manageiq-providers-ibm_cloud/issues)