### PR TITLE
Add PowerVS NetworkManager specs

### DIFF
--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager_spec.rb
@@ -1,0 +1,27 @@
+describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager do
+  context "ems" do
+    it "does not support network creation" do
+      ems = FactoryBot.create(:ems_ibm_cloud_power_virtual_servers_cloud)
+      expect(ems.supports_ems_network_new?).to eq(false)
+    end
+  end
+
+  context "singleton methods" do
+    it "returns the expected value for the description method" do
+      expect(described_class.description).to eq('IBM Power Systems Virtual Servers Network')
+    end
+
+    it "returns the expected value for the ems_type method" do
+      expect(described_class.ems_type).to eq('ibm_cloud_power_virtual_servers_network')
+    end
+
+    it "returns the expected value for the hostname_required? method" do
+      expect(described_class.hostname_required?).to eq(false)
+    end
+
+    it "returns the expected value for the display_name method" do
+      expect(described_class.display_name).to eq('Network Manager')
+      expect(described_class.display_name(2)).to eq('Network Managers')
+    end
+  end
+end


### PR DESCRIPTION
```
[basha@oc7502186607 manageiq-providers-ibm_cloud]$ bundle exec rspec spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager_spec.rb
** ManageIQ master, codename: Kasparov

Randomized with seed 10680
..FF..

Failures:

  1) ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager singleton methods returns the expected value for the display_name method
     Failure/Error: expect(described_class.display_name).to eq('Network Provider (cloud_network)')
     
       expected: "Network Provider (cloud_network)"
            got: "Network Manager"
     
       (compared using ==)
     # ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager_spec.rb:33:in `block (3 levels) in <top (required)>'

  2) ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager singleton methods returns the expected value for the default_blacklisted_event_names method
     Failure/Error: expect(described_class.default_blacklisted_event_names).to eq(array)
     
       expected: ["ConfigurationSnapshotDeliveryCompleted", "ConfigurationSnapshotDeliveryStarted", "ConfigurationSnapshotDeliveryFailed"]
            got: []
     
       (compared using ==)
     # ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager_spec.rb:29:in `block (3 levels) in <top (required)>'

Finished in 2.8 seconds (files took 8.05 seconds to load)
6 examples, 2 failures

Failed examples:

rspec ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager_spec.rb:32 # ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager singleton methods returns the expected value for the display_name method
rspec ./spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager_spec.rb:22 # ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager singleton methods returns the expected value for the default_blacklisted_event_names method

Randomized with seed 10680
```