### PR TITLE
PowerVS define CloudVolumeType list in settings

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
@@ -46,11 +46,6 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers <
   def storage_types
     # TODO: The Power Cloud API does not yet have a call to retrieve
     # available storage types.
-    [
-      {"description" => "Tier 1", "state" => "active", "type" => "tier1"},
-      {"description" => "Tier 3", "state" => "active", "type" => "tier3"},
-      {"description" => "ssd", "state" => "active", "type" => "ssd-legacy"},
-      {"description" => "standard", "state" => "active", "type" => "standard-legacy"}
-    ]
+    ::Settings.ems_refresh.ibm_cloud_power_virtual_servers.storage_types
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,14 +1,14 @@
 :ems:
-  :ems_ibm_cloud_virtual_servers:
+  :ems_ibm_cloud_power_virtual_servers:
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:
         :power:
           :critical:
-            - IBM_CLOUD_VIRTUAL_SERVERS_instance_power_on
-            - IBM_CLOUD_VIRTUAL_SERVERS_instance_power_off
+            - IBM_CLOUD_POWER_VIRTUAL_SERVERS_instance_power_on
+            - IBM_CLOUD_POWER_VIRTUAL_SERVERS_instance_power_off
 :http_proxy:
-  :ibm_cloud_virtual_servers:
+  :ibm_cloud_power_virtual_servers:
     :host:
     :password:
     :port:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,8 +5,23 @@
       :event_groups:
         :power:
           :critical:
-            - IBM_CLOUD_POWER_VIRTUAL_SERVERS_instance_power_on
-            - IBM_CLOUD_POWER_VIRTUAL_SERVERS_instance_power_off
+          - IBM_CLOUD_POWER_VIRTUAL_SERVERS_instance_power_on
+          - IBM_CLOUD_POWER_VIRTUAL_SERVERS_instance_power_off
+:ems_refresh:
+  :ibm_cloud_power_virtual_servers:
+    :storage_types:
+    - :description: Tier 1
+      :state: active
+      :type: tier1
+    - :description: Tier 3
+      :state: active
+      :type: tier3
+    - :description: SSD
+      :state: active
+      :type: ssd-legacy
+    - :description: Standard
+      :state: active
+      :type: standard-legacy
 :http_proxy:
   :ibm_cloud_power_virtual_servers:
     :host:


### PR DESCRIPTION
Commit b90e883 hard-coded a list of available storage types in the collector source code. These values may change in the future, so moving them into config/settings.yml to allow updating without source patches.

@blancett @Real-Omar-Afifi The config/settings.yml was stale from before we updated the plugin namespaces. It needs some VPC :heart: too.