### PR TITLE
Filter VMs by 'volume_type' in volume attach

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
@@ -4,7 +4,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
   supports_not :update
 
   def available_vms
-    availability_zone.vms
+    availability_zone.vms.select { |vm| vm.format == volume_type }
   end
 
   def self.validate_create_volume(ext_management_system)


### PR DESCRIPTION
Volume 'volume_type' must match VM 'format' for the Power Virtual Server
backend to allow an attach operation.