### PR TITLE
Added support for Cloud Volume creation in IBM PVS provisioning

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
 
   def prepare_for_clone_task
     specs = {
-      'serverName' => get_option(:vm_target_name) ,
+      'serverName' => get_option(:vm_target_name),
       'imageID'    => get_option_last(:src_vm_id),
       'processors' => get_option_last(:entitled_processors).to_f,
       'procType'   => get_option_last(:instance_type),

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
 
   def prepare_for_clone_task
     specs = {
-      'serverName' => get_option(:vm_target_name),
+      'serverName' => get_option(:vm_target_name) ,
       'imageID'    => get_option_last(:src_vm_id),
       'processors' => get_option_last(:entitled_processors).to_f,
       'procType'   => get_option_last(:instance_type),
@@ -24,15 +24,16 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     chosen_storage_type = get_option_last(:storage_type)
     specs['storageType'] = chosen_storage_type unless chosen_storage_type == 'None'
 
-    chosen_volumes = options[:cloud_volumes]
-    specs['volumeIDs'] = chosen_volumes unless chosen_volumes.compact.empty?
-
     chosen_key_pair = get_option_last(:guest_access_key_pair)
     specs['keyPairName'] = chosen_key_pair unless chosen_key_pair == 'None'
 
     user_script_text = options[:user_script_text]
     user_script_text64 = Base64.encode64(user_script_text) unless user_script_text.nil?
     specs['userData'] = user_script_text64 unless user_script_text64.nil?
+
+    attached_volumes = options[:cloud_volumes] || []
+    attached_volumes.concat(phase_context[:new_volumes]).compact!
+    specs['volumeIDs'] = attached_volumes unless attached_volumes.empty?
 
     specs
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
@@ -8,16 +8,13 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     phase_context[:new_volumes] = []
 
     if new_volumes.any?
-      source.with_provider_object({:service => "PowerIaas"}) do |power_iaas|
+      source.with_provider_object(:service => "PowerIaas") do |power_iaas|
         new_volumes.each do |new_volume|
           phase_context[:new_volumes] << power_iaas.create_volume(new_volume)['volumeID']
         end
       end
     end
 
-    # TODO: find out if we have to wait here until cloud volumes are available
-
     signal :prepare_provision
   end
-
 end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
@@ -1,5 +1,23 @@
 module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provision::StateMachine
   def create_destination
+    signal :prepare_volumes
+  end
+
+  def prepare_volumes
+    new_volumes = options[:new_volumes]
+    phase_context[:new_volumes] = []
+
+    if new_volumes.any?
+      source.with_provider_object({:service => "PowerIaas"}) do |power_iaas|
+        new_volumes.each do |new_volume|
+          phase_context[:new_volumes] << power_iaas.create_volume(new_volume)['volumeID']
+        end
+      end
+    end
+
+    # TODO: find out if we have to wait here until cloud volumes are available
+
     signal :prepare_provision
   end
+
 end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -63,18 +63,18 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
     stop = false
     new_volumes = []
 
-    while not stop
+    while !stop
       new_volume = {}
 
-      %w(name size diskType shareable).map do |fld|
-        cnt = new_volumes.length+1
-        key = (:"#{fld}_#{cnt}").to_sym
+      %w[name size diskType shareable].map do |fld|
+        cnt = new_volumes.length + 1
+        key = :"#{fld}_#{cnt}".to_sym
         new_volume[fld.to_sym] = values[key] if values.key?(key)
       end
 
       stop = new_volume.empty?
 
-      if not stop
+      if !stop
         new_volume[:name] = nil if new_volume[:name].blank?
         new_volume[:diskType] = nil if new_volume[:diskType].blank?
         new_volume[:size] = new_volume[:size].blank? ? nil : new_volume[:size].to_i

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -85,7 +85,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
   def validate_entitled_processors(field, values, dlg, fld, value)
     dedicated = values[:instance_type][1] == 'dedicated'
 
-    fval = value.match(/^\s*[\d]+(\.[\d]+)?\s*$/) ? value.strip.to_f : 0
+    fval = value.match(/^\s*[\d]*(\.[\d]+)?\s*$/) ? value.strip.to_f : 0
     return "Entitled Processors field does not contain a well-formed positive number" unless fval > 0
 
     if dedicated

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -18,8 +18,8 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
     TIMEZONES
   end
 
-  def keys_for_volumes
-    [:name, :size, :diskType, :shareable]
+  def volume_dialog_keys
+    %i[name size diskType shareable]
   end
 
   def allowed_sys_type(_options = {})

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -82,10 +82,10 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
     new_volumes
   end
 
-  def validate_entitled_processors(field, values, dlg, fld, value)
+  def validate_entitled_processors(_field, values, _dlg, _fld, value)
     dedicated = values[:instance_type][1] == 'dedicated'
 
-    fval = value.match(/^\s*[\d]*(\.[\d]+)?\s*$/) ? value.strip.to_f : 0
+    fval = /^\s*[\d]*(\.[\d]+)?\s*$/.match?(value) ? value.strip.to_f : 0
     return "Entitled Processors field does not contain a well-formed positive number" unless fval > 0
 
     if dedicated

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -18,6 +18,10 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
     TIMEZONES
   end
 
+  def keys_for_volumes
+    [:name, :size, :diskType, :shareable]
+  end
+
   def allowed_sys_type(_options = {})
     # TODO: replace with api provided values, once issue '114' is solved and merged
     {0 => "s922", 1 => "e880"}

--- a/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
@@ -174,9 +174,42 @@
           :data_type: :string
       :display: :show
 
+    :volumes:
+      :description: New Volumes
+      :fields:
+        :name:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :size:
+          :description: Size (GB)
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 10
+        :shareable:
+          :description: Shareable
+          :required: false
+          :data_type: :boolean
+          :default: false
+          :display: :edit
+        :diskType:
+          :description: Disk type
+          :required: false
+          :data_type: :string
+          :min_length:
+          :max_length: 20
+          :display: :edit
+      :display: :show
+
   :dialog_order:
   - :service
   - :hardware
+  - :volumes
   - :network
   - :customize
 

--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -8,4 +8,8 @@ FactoryBot.define do
       end
     end
   end
+
+  factory :template_ibm_cloud_power_virtual_servers, :class => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template", :parent => :template_cloud do
+    vendor { "ibm" }
+  end
 end

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
@@ -76,50 +76,50 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provi
         ]
       )
     values = {
-        :name        => nil,
-        :size        => nil,
-        :shareable   => false,
-        :diskType    => nil,
-        :name_1      => "disk_one",
-        :diskType_1  => "tier1",
-        :shareable_1 => "null",
-        :size_2      => "2",
-        :diskType_2  => "standard-legacy",
-        :name_3      => "disk_three",
-        :size_3      => "3",
-       :diskType_3  => "tier3",
-       :name_4      => "disk_four",
-       :size_4      => "",
-       :diskType_4  => "ssd-legacy",
-       :shareable_4 => true
+      :name        => nil,
+      :size        => nil,
+      :shareable   => false,
+      :diskType    => nil,
+      :name_1      => "disk_one",
+      :diskType_1  => "tier1",
+      :shareable_1 => "null",
+      :size_2      => "2",
+      :diskType_2  => "standard-legacy",
+      :name_3      => "disk_three",
+      :size_3      => "3",
+      :diskType_3  => "tier3",
+      :name_4      => "disk_four",
+      :size_4      => "",
+      :diskType_4  => "ssd-legacy",
+      :shareable_4 => true
    }
    expect(workflow.parse_new_volumes_fields(values))
      .to match_array(
        [
          {
-             :name      => "disk_one",
-             :diskType  => "tier1",
-             :size      => 0,
-             :shareable => false
+           :name      => "disk_one",
+           :diskType  => "tier1",
+           :size      => 0,
+           :shareable => false
          },
          {
-             :size      => 2,
-             :diskType  => "standard-legacy",
-             :shareable => false
+           :size      => 2,
+           :diskType  => "standard-legacy",
+           :shareable => false
          },
          {
-             :name      => "disk_three",
-             :size      => 3,
-             :diskType  => "tier3",
-             :shareable => false
+           :name      => "disk_three",
+           :size      => 3,
+           :diskType  => "tier3",
+           :shareable => false
          },
          {
-             :name      => "disk_four",
-             :size      => 0,
-             :diskType  => "ssd-legacy",
-             :shareable => true
+           :name      => "disk_four",
+           :size      => 0,
+           :diskType  => "ssd-legacy",
+           :shareable => true
          }
-      ]
-    )
+       ]
+     )
   end
 end

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
@@ -92,34 +92,34 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provi
       :size_4      => "",
       :diskType_4  => "ssd-legacy",
       :shareable_4 => true
