### PR TITLE
Set PowerVS SystemType name

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
@@ -211,7 +211,8 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
     collector.system_pool.each do |v|
       persister.flavors.build(
         :type    => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SystemType",
-        :ems_ref => v['type']
+        :ems_ref => v['type'],
+        :name    => v['type']
       )
     end
   end


### PR DESCRIPTION
Flavors are displayed in the UI with a subset of the DB table columns.
Setting ':name' here so the user doesn't get a UI table with a bunch of
blank rows.