### PR TITLE
Add PowerVS Cloud Volume Create

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -8,8 +8,12 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
   require_nested :Vm
 
   include ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
-  delegate :cloud_volumes, :to => :storage_manager
-  delegate :cloud_volume_types, :to => :storage_manager
+
+  delegate :cloud_volumes,
+           :cloud_volume_types,
+           :to        => :storage_manager,
+           :allow_nil => true
+
   has_one :storage_manager,
           :foreign_key => :parent_ems_id,
           :class_name  => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager",
@@ -24,6 +28,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
   before_update :ensure_managers_zone
 
   supports :provisioning
+  supports_not :volume_availability_zones
 
   def image_name
     "ibm"

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
@@ -24,6 +24,9 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager < Manag
            :to        => :parent_manager,
            :allow_nil => true
 
+  virtual_delegate :cloud_tenants, :to => :parent_manager, :allow_nil => true
+  virtual_delegate :volume_availability_zones, :to => :parent_manager, :allow_nil => true
+
   def image_name
     "ibm"
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
@@ -1,4 +1,27 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudVolume < ::CloudVolume
+  supports :create
+
+  def self.validate_create_volume(ext_management_system)
+    validate_volume(ext_management_system)
+  end
+
+  def self.raw_create_volume(ext_management_system, options)
+    volume_params = {
+      'name'     => options[:name],
+      'size'     => options[:size],
+      'diskType' => options[:volume_type]
+    }
+
+    volume = nil
+    ext_management_system.with_provider_connection(:service => 'PowerIaas') do |power_iaas|
+      volume = power_iaas.create_volume(volume_params)
+    end
+    {:ems_ref => volume['volumeID'], :status => volume['state'], :name => volume['name']}
+  rescue => e
+    _log.error("volume=[#{volume_params}], error: #{e}")
+    raise MiqException::MiqVolumeCreateError, e.to_s, e.backtrace
+  end
+
   def validate_delete_volume
     msg = validate_volume
     return {:available => msg[:available], :message => msg[:message]} unless msg[:available]


### PR DESCRIPTION
Add PowerVS Cloud Volume create feature. Available types are retrieved
from the 'cloud_volume_types' table.

Requires UI changes, see PR ManageIQ/manageiq-ui-classic#7351