### PR TITLE
Fix PowerVS ems connect options (use ':service' instead of ':target')

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/auth_key_pair.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::AuthKeyP
   IbmCvsKeyPair = Struct.new(:name, :key_name, :fingerprint, :private_key)
 
   def self.raw_create_key_pair(ext_management_system, create_options)
-    power_iaas = ext_management_system.connect(:target => "PowerIaas")
+    power_iaas = ext_management_system.connect(:service => "PowerIaas")
     kp = power_iaas.create_key_pair(create_options[:name], create_options[:public_key])
     IbmCvsKeyPair.new(kp["name"], kp["name"], nil, nil)
   rescue => err
@@ -22,7 +22,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::AuthKeyP
   end
 
   def raw_delete_key_pair
-    power_iaas = resource.connect(:target => "PowerIaas")
+    power_iaas = resource.connect(:service => "PowerIaas")
     power_iaas.delete_key_pair(name)
   rescue => err
     _log.log_backtrace(err)

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
@@ -39,7 +39,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template
   end
 
   def raw_delete_image
-    ext_management_system.with_provider_connection(:target => 'PowerIaas') do |power_iaas|
+    ext_management_system.with_provider_connection(:service => 'PowerIaas') do |power_iaas|
       power_iaas.delete_image(ems_ref)
       _log.info("Deleting cloud image=[name: '#{name}', id: '#{ems_ref}']")
     end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -4,28 +4,28 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
   supports_not :suspend
 
   def raw_start
-    with_provider_connection({:target => 'PowerIaas'}) do |power_iaas|
+    with_provider_connection({:service => 'PowerIaas'}) do |power_iaas|
       power_iaas.start_pvm_instance(ems_ref)
     end
     update!(:raw_power_state => "on")
   end
 
   def raw_stop
-    with_provider_connection({:target => 'PowerIaas'}) do |power_iaas|
+    with_provider_connection({:service => 'PowerIaas'}) do |power_iaas|
       power_iaas.stop_pvm_instance(ems_ref)
     end
     update!(:raw_power_state => "off")
   end
 
   def raw_reboot_guest
-    with_provider_connection({:target => 'PowerIaas'}) do |power_iaas|
+    with_provider_connection({:service => 'PowerIaas'}) do |power_iaas|
       power_iaas.reboot_pvm_instance(ems_ref)
     end
     update!(:raw_power_state => "off")
   end
 
   def raw_destroy
-    with_provider_connection({:target => 'PowerIaas'}) do |power_iaas|
+    with_provider_connection({:service => 'PowerIaas'}) do |power_iaas|
       power_iaas.delete_pvm_instance(ems_ref)
     end
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
@@ -69,7 +69,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager < Manag
   end
 
   def raw_create_cloud_subnet(ext_management_system, options)
-    ext_management_system.with_provider_connection({:target => 'PowerIaas'}) do |power_iaas|
+    ext_management_system.with_provider_connection({:service => 'PowerIaas'}) do |power_iaas|
       type ||= 'vlan'
 
       subnet = {


### PR DESCRIPTION
See the connect method defined in
app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
We're using the ':service' as the 'options' key to set the connection
type.