### PR TITLE
PowerVS: Add Availability Zone

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers.rb
@@ -28,6 +28,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::PowerVirtualServers <
   private
 
   def initialize_cloud_inventory_collections
+    add_cloud_collection(:availability_zones)
     add_cloud_collection(:flavors)
     add_cloud_collection(:vms) do |builder|
       builder.add_default_values(:ems_id => ->(persister) { persister.cloud_manager.id })


### PR DESCRIPTION
PowerVS resource availability is bound by the service instance (which
maps directly to a Cloud Manager ems). There's existing logic we can
re-use (e.g. cloud volume availability) if we create a single
availability zone for each Cloud Manager instance.