### PR TITLE
Fix VPC CloudManager verify_credentials

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
@@ -17,7 +17,7 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
   end
 
   def verify_credentials(_auth_type = nil, options = {})
-    connect(options)
+    !!connect(options)&.token&.authorization_header
   end
 
   module ClassMethods
@@ -76,7 +76,7 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
       auth_key = args.dig('authentications', 'default', 'auth_key')
       auth_key = ManageIQ::Password.try_decrypt(auth_key)
       auth_key ||= find(args['id']).authentication_token('default')
-      !!raw_connect(auth_key)
+      !!raw_connect(auth_key)&.token&.authorization_header
     end
 
     def raw_connect(api_key)

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager_spec.rb
@@ -1,4 +1,6 @@
 describe ManageIQ::Providers::IbmCloud::VPC::CloudManager do
+  let(:api_key) { Rails.application.secrets.ibmcvs.try(:[], :api_key) || "IBMCVS_API_KEY" }
+
   it ".ems_type" do
     expect(described_class.ems_type).to eq('ibm_vpc')
   end
@@ -9,10 +11,6 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager do
 
   it "verifies regions options" do
     expect(described_class.provider_region_options.count).to eq(6)
-  end
-
-  it "tests the verify credentials logic" do
-    expect(validate('IBMCVS_API_KEY')).to eq(true)
   end
 
   it "does not create orphaned network_manager" do
@@ -43,19 +41,25 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager do
     expect(ems.network_manager.zone_id).to eq zone2.id
   end
 
-  it "tests the connect logic" do
-    zone1 = FactoryBot.create(:zone)
-    ems = FactoryBot.create(:ems_ibm_cloud_vpc, :zone => zone1, :provider_region => "us-east")
-    ems.authentications << FactoryBot.create(:authentication, :auth_key => "IBMCVS_API_KEY")
-    VCR.use_cassette(described_class.name.underscore) do
-      expect(!!ems.connect).to eq(true)
+  context "#connect" do
+    let(:ems) do
+      FactoryBot.create(:ems_ibm_cloud_vpc, :provider_region => "us-east").tap do |ems|
+        ems.authentications << FactoryBot.create(:authentication, :auth_key => api_key)
+      end
     end
-    ems.destroy
+
+    it "tests the connect logic" do
+      VCR.use_cassette(described_class.name.underscore) do
+        expect(ems.verify_credentials).to be_truthy
+      end
+    end
   end
 
-  def validate(auth_key)
-    VCR.use_cassette(described_class.name.underscore) do
-      described_class.verify_credentials("authentications" => {"default" => {"auth_key" => auth_key}})
+  context ".verify_credentials" do
+    it "verifies the connection" do
+      VCR.use_cassette(described_class.name.underscore) do
+        described_class.verify_credentials("authentications" => {"default" => {"auth_key" => api_key}})
+      end
     end
   end
 end

