### PR TITLE
PowerVS: Use 'cloud_volume_types' table for storage types

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
@@ -24,7 +24,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
     networks
     sshkeys
     systemtypes
-    storagetypes
+    cloud_volume_types
   end
 
   def instances
@@ -99,7 +99,6 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
     collector.images.each do |ibm_image|
       id    = ibm_image['imageID']
       name  = ibm_image['name']
-
       os      = ibm_image['specifications']['operatingSystem']
       arch    = ibm_image['specifications']['architecture']
       endian  = ibm_image['specifications']['endianness']
@@ -217,15 +216,16 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
     end
   end
 
-  def storagetypes
+  def cloud_volume_types
     # get only the active storage
     collector.storage_types.each do |v|
       next unless v['state'] == 'active'
 
-      persister.flavors.build(
-        :type    => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::StorageType",
-        :ems_ref => v['type'],
-        :name    => v['description']
+      persister.cloud_volume_types.build(
+        :type        => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudVolumeType",
+        :ems_ref     => v['type'],
+        :name        => v['type'],
+        :description => v['description']
       )
     end
   end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers.rb
@@ -65,6 +65,9 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::PowerVirtualServers <
     add_storage_collection(:cloud_volumes) do |builder|
       builder.add_default_values(:ems_id => ->(persister) { persister.storage_manager.id })
     end
+    add_storage_collection(:cloud_volume_types) do |builder|
+      builder.add_default_values(:ems_id => ->(persister) { persister.storage_manager.id })
+    end
   end
 
   def add_cloud_collection(name)

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -9,6 +9,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
 
   include ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
   delegate :cloud_volumes, :to => :storage_manager
+  delegate :cloud_volume_types, :to => :storage_manager
   has_one :storage_manager,
           :foreign_key => :parent_ems_id,
           :class_name  => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager",
@@ -18,10 +19,6 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
   has_many :system_types,
            :foreign_key => :ems_id,
            :class_name  => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SystemType"
-
-  has_many :storage_types,
-           :foreign_key => :ems_id,
-           :class_name  => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::StorageType"
 
   before_create :ensure_managers
   before_update :ensure_managers_zone

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/storage_type.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/storage_type.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::StorageType < ::Flavor
-end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager < ManageIQ::Providers::StorageManager
   require_nested :CloudVolume
+  require_nested :CloudVolumeType
   require_nested :Refresher
 
   include ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume_type.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume_type.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudVolumeType < ::CloudVolumeType
+end


### PR DESCRIPTION
Storing both system types and storage types in the 'flavors' table is
confusing. Storage types for 'CloudVolume' objects fits perfectly into
the 'cloud_volume_types' table.