### PR TITLE
Make the default credentials required in the provider DDF

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -52,6 +52,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
                       :id                     => 'endpoints.default.valid',
                       :name                   => 'endpoints.default.valid',
                       :skipSubmit             => true,
+                      :isRequired             => true,
                       :validationDependencies => %w[type zone_id uid_ems],
                       :fields                 => [
                         {

--- a/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
@@ -47,6 +47,7 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
                 :component              => 'validate-provider-credentials',
                 :name                   => 'authentications.default.valid',
                 :skipSubmit             => true,
+                :isRequired             => true,
                 :validationDependencies => %w[type zone_id provider_region],
                 :fields                 => [
                   {


### PR DESCRIPTION
The default behavior for the `async-credentials` component is [changing to be optional](https://github.com/ManageIQ/manageiq-ui-classic/pull/7347), so it has to be explicitly marked as required here.