--- a/spec/vcr_cassettes/manageiq/providers/ibm_cloud/vpc/cloud_manager.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_cloud/vpc/cloud_manager.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.cloud.ibm.com/identity/token
+    body:
+      encoding: UTF-8
+      string: grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=IBMCVS_API_KEY
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2509'
+      Transaction-Id:
+      - 35d07684780a4641b887af9bf1cbc002
+      Cache-Control:
+      - no-cache, no-store
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Content-Language:
+      - en-US
+      X-Akamai-Path-Stats:
+      - "[3:33129:4470871]"
+      Date:
+      - Fri, 09 Oct 2020 17:59:15 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - sessioncookie=6e95b82a7f952738ffdd9d9d694b9eb0; Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"eyJraWQiOiIyMDIwMDkyMjE4MzMiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0wNjAwMDA0UzM4IiwiaWQiOiJJQk1pZC0wNjAwMDA0UzM4IiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiNTAxODBiNjYtZTBjZi00YWE2LTg0ZTMtMjFiMTNkMGI4NjgyIiwiaWRlbnRpZmllciI6IjA2MDAwMDRTMzgiLCJnaXZlbl9uYW1lIjoiQnJhZCIsImZhbWlseV9uYW1lIjoiQmxhbmNldHQiLCJuYW1lIjoiQnJhZCBCbGFuY2V0dCIsImVtYWlsIjoiYmxhbmNldHRAdXMuaWJtLmNvbSIsInN1YiI6ImJsYW5jZXR0QHVzLmlibS5jb20iLCJhY2NvdW50Ijp7InZhbGlkIjp0cnVlLCJic3MiOiJjNTZjOWEyNjhkMjNlMWIzMzlhYzE0Nzc0MzU4MTMzYyIsImltc191c2VyX2lkIjoiNzI4MjEwMyIsImZyb3plbiI6dHJ1ZSwiaW1zIjoiMTE2MDQ0NyJ9LCJpYXQiOjE2MDIyNjYzNTEsImV4cCI6MTYwMjI2OTk1MSwiaXNzIjoiaHR0cHM6Ly9pYW0uY2xvdWQuaWJtLmNvbS9pZGVudGl0eSIsImdyYW50X3R5cGUiOiJ1cm46aWJtOnBhcmFtczpvYXV0aDpncmFudC10eXBlOmFwaWtleSIsInNjb3BlIjoiaWJtIG9wZW5pZCIsImNsaWVudF9pZCI6ImRlZmF1bHQiLCJhY3IiOjEsImFtciI6WyJwd2QiXX0.IuK6Vwgsneq5lv4Kbea7DeBbHu5PameVlVJxtdln_IRxx9WD9clq8DaQqcAv_APqMsnPwaPDkm-I_SW_yxErh5nNcWyncDRdSztnB13_IN6b5RSfeXGsQg_Xlhga08EjTtT5H73ovzC-tolPQvhvunmtmcCPloGACi759gy1OtMeqOGszTGAjfmlNgGWx869mr8VBuUEWPuo2PeSkNx6qbUll59isK7LjqyYPLW31qXjM7Sd8PM-truQud0byKriCMdgnFviaoGyquEs80gZ_H_-DLyop15OfScRvYqdrFUGqGlX9ttz5GnB5aWDW85pdxKphNIrDpPl4Xuy1vDf1Q","refresh_token":"OKAv47Ssq2Sx09Zv4XpdinttkjsQAlfioXoBkDy9JhcQu4uZL0iJ6kI51PUqheki-07vWzo3ODpJ0eBfEPae1dLpR5rlSxxZtjeKlqtn6I-suv9_LGOMUjzfvnjp-L8Sc2TFNZVzs8v79_LKlavClZVHtZB3-6u9Q2FkvtoPRnx2S7ASKhbPFzEk9AFdmkA3zJztErlFsJA53zwS2n4Asz-IYKI9LgiCpr5-pX1uCJN28rkNR9Rn0jZJPdii8U9cNLuZB6pI8tlB1az79zQOqgp7wB-soQJBBT5FCzJgeL8D3fQ038P7XJaI3K_xeCsbNqCf8AZWOIvS2_KzYUAlu3IZEpb53fnmikuIHj7BA3tc7iRYQhNZpcBifW3JfvF_eYoplvGHhBns-ARC_yvhFQc18e_0JsNP3ZhW1Z7muKnE5cGDiIVUo6pQAykE84fFiVCfku9njxXOAOkj0LP-K_MIkVGeHp_O-lNTl_-EeDsJxoUlgSdJaAd2TvQQANIELdF3miifJpj7WvNuHJHeutEDqD-JvnrFRErZq7BQ2wMe1XLZGyIj1K265hzJSqsbCNxVZRRUkdIUNpKAs4iWduc9apoXF2d1h2xuVPLawGi1XBTiTn0M9kvSF5cCOBn8osx9kUKzWqq0WeNN19LDa7oZDRD0yK90EGK_lDxPH0iSGFINWlopU8YyybkezxUNemApMuSOlTBH8REvh3sXVpnEVCEUHo2NLM3gjBJBAvW91-cfqR2nCZQndHYdelj7f5FuKp0RBruVhXdJSfSC1gpkRuB39ewAVH23OAfM3PbdGg8--Qw14B4a_S9qWecqRKzxkuY27JJJY2XD30f40o-7MhMNL7sUMmxTTKL8qrmV3X1gwwceQII9-77fl85LNtan5F6tSMOH8clbbqeqnsa25ALZsFNqMec_QACTfuyDqaziacqrp2hCmJciBZ53IW_vKQpCwJ1CUhVSfkcJbYquaQd825cBwikUULX2Wq1xNKgGA1GTahLM4lmB7VGaCkY-1W5QkSQ5o1vPZ36Dtngwwi--gG7aIeocAgluJsLUQi9SSG8EHM0IO6yuwT7VOvr7yGVfZhbN2geGnPD1OFlbi8eV5xsRAH98NJx7_asYFK2wImkHQAOfuwIyNmjjfPM","ims_user_id":7282103,"token_type":"Bearer","expires_in":3600,"expiration":4102462800,"refresh_token_expiration":1604858351,"scope":"ibm
+        openid"}'
+    http_version:
+  recorded_at: Fri, 09 Oct 2020 17:59:15 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
I noticed this when I deleted the `cloud_manager.yml` vcr cassette and the specs were passing without any VCR at all :laughing: 

VPC verify_credentials (class and instance levels) weren't actually issuing any API calls that would check if the credentials are valid or not.

Updated to fetch the authorization_header from the IAM token which does issue an API call to the IAM token service.