### PR TITLE
Remove redundant braces around connect options

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -16,7 +16,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
   end
 
   def start_clone(clone_options)
-    source.with_provider_object({:service => "PowerIaas"}) do |power_iaas|
+    source.with_provider_object(:service => "PowerIaas") do |power_iaas|
       power_iaas.create_pvm_instance(clone_options)[0]['pvmInstanceID']
     end
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -4,28 +4,28 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
   supports_not :suspend
 
   def raw_start
-    with_provider_connection({:service => 'PowerIaas'}) do |power_iaas|
+    with_provider_connection(:service => 'PowerIaas') do |power_iaas|
       power_iaas.start_pvm_instance(ems_ref)
     end
     update!(:raw_power_state => "on")
   end
 
   def raw_stop
-    with_provider_connection({:service => 'PowerIaas'}) do |power_iaas|
+    with_provider_connection(:service => 'PowerIaas') do |power_iaas|
       power_iaas.stop_pvm_instance(ems_ref)
     end
     update!(:raw_power_state => "off")
   end
 
   def raw_reboot_guest
-    with_provider_connection({:service => 'PowerIaas'}) do |power_iaas|
+    with_provider_connection(:service => 'PowerIaas') do |power_iaas|
       power_iaas.reboot_pvm_instance(ems_ref)
     end
     update!(:raw_power_state => "off")
   end
 
   def raw_destroy
-    with_provider_connection({:service => 'PowerIaas'}) do |power_iaas|
+    with_provider_connection(:service => 'PowerIaas') do |power_iaas|
       power_iaas.delete_pvm_instance(ems_ref)
     end
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
@@ -69,7 +69,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager < Manag
   end
 
   def raw_create_cloud_subnet(ext_management_system, options)
-    ext_management_system.with_provider_connection({:service => 'PowerIaas'}) do |power_iaas|
+    ext_management_system.with_provider_connection(:service => 'PowerIaas') do |power_iaas|
       type ||= 'vlan'
 
       subnet = {


### PR DESCRIPTION
`PowerVirtualServers::CloudManager#connect` takes a single hash parameter so curly braces around the options aren't necessary