-   }
-   expect(workflow.parse_new_volumes_fields(values))
-     .to match_array(
-       [
-         {
-           :name      => "disk_one",
-           :diskType  => "tier1",
-           :size      => 0,
-           :shareable => false
-         },
-         {
-           :size      => 2,
-           :diskType  => "standard-legacy",
-           :shareable => false
-         },
-         {
-           :name      => "disk_three",
-           :size      => 3,
-           :diskType  => "tier3",
-           :shareable => false
-         },
-         {
-           :name      => "disk_four",
-           :size      => 0,
-           :diskType  => "ssd-legacy",
-           :shareable => true
-         }
-       ]
-     )
+    }
+    expect(workflow.parse_new_volumes_fields(values))
+      .to match_array(
+        [
+          {
+            :name      => "disk_one",
+            :diskType  => "tier1",
+            :size      => 0,
+            :shareable => false
+          },
+          {
+            :size      => 2,
+            :diskType  => "standard-legacy",
+            :shareable => false
+          },
+          {
+            :name      => "disk_three",
+            :size      => 3,
+            :diskType  => "tier3",
+            :shareable => false
+          },
+          {
+            :name      => "disk_four",
+            :size      => 0,
+            :diskType  => "ssd-legacy",
+            :shareable => true
+          }
+        ]
+      )
   end
 end

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
@@ -1,0 +1,79 @@
+describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::ProvisionWorkflow do
+  include Spec::Support::WorkflowHelper
+
+  let(:admin) { FactoryBot.create(:user_with_group) }
+  let(:ems) { FactoryBot.create(:ems_ibm_cloud_power_virtual_servers_cloud) }
+  let(:template) do
+    FactoryBot.create(
+      :template_ibm_cloud_power_virtual_servers,
+      :name                  => "template",
+      :ext_management_system => ems
+    )
+  end
+  let(:workflow) do
+    stub_dialog
+    allow(User).to receive_messages(:server_timezone => "UTC")
+    described_class.new({:src_vm_id => template.id}, admin.userid)
+  end
+
+  it "#parse_new_volumes_fields" do
+    values = {
+      :name      => nil,
+      :size      => nil,
+      :shareable => false,
+      :diskType  => nil
+    }
+    expect(workflow.parse_new_volumes_fields(values))
+      .to match_array([])
+    values = {
+      :name        => nil,
+      :size        => nil,
+      :shareable   => false,
+      :diskType    => nil,
+      :name_1      => "disk_one",
+      :size_1      => "1",
+      :diskType_1  => "tier1",
+      :shareable_1 => "null",
+      :name_2      => "disk_two",
+      :size_2      => "2",
+      :diskType_2  => "standard-legacy",
+      :name_3      => "disk_three",
+      :size_3      => "3",
+      :diskType_3  => "tier3",
+      :shareable_3 => nil,
+      :name_4      => "disk_four",
+      :size_4      => "4",
+      :diskType_4  => "ssd-legacy",
+      :shareable_4 => true
+    }
+    expect(workflow.parse_new_volumes_fields(values))
+      .to match_array(
+        [
+          {
+            :name      => "disk_one",
+            :size      => 1,
+            :diskType  => "tier1",
+            :shareable => false
+          },
+          {
+            :name      => "disk_two",
+            :size      => 2,
+            :diskType  => "standard-legacy",
+            :shareable => false
+          },
+          {
+            :name      => "disk_three",
+            :size      => 3,
+            :diskType  => "tier3",
+            :shareable => false
+          },
+          {
+            :name      => "disk_four",
+            :size      => 4,
+            :diskType  => "ssd-legacy",
+            :shareable => true
+          }
+        ]
+      )
+  end
+end

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
@@ -75,5 +75,51 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provi
           }
         ]
       )
