### PR TITLE
Use consistent child manager names

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -47,12 +47,12 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
 
   def ensure_network_manager
     build_network_manager(:type => 'ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager') unless network_manager
-    network_manager.name = "Network-Manager of '#{name}'"
+    network_manager.name = "#{name} Network Manager"
   end
 
   def ensure_storage_manager
     build_storage_manager unless storage_manager
-    storage_manager.name = "Storage-Manager of '#{name}'"
+    storage_manager.name = "#{name} Block Storage Manager"
   end
 
   def self.hostname_required?

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -24,12 +24,12 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::Cl
 
   def ensure_network_manager
     build_network_manager(:type => 'ManageIQ::Providers::IbmCloud::VPC::NetworkManager') unless network_manager
-    network_manager.name = "Network-Manager of '#{name}'"
+    network_manager.name = "#{name} Network Manager"
   end
 
   def ensure_storage_manager
     build_storage_manager(:type => 'ManageIQ::Providers::IbmCloud::VPC::StorageManager') unless storage_manager
-    storage_manager.name = "Storage-Manager of '#{name}'"
+    storage_manager.name = "#{name} Block Storage Manager"
   end
 
   def ensure_managers_zone


### PR DESCRIPTION
Existing providers name child network and storage managers in the
following formats, respectively:

"#{name} Network Manager"
"#{name} <type> Storage Manager"

Addresses point 1 of #100 