### PR TITLE
Filter existing volume types in provisioning form

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -48,8 +48,15 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
   end
 
   def allowed_cloud_volumes(_options = {})
-    ar_volumes = ar_ems.cloud_volumes
+    storage_type = values&.dig(:storage_type, 1)
+
+    ar_volumes = ar_ems.cloud_volumes.select do |cloud_volume|
+      cloud_volume['volume_type'] == storage_type &&
+        (cloud_volume['multi_attachment'] || cloud_volume['status'] == 'available')
+    end
+
     cloud_volumes = ar_volumes&.map { |cloud_volume| [cloud_volume['ems_ref'], cloud_volume['name']] }
+
     Hash[cloud_volumes || {}]
   end
 


### PR DESCRIPTION
During VM provisioning existing volumes can be selected to be attached
to the new VM. The selection list can be filtered to show only volumes
available for attachment. Volumes are available if all of the following
conditions are true:

- Volume type matches the selected VM storage type
- Volume is shareable ('multi_attachment' == true)
- Volume status is 'available'