+    values = {
+        :name        => nil,
+        :size        => nil,
+        :shareable   => false,
+        :diskType    => nil,
+        :name_1      => "disk_one",
+        :diskType_1  => "tier1",
+        :shareable_1 => "null",
+        :size_2      => "2",
+        :diskType_2  => "standard-legacy",
+        :name_3      => "disk_three",
+        :size_3      => "3",
+       :diskType_3  => "tier3",
+       :name_4      => "disk_four",
+       :size_4      => "",
+       :diskType_4  => "ssd-legacy",
+       :shareable_4 => true
+   }
+   expect(workflow.parse_new_volumes_fields(values))
+     .to match_array(
+       [
+         {
+             :name      => "disk_one",
+             :diskType  => "tier1",
+             :size      => 0,
+             :shareable => false
+         },
+         {
+             :size      => 2,
+             :diskType  => "standard-legacy",
+             :shareable => false
+         },
+         {
+             :name      => "disk_three",
+             :size      => 3,
+             :diskType  => "tier3",
+             :shareable => false
+         },
+         {
+             :name      => "disk_four",
+             :size      => 0,
+             :diskType  => "ssd-legacy",
+             :shareable => true
+         }
+      ]
+    )
   end
 end


### PR DESCRIPTION
- conerns IBM Power Virtual Server provisioning form
- it is possible now to create new cloud volumes during
  the provisioning itself
- added "New Volumes" tab to the form
- fields: (volume) name, size (gb), shareable (bool), disk-type
  (currently) text field
- multiple volumes can be created
- current limitations are missing validation on the form itself,
  disk-type is not a pull-down field, missing clear volume button,
  missing the ignoring of empty fields of the volume added on UI
  dynamically
- corresp. UI classic changes are in this PR:
  https://github.com/ManageIQ/manageiq-ui-classic/pull/7338