### PR TITLE
Add APP_PATH to allow using Rails directly

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -4,6 +4,8 @@
 
 ENGINE_ROOT = File.expand_path('..', __dir__)
 ENGINE_PATH = File.expand_path('../lib/manageiq/providers/ibm_cloud/engine', __dir__)
+APP_PATH    = File.expand_path('../../spec/manageiq/config/application', __FILE__)
+
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])


### PR DESCRIPTION
Allow calling e.g. `rails c` directly from the plugin by adding APP_PATH to the bin/rails script

This was blasted out to all the plugins but this one seems to have been missed, see https://github.com/ManageIQ/manageiq-providers-amazon/pull/641

cc @Fryguy 