### PR TITLE
Fix PowerVS delete subnet call

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/cloud_subnet.rb
@@ -27,8 +27,8 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager::CloudS
   end
 
   def raw_delete_cloud_subnet
-    ext_management_system.with_provider_connection({:service => 'PowerIaas'}) do |net_control|
-      net_control.del_subnet(ems_ref)
+    ext_management_system.with_provider_connection(:service => 'PowerIaas') do |power_iaas|
+      power_iaas.delete_network(ems_ref)
     end
   rescue => e
     _log.error("network=[#{name}], error: #{e}")


### PR DESCRIPTION
The call to delete PowerVS cloud subnets needs to be updated to match
the 'ibm-cloud-sdk' gem.