### PR TITLE
Setting default subnet type to 'vlan-pub' in PVS

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
@@ -70,10 +70,8 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager < Manag
 
   def raw_create_cloud_subnet(ext_management_system, options)
     ext_management_system.with_provider_connection(:service => 'PowerIaas') do |power_iaas|
-      type ||= 'vlan'
-
       subnet = {
-        :type       => type,
+        :type       => options[:type] || 'pub-vlan',
         :name       => options[:name],
         :cidr       => options[:cidr],
         :gateway    => options[:gateway_ip],


### PR DESCRIPTION
- concerns Power Virtual Servers provider
- until UI supports a drop-down with network
  type selection we hardcode the value to 'vlan-pub'