### PR TITLE
PowerVS: Update registration auth_key label

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -59,7 +59,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
                           :component  => "password-field",
                           :name       => "authentications.default.auth_key",
                           :id         => "authentications.default.auth_key",
-                          :label      => _("IBM Cloud API Key (if not using an existing provider)"),
+                          :label      => _("IBM Cloud API Key"),
                           :type       => "password",
                           :isRequired => true,
                           :validate   => [{:type => "required"}]


### PR DESCRIPTION
For now users must input an API key each time they register a new
provider. The "(if not using an existing provider)" text can be added
back once we implement a top-level provider.