### PR TITLE
Remove stale volume API calls module

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/vol_api_calls.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/vol_api_calls.rb
@@ -1,4 +1,0 @@
-module ManageIQ::Providers::IbmCloud::PowerVirtualServers::VolAPICalls
-  require 'rest-client'
-  require 'json'  
-end


### PR DESCRIPTION
All API calls are now made through the 'ibm-cloud-sdk-ruby' Ruby gem.