### PR TITLE
Enable manageiq-provider-ibm_cloud logging

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -108,6 +108,8 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
       end
 
       require "ibm-cloud-sdk"
+      IBM::Cloud::SDK.logger = $ibmcloud_log
+
       iam = IBM::Cloud::SDK::IAM.new(api_key)
       token = iam.get_identity_token
       power_iaas_service = IBM::Cloud::SDK::ResourceController.new(token).get_resource(pcloud_guid)

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -108,7 +108,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
       end
 
       require "ibm-cloud-sdk"
-      IBM::Cloud::SDK.logger = $ibmcloud_log
+      IBM::Cloud::SDK.logger = $ibm_cloud_log
       iam = IBM::Cloud::SDK::IAM.new(api_key)
       token = iam.get_identity_token
       power_iaas_service = IBM::Cloud::SDK::ResourceController.new(token).get_resource(pcloud_guid)

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -109,7 +109,6 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
 
       require "ibm-cloud-sdk"
       IBM::Cloud::SDK.logger = $ibmcloud_log
-
       iam = IBM::Cloud::SDK::IAM.new(api_key)
       token = iam.get_identity_token
       power_iaas_service = IBM::Cloud::SDK::ResourceController.new(token).get_resource(pcloud_guid)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,8 @@
     :password:
     :port:
     :user:
+:log:
+  :level_ibm_cloud: info
 :workers:
   :worker_base:
     :event_catcher:


### PR DESCRIPTION
This is part of the change to enable login in ibmcloud.log.

Depends on https://github.com/ManageIQ/manageiq/pull/20624
