### PR TITLE
PowerVS: Enforce single volume type in provisioning forms

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
@@ -42,7 +42,8 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
         :vendor            => "ibm",
         :connection_state  => "connected",
         :raw_power_state   => instance["status"],
-        :uid_ems           => instance["pvmInstanceID"]
+        :uid_ems           => instance["pvmInstanceID"],
+        :format            => instance["storageType"]
       )
 
       # saving hardware information (CPU, Memory, etc.)
@@ -124,7 +125,8 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
         :vendor             => "ibm",
         :raw_power_state    => "never",
         :template           => true,
-        :storage_profile_id => persister.cloud_volume_types.lazy_find(ibm_image["storageType"])
+        :storage_profile_id => persister.cloud_volume_types.lazy_find(ibm_image["storageType"]),
+        :format             => ibm_image["storageType"]
       )
 
       persister.operating_systems.build(

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -5,24 +5,22 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
 
   def prepare_for_clone_task
     specs = {
-      'serverName' => get_option(:vm_target_name),
-      'imageID'    => get_option_last(:src_vm_id),
-      'processors' => get_option_last(:entitled_processors).to_f,
-      'procType'   => get_option_last(:instance_type),
-      'memory'     => get_option_last(:vm_memory).to_i,
-      'sysType'    => get_option_last(:sys_type),
-      'pinPolicy'  => get_option_last(:pin_policy),
-      'migratable' => get_option_last(:migratable) == 1,
-      'networks'   => [{"networkID" => get_option(:vlan)}], # TODO: support multiple values
-      'replicants' => 1, # TODO: we have to use this field instead of what 'MIQ' does
+      'serverName'  => get_option(:vm_target_name),
+      'imageID'     => get_option_last(:src_vm_id),
+      'processors'  => get_option_last(:entitled_processors).to_f,
+      'procType'    => get_option_last(:instance_type),
+      'memory'      => get_option_last(:vm_memory).to_i,
+      'sysType'     => get_option_last(:sys_type),
+      'pinPolicy'   => get_option_last(:pin_policy),
+      'migratable'  => get_option_last(:migratable) == 1,
+      'networks'    => [{"networkID" => get_option(:vlan)}], # TODO: support multiple values
+      'replicants'  => 1, # TODO: we have to use this field instead of what 'MIQ' does
+      'storageType' => get_option_last(:storage_type)
     }
 
     # TODO: support multiple values
     ip_addr = get_option_last(:ip_addr)
     specs['networks'][0]['ipAddress'] = ip_addr unless !ip_addr || ip_addr.strip.blank?
-
-    chosen_storage_type = get_option_last(:storage_type)
-    specs['storageType'] = chosen_storage_type unless chosen_storage_type == 'None'
 
     chosen_key_pair = get_option_last(:guest_access_key_pair)
     specs['keyPairName'] = chosen_key_pair unless chosen_key_pair == 'None'

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -24,13 +24,13 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
 
   def allowed_sys_type(_options = {})
     ar_sys_types = ar_ems.flavors
-    sys_types = ar_sys_types&.map&.with_index(1) { |sys_type, i| [i, sys_type['name']] }
+    sys_types = ar_sys_types&.map&.each_with_index { |sys_type, i| [i, sys_type['name']] }
     Hash[sys_types || {}]
   end
 
   def allowed_storage_type(_options = {})
     ar_storage_types = ar_ems.cloud_volume_types
-    storage_types = ar_storage_types&.map&.with_index(1) { |storage_type, i| [i, storage_type['name']] }
+    storage_types = ar_storage_types&.map&.each_with_index { |storage_type, i| [i, storage_type['name']] }
     Hash[storage_types || none]
   end
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -19,7 +19,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
   end
 
   def volume_dialog_keys
-    %i[name size diskType shareable]
+    %i[name size shareable]
   end
 
   def allowed_sys_type(_options = {})
@@ -60,6 +60,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
 
   def parse_new_volumes_fields(values)
     new_volumes = []
+    storage_type = values[:storage_type][1]
 
     values.select { |k, _v| k =~ /(#{volume_dialog_keys.join("|")})_(\d+)/ }.each do |key, value|
       field, cnt = key.to_s.split("_")
@@ -72,6 +73,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
     new_volumes.drop(1).map! do |new_volume|
       new_volume[:size] = new_volume[:size].to_i
       new_volume[:shareable] = [nil, 'null'].exclude?(new_volume[:shareable])
+      new_volume[:diskType] = storage_type
       new_volume
     end
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -31,8 +31,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
   def allowed_storage_type(_options = {})
     ar_storage_types = ar_ems.cloud_volume_types
     storage_types = ar_storage_types&.map&.with_index(1) { |storage_type, i| [i, storage_type['name']] }
-    none = [0, 'None']
-    Hash[storage_types&.insert(0, none) || none]
+    Hash[storage_types || none]
   end
 
   def allowed_guest_access_key_pairs(_options = {})

--- a/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
@@ -197,13 +197,6 @@
           :data_type: :boolean
           :default: false
           :display: :edit
-        :diskType:
-          :description: Disk type
-          :required: false
-          :data_type: :string
-          :min_length:
-          :max_length: 20
-          :display: :edit
       :display: :show
 
   :dialog_order:

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
@@ -18,33 +18,29 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provi
 
   it "#parse_new_volumes_fields" do
     values = {
-      :name      => nil,
-      :size      => nil,
-      :shareable => false,
-      :diskType  => nil
+      :storage_type => [0, "tier1"],
+      :name         => nil,
+      :size         => nil,
+      :shareable    => false
     }
     expect(workflow.parse_new_volumes_fields(values))
       .to match_array([])
     values = {
-      :name        => nil,
-      :size        => nil,
-      :shareable   => false,
-      :diskType    => nil,
-      :name_1      => "disk_one",
-      :size_1      => "1",
-      :diskType_1  => "tier1",
-      :shareable_1 => "null",
-      :name_2      => "disk_two",
-      :size_2      => "2",
-      :diskType_2  => "standard-legacy",
-      :name_3      => "disk_three",
-      :size_3      => "3",
-      :diskType_3  => "tier3",
-      :shareable_3 => nil,
-      :name_4      => "disk_four",
-      :size_4      => "4",
-      :diskType_4  => "ssd-legacy",
-      :shareable_4 => true
+      :storage_type => [1, "tier1"],
+      :name         => nil,
+      :size         => nil,
+      :shareable    => false,
+      :name_1       => "disk_one",
+      :size_1       => "1",
+      :shareable_1  => "null",
+      :name_2       => "disk_two",
+      :size_2       => "2",
+      :name_3       => "disk_three",
+      :size_3       => "3",
+      :shareable_3  => nil,
+      :name_4       => "disk_four",
+      :size_4       => "4",
+      :shareable_4  => true
     }
     expect(workflow.parse_new_volumes_fields(values))
       .to match_array(
@@ -58,59 +54,55 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provi
           {
             :name      => "disk_two",
             :size      => 2,
-            :diskType  => "standard-legacy",
+            :diskType  => "tier1",
             :shareable => false
           },
           {
             :name      => "disk_three",
             :size      => 3,
-            :diskType  => "tier3",
+            :diskType  => "tier1",
             :shareable => false
           },
           {
             :name      => "disk_four",
             :size      => 4,
-            :diskType  => "ssd-legacy",
+            :diskType  => "tier1",
             :shareable => true
           }
         ]
       )
     values = {
-      :name        => nil,
-      :size        => nil,
-      :shareable   => false,
-      :diskType    => nil,
-      :name_1      => "disk_one",
-      :diskType_1  => "tier1",
-      :shareable_1 => "null",
-      :size_2      => "2",
-      :diskType_2  => "standard-legacy",
-      :name_3      => "disk_three",
-      :size_3      => "3",
-      :diskType_3  => "tier3",
-      :name_4      => "disk_four",
-      :size_4      => "",
-      :diskType_4  => "ssd-legacy",
-      :shareable_4 => true
+      :storage_type => [2, "ssd-legacy"],
+      :name         => nil,
+      :size         => nil,
+      :shareable    => false,
+      :name_1       => "disk_one",
+      :shareable_1  => "null",
+      :size_2       => "2",
+      :name_3       => "disk_three",
+      :size_3       => "3",
+      :name_4       => "disk_four",
+      :size_4       => "",
+      :shareable_4  => true
     }
     expect(workflow.parse_new_volumes_fields(values))
       .to match_array(
         [
           {
             :name      => "disk_one",
-            :diskType  => "tier1",
+            :diskType  => "ssd-legacy",
             :size      => 0,
             :shareable => false
           },
           {
             :size      => 2,
-            :diskType  => "standard-legacy",
+            :diskType  => "ssd-legacy",
             :shareable => false
           },
           {
             :name      => "disk_three",
             :size      => 3,
-            :diskType  => "tier3",
+            :diskType  => "ssd-legacy",
             :shareable => false
           },
           {


### PR DESCRIPTION
PowerVS VMs require all attached volumes to be the same type. This PR removes unnecessary storage type fields in the VM provisioning 'New Volume' tab, and sets all new volume types to the selection made in the 'Profiles' tab.