### PR TITLE
Support for multiple fields on IBM Power Virtual Servers provisioning form.

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -15,6 +15,8 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
           :autosave    => true,
           :dependent   => :destroy
 
+  delegate :cloud_volumes, :to => :storage_manager
+
   before_create :ensure_managers
   before_update :ensure_managers_zone
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -1,8 +1,10 @@
+require 'ipaddr'
+
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::ProvisionWorkflow < ::MiqProvisionCloudWorkflow
-  TIMEZONES = 
-  {
-    '006' => '(UTC-07:00) US Mountain Standard Time',
-  }.freeze
+  TIMEZONES =
+    {
+      '006' => '(UTC-07:00) US Mountain Standard Time',
+    }.freeze
 
   def self.provider_model
     ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager
@@ -16,15 +18,69 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
     TIMEZONES
   end
 
+  def allowed_sys_type(_options = {})
+    # TODO: replace with api provided values, once issue '114' is solved and merged
+    {0 => "s922", 1 => "e880"}
+  end
+
+  def allowed_storage_type(_options = {})
+    # TODO: replace with api provided values, once issue '115' is solved and merged
+    {0 => "None", 1 => "Tier 1", 2 => "Tier 3"}
+  end
+
+  def allowed_guest_access_key_pairs(_options = {})
+    ar_ems = ar_ems_get
+    ar_key_pairs = ar_ems&.key_pairs
+    key_pairs = ar_key_pairs&.map&.with_index { |key_pair, i| [i + 1, key_pair['name']] }
+    none = [0, 'None']
+    Hash[key_pairs&.insert(0, none) || none]
+  end
+
   def allowed_subnets(_options = {})
-    ems = resources_for_ui[:ems]
-    ar_ems = load_ar_obj(ems) if ems
-    ar_subnets = ar_ems.cloud_subnets if ar_ems
+    ar_ems = ar_ems_get
+    ar_subnets = ar_ems&.cloud_subnets
     subnets = ar_subnets&.collect { |subnet| [subnet[:ems_ref], subnet[:name]] }
     Hash[subnets || {}]
   end
 
+  def allowed_cloud_volumes(_options = {})
+    ar_ems = ar_ems_get
+    ar_volumes = ar_ems&.cloud_volumes if ar_ems
+    cloud_volumes = ar_volumes&.map { |cloud_volume| [cloud_volume['ems_ref'], cloud_volume['name']] }
+    Hash[cloud_volumes || {}]
+  end
+
+  def validate_entitled_processors(_field, values, _dlg, _fld, value)
+    dedicated = values[:instance_type][1] == 'dedicated'
+
+    fval = /^\s*[\d]*(\.[\d]+)?\s*$/.match?(value) ? value.strip.to_f : 0
+    return "Entitled Processors field does not contain a well-formed positive number" unless fval > 0
+
+    if dedicated
+      return 'For dedicated processors, the format is: "positive integer"' unless fval % 1 == 0
+    else
+      return 'For shared processors, the format is: "positive whole multiple of 0.25"' unless (fval / 0.25) % 1 == 0
+    end
+  end
+
+  def validate_ip_address(_field, _values, _dlg, _fld, value)
+    return if value.blank?
+
+    begin
+      valid = IPAddr.new(value.strip).ipv4?
+    rescue IPAddr::InvalidAddressError
+      valid = false
+    end
+
+    return 'IP-address field has to be either blank or a valid IPv4 address' unless valid
+  end
+
   private
+
+  def ar_ems_get
+    ems = resources_for_ui[:ems]
+    ems ? load_ar_obj(ems) : nil
+  end
 
   def dialog_name_from_automate(_message = 'get_dialog_name')
   end

--- a/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
@@ -13,9 +13,46 @@
       :display: :hide
 
     :customize:
