### PR TITLE
Disable subnet create form

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager < ManageIQ::Providers::NetworkManager
-  supports :create
-
   require_nested :Refresher
   require_nested :CloudNetwork
   require_nested :CloudSubnet

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/cloud_subnet.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager::CloudSubnet < ::CloudSubnet
-  supports :create
-
   supports :delete do
     if number_of(:vms) > 0
       unsupported_reason_add(:delete, _("The Network has active VMIs related to it"))


### PR DESCRIPTION
The network subnet create form is not fully implemented. Work is being
deferred until DDF is implemented.

See this conversation for more context:
https://github.com/ManageIQ/manageiq-documentation/pull/1491#discussion_r507967128

WIP because the form seems to be hanging.