### PR TITLE
Add VM provisioning checkbox for public network

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -32,7 +32,12 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     attached_volumes.concat(phase_context[:new_volumes]).compact!
     specs['volumeIDs'] = attached_volumes unless attached_volumes.empty?
 
-    attached_networks = [{"networkID" => get_option(:vlan)}] # TODO: support multiple values
+    attached_networks = case get_option(:vlan)
+                        when 'None'
+                          []
+                        else
+                          [{"networkID" => get_option(:vlan)}] # TODO: support multiple values
+                        end
     attached_networks.concat(phase_context[:new_networks]).compact!
     specs['networks'] = attached_networks
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -13,7 +13,6 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
       'sysType'     => get_option_last(:sys_type),
       'pinPolicy'   => get_option_last(:pin_policy),
       'migratable'  => get_option_last(:migratable) == 1,
-      'networks'    => [{"networkID" => get_option(:vlan)}], # TODO: support multiple values
       'replicants'  => 1, # TODO: we have to use this field instead of what 'MIQ' does
       'storageType' => get_option_last(:storage_type)
     }
@@ -32,6 +31,10 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     attached_volumes = options[:cloud_volumes] || []
     attached_volumes.concat(phase_context[:new_volumes]).compact!
     specs['volumeIDs'] = attached_volumes unless attached_volumes.empty?
+
+    attached_networks = [{"networkID" => get_option(:vlan)}] # TODO: support multiple values
+    attached_networks.concat(phase_context[:new_networks]).compact!
+    specs['networks'] = attached_networks
 
     specs
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
@@ -1,9 +1,9 @@
 module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provision::StateMachine
   def create_destination
-    signal :prepare_volumes
+    signal :prepare_volumes_and_networks
   end
 
-  def prepare_volumes
+  def prepare_volumes_and_networks
     new_volumes = options[:new_volumes]
     phase_context[:new_volumes] = []
 
@@ -12,6 +12,15 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
         new_volumes.each do |new_volume|
           phase_context[:new_volumes] << power_iaas.create_volume(new_volume)['volumeID']
         end
+      end
+    end
+
+    phase_context[:new_networks] = []
+
+    if options[:public_network][0]
+      source.with_provider_object(:service => "PowerIaas") do |power_iaas|
+        new_network = power_iaas.create_network('type' => 'pub-vlan')
+        phase_context[:new_networks] << {"networkID" => new_network['networkID']}
       end
     end
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -44,7 +44,8 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
   def allowed_subnets(_options = {})
     ar_subnets = ar_ems.cloud_subnets
     subnets = ar_subnets&.collect { |subnet| [subnet[:ems_ref], subnet[:name]] }
-    Hash[subnets || {}]
+    none = ['None', 'None']
+    Hash[subnets.unshift(none)]
   end
 
   def allowed_cloud_volumes(_options = {})

--- a/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
@@ -172,6 +172,15 @@
           :required: true
           :display: :edit
           :data_type: :string
+        :public_network:
+          :values:
+            false: 0
+            true: 1
+          :description: Attach to New Public Network
+          :required: false
+          :display: :edit
+          :data_type: :boolean
+          :default: false
       :display: :show
 
     :volumes:

--- a/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
@@ -170,6 +170,7 @@
             :method: :allowed_subnets
           :description: Network Interfaces
           :required: true
+          :default: None
           :display: :edit
           :data_type: :string
         :public_network:


### PR DESCRIPTION
PowerVS networks are type 'vlan' or 'pub-vlan'. The public, 'pub-vlan',
type can be created without any user given paramters. Providing a simple
checkbox dialog makes it easy to assign a public IP to a newly created
VM.

Depends on:
- [x] ManageIQ/manageiq-ui-classic#7403 (merged)