-      :fields: {}
-      :description: Extra
-      :display: :hide
+      :description: Customization
+      :fields:
+        :ip_addr:
+          :description: Specify an IPv4 address
+          :required_method: :validate_ip_address
+          :required: true
+          :display: :edit
+          :data_type: :string
+          :min_length: 8
+          :max_length: 16
+        :pin_policy:
+          :values:
+            1: "none"
+            2: "soft"
+            3: "hard"
+          :description: VM pinning
+          :required: true
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :migratable:
+          :values:
+            false: 0
+            true: 1
+          :description: Migratable
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :user_script:
+          :description: Upload
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :user_script_text:
+          :description: User Script
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
 
     :environment:
       :description: Environment
@@ -61,39 +98,64 @@
     :hardware:
       :description: Profile
       :fields:
-        :number_of_sockets:
-          :values:
-            1: 1
-            2: 2
-            4: 4
-            8: 8
-          :description: Cores (CPUs)
+        :entitled_processors:
+          :description: Entitled Processors
           :required: true
+          :required_method: :validate_entitled_processors
           :display: :edit
-          :default: 1
-          :data_type: :integer
+          :default: '0.25'
+          :data_type: :string
+          :min_length: 1
+          :max_length: 5
         :instance_type:
           :values:
-            1: "capped"
-            2: "uncapped"
-            3: "dedicated"
+            0: "capped"
+            1: "shared"
+            2: "dedicated"
           :description: Processor
           :required: true
           :display: :edit
-          :default: 1
+          :default: 0
           :data_type: :integer
-        :vm_memory:
-          :values:
-            2:  2
-            4:  4
-            8:  8
-            16: 16
-            32: 32
-            64: 64
-          :description: Memory (GB)
+        :sys_type:
+          :values_from:
+            :method: :allowed_sys_type
+          :description: Machine Type
           :required: true
           :display: :edit
-          :default: 2
+          :default: 0
+          :data_type: :integer
+        :storage_type:
+          :values_from:
+            :method: :allowed_storage_type
+          :description: Storage Type
+          :required: true
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :vm_memory:
+          :description: Memory (GB)
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /^\s*[0-9]+\s*$/
+          :required: true
+          :default: "2"
+          :data_type: :string
+          :display: :edit
+        :cloud_volumes:
+          :values_from:
+            :method: :allowed_cloud_volumes
+          :description: Attach Volumes
+          :required: false
+          :display: :edit
+          :auto_select_single: false
+          :data_type: :string
+        :guest_access_key_pair:
+          :values_from:
+            :method: :allowed_guest_access_key_pairs
+          :description: Key Pair
+          :required: true
+          :display: :edit
+          :default: 0
           :data_type: :integer
       :display: :show
 
@@ -116,9 +178,10 @@
   - :service
   - :hardware
   - :network
+  - :customize
 
   - :purpose     # unused
   - :requester   # unused
   - :environment # unused
-  - :customize   # unused
   - :schedule    # unused
+

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -87,7 +87,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
       )
 
       expect(vm.operating_system).to have_attributes(
-        :product_name => "aix"
+        :product_name => "unix_aix"
       )
 
       expect(vm.cloud_networks.pluck(:ems_ref))
@@ -161,7 +161,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
         :name        => "c91ad01c-23e0-4602-b605-8f8c259e8150",
         :mac_address => "fa:1f:a0:cd:36:20",
         :status      => "ACTIVE",
-        :device_ref  => "7effc17f-f708-48f0-862d-4177fabf62fe",
+        :device_ref  => "7effc17f-f708-48f0-862d-4177fabf62fe"
       )
 
       expect(network_port.cloud_subnets.count).to eq(2)


### PR DESCRIPTION
- added support for the user post-provisioning script upload
- added support for multiple volume attachment to provisioning form
- added support for "IP-Address v4" field to provisioning form
- added CPU amount validation based on the CPU type on provisioning form
- changed Memory field from drop-down to text-input on provisioning form
- added "Keypair" field to the provisioning form
- added support for "VM Pinning", "Migratable", "System Type" to the provisioning form
- added support for 'Entitled Processors' to the provisioning form
- moved 'Storage Type' and 'System Type' values to the provision_workflow code
- using getter for the access to EMS data in DB in provision_workflow
- fix in a spec containing a wrong AIX OS name
- fix for the case of empty set of values in the 'volumes' field