### PR TITLE
VPC Power states

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,0 +1,3 @@
+Style/GlobalVars:
+  AllowedVariables:
+    - $ibm_cloud_log # Global cloud plugin log from ManageIQ.

--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,3 +1,7 @@
 Style/GlobalVars:
   AllowedVariables:
   - $ibm_cloud_log # Global cloud plugin log from ManageIQ.
+
+Style/MethodCallWithArgsParentheses:
+  Exclude:
+  - spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb

--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,3 +1,3 @@
 Style/GlobalVars:
   AllowedVariables:
-    - $ibm_cloud_log # Global cloud plugin log from ManageIQ.
+  - $ibm_cloud_log # Global cloud plugin log from ManageIQ.

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
@@ -21,4 +21,36 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
   def self.display_name(number = 1)
     n_('Instance (IBM)', 'Instances (IBM)', number)
   end
+
+  # Send a start action to IBM Cloud. Wait for state to change to started, then update the raw_power_state to the current instance state.
+  def raw_start
+    with_provider_connection() do |vpc|
+      instance = vpc.instances.instance(ems_ref)
+      instance.actions.start
+      _log.info("Starting instance #{ems_ref} in state #{instance.status}.")
+      instance.wait_for(started: true)
+      update!(:raw_power_state => instance.status)
+      _log.info("Started instance #{ems_ref} in state #{instance.status}.")
+    end
+  end
+
+  # IBM Cloud does not support suspend. Hiding it from UI.
+  supports_not :suspend
+
+  # Send a stop action to IBM Cloud. Wait for state to change to stopped, then update the raw_power_state to the current instance state.
+  def raw_stop
+    with_provider_connection() do |vpc|
+      instance = vpc.instances.instance(ems_ref)
+      instance.actions.stop
+      _log.info("Stopping instance #{ems_ref} in state #{instance.status}.")
+      instance.wait_for(started: false)
+      update!(:raw_power_state => instance.status)
+      _log.info("Stopped instance #{ems_ref} in state #{instance.status}.")
+    end
+  end
+
+  # IBM Cloud does not support pause. Using stop since can't unsupport it.
+  def raw_pause
+    raw_stop
+  end
 end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
@@ -74,7 +74,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
   # @param force [Boolean] Ungracefully reboot VM.
   def raw_reboot_guest(force: false)
     with_provider_object do |instance|
-      instance.actions.reboot(force)
+      instance.actions.reboot(:force => force)
       sleep 5 # Sleep for 5 seconds to allow for reboot sequence to start.
       instance.wait_for! do
         sdk_update_status(instance)

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
@@ -54,6 +54,23 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
     raw_stop
   end
 
+  # Show reboot in the instance menu when on.
+  supports :reboot_guest do
+    unsupported_reason_add(:reboot_guest, _('The VM is not powered on')) unless current_state == 'on'
+  end
 
+  def raw_reboot_guest
+    with_provider_connection do |vpc|
+      instance = vpc.instances.instance(ems_ref)
+      instance.actions.reboot
+      instance.wait_for(:sleep_time => 0.5, :timeout => 60) do
+        update!(:raw_power_state => instance.status)
+        instance.transitional?
+      end
+      instance.wait_for do
+        update!(:raw_power_state => instance.status)
+        instance.started?
+      end
+    end
   end
 end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
@@ -32,6 +32,10 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
         instance.started?
       end
     end
+  rescue => e
+    $ibm_cloud_log.error(e.to_s)
+    $ibm_cloud_log.log_backtrace(e)
+    raise
   end
 
   # IBM Cloud does not support suspend. Hiding it from UI.
@@ -47,6 +51,10 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
         instance.stopped?
       end
     end
+  rescue => e
+    $ibm_cloud_log.error(e.to_s)
+    $ibm_cloud_log.log_backtrace(e)
+    raise
   end
 
   # IBM Cloud does not support pause. Using stop since can't hide it in UI.
@@ -68,6 +76,10 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
         instance.started?
       end
     end
+  rescue => e
+    $ibm_cloud_log.error(e.to_s)
+    $ibm_cloud_log.log_backtrace(e)
+    raise
   end
 
   supports :reset do

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
@@ -22,10 +22,14 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
     n_('Instance (IBM)', 'Instances (IBM)', number)
   end
 
+  # Used in with_provider_object to scope SDK to this instance.
+  def provider_object(vpc)
+    vpc.instances.instance(ems_ref)
+  end
+
   # Send a start action to IBM Cloud. Wait for state to change to started, then update the raw_power_state.
   def raw_start
-    with_provider_connection do |vpc|
-      instance = vpc.instances.instance(ems_ref)
+    with_provider_object do |instance|
       instance.actions.start
       instance.wait_for! do
         sdk_update_status(instance)
@@ -43,8 +47,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
 
   # Send a stop action to IBM Cloud. Wait for state to change to stopped, then update the raw_power_state.
   def raw_stop
-    with_provider_connection do |vpc|
-      instance = vpc.instances.instance(ems_ref)
+    with_provider_object do |instance|
       instance.actions.stop
       instance.wait_for! do
         sdk_update_status(instance)
@@ -70,8 +73,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
   # Gracefully reboot the quest.
   # @param force [Boolean] Ungracefully reboot VM.
   def raw_reboot_guest(force: false)
-    with_provider_connection do |vpc|
-      instance = vpc.instances.instance(ems_ref)
+    with_provider_object do |instance|
       instance.actions.reboot(force)
       sleep 5 # Sleep for 5 seconds to allow for reboot sequence to start.
       instance.wait_for! do

--- a/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
@@ -85,7 +85,7 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
       end
 
       require 'ibm-cloud-sdk'
-      IBM::CloudSDK.new(api_key)
+      IBM::CloudSDK.new(api_key, :logger => $ibm_cloud_log)
     end
   end
 end

--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -12,4 +12,18 @@ FactoryBot.define do
   factory :template_ibm_cloud_power_virtual_servers, :class => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template", :parent => :template_cloud do
     vendor { "ibm" }
   end
+
+  factory :vm_ibm_cloud_vpc, :class => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm", :parent => :vm_cloud do
+    vendor { "ibm" }
+
+    trait :with_provider do
+      after(:create) do |x|
+        FactoryBot.create(:ems_ibm_cloud_vpc, :vms => [x])
+      end
+    end
+  end
+
+  factory :template_ibm_cloud_vpc, :class => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template", :parent => :template_cloud do
+    vendor { "ibm" }
+  end
 end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
@@ -1,16 +1,5 @@
 require 'logger'
 
-class ParentClass
-  attr_accessor :connection, :token
-
-  def logger
-    Logger.new(nil)
-  end
-
-  def url(url)
-  end
-end
-
 describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm do
   let(:ems) do
     FactoryBot.create(:ems_ibm_cloud_vpc, :provider_region => "us-east").tap do |ems|
@@ -52,14 +41,21 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm do
       allow(vm).to receive(:provider_object).and_return(instance)
     end
 
+    let(:parent) do
+      vpc = double("IBM::Cloud::SDK::Vpc")
+      allow(vpc).to receive(:logger).and_return(Logger.new($stdout))
+      allow(vpc).to receive_messages(:url => nil, :token => nil, :connection => nil)
+      vpc
+    end
+
     let(:actions) do
-      actions = IBM::Cloud::SDK::VPC::INSTANCE::Actions.new(ParentClass.new)
+      actions = IBM::Cloud::SDK::VPC::INSTANCE::Actions.new(parent)
       allow(actions).to receive(:create).and_return({:this => 'mock'})
       actions
     end
 
     let(:instance) do
-      instance = IBM::Cloud::SDK::VPC::Instance.new(ParentClass.new)
+      instance = IBM::Cloud::SDK::VPC::Instance.new(parent)
       allow(instance).to receive(:refresh) { instance.merge!({:id => 'mock_id', :name => 'Test instance', :status => 'running'}) }
       allow(instance).to receive(:actions).and_return(actions)
       instance.refresh

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
@@ -43,7 +43,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm do
 
     let(:parent) do
       vpc = double("IBM::Cloud::SDK::Vpc")
-      allow(vpc).to receive(:logger).and_return(Logger.new($stdout))
+      allow(vpc).to receive(:logger).and_return(Logger.new(nil))
       allow(vpc).to receive_messages(:url => nil, :token => nil, :connection => nil)
       vpc
     end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
@@ -1,0 +1,94 @@
+require 'pry'
+require 'logger'
+
+class ParentClass
+  attr_accessor :connection, :token
+
+  def logger
+    Logger.new(nil)
+  end
+
+  def url(url)
+  end
+end
+
+describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm do
+  let(:ems) do
+    FactoryBot.create(:ems_ibm_cloud_vpc, :provider_region => "us-east").tap do |ems|
+      ems.authentications << FactoryBot.create(:authentication, :auth_key => 'IBMCVS_API_KEY')
+    end
+  end
+
+  let(:vm) do
+    FactoryBot.create(:vm_ibm_cloud_vpc, :ext_management_system => ems)
+  end
+
+  context "is_available?" do
+    let(:power_state_on)        { "running" }
+    let(:power_state_suspended) { "stopped" }
+
+    context "with :start" do
+      let(:state) { :start }
+      include_examples "Vm operation is available when not powered on"
+    end
+
+    context "with :stop" do
+      let(:state) { :stop }
+      include_examples "Vm operation is available when powered on"
+    end
+
+    context "with :reboot_guest" do
+      let(:state) { :reboot_guest }
+      include_examples "Vm operation is available when powered on"
+    end
+
+    context "with :reset" do
+      let(:state) { :reset }
+      include_examples "Vm operation is available when powered on"
+    end
+  end
+
+  describe 'power operations' do
+    before(:each) do
+      allow(vm).to receive(:provider_object).and_return(instance)
+    end
+
+    let(:actions) do
+      actions = IBM::Cloud::SDK::VPC::INSTANCE::Actions.new(ParentClass.new)
+      allow(actions).to receive(:create).and_return({:this => 'mock'})
+      actions
+    end
+
+    let(:instance) do
+      instance = IBM::Cloud::SDK::VPC::Instance.new(ParentClass.new)
+      allow(instance).to receive(:refresh) { instance.merge!({:id => 'mock_id', :name => 'Test instance', :status => 'running'}) }
+      allow(instance).to receive(:actions).and_return(actions)
+      instance.refresh
+      instance
+    end
+
+    it 'stops the virtual machine' do
+      allow(instance).to receive(:status).and_return('running', 'stopping', 'stopped')
+      vm.raw_stop
+      expect(vm.power_state).to eq('off')
+    end
+
+    it 'starts the virtual machine' do
+      allow(instance).to receive(:status).and_return('stopped', 'starting', 'running')
+      vm.raw_start
+      expect(vm.power_state).to eq('on')
+    end
+
+    it 'reboots the virtual machine' do
+      allow(instance).to receive(:status).and_return('running', 'stopping', 'stopped', 'starting', 'running')
+      vm.raw_reboot_guest
+      expect(vm.power_state).to eq('on')
+    end
+
+    it 'force reboot the virtual machine' do
+      allow(instance).to receive(:status).and_return('running', 'stopping', 'stopped', 'starting', 'running')
+      vm.raw_reset
+      expect(vm.power_state).to eq('on')
+    end
+  end
+end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'logger'
 
 class ParentClass

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
@@ -49,12 +49,14 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm do
     end
 
     let(:actions) do
+      require 'ibm-cloud-sdk'
       actions = IBM::Cloud::SDK::VPC::INSTANCE::Actions.new(parent)
       allow(actions).to receive(:create).and_return({:this => 'mock'})
       actions
     end
 
     let(:instance) do
+      require 'ibm-cloud-sdk'
       instance = IBM::Cloud::SDK::VPC::Instance.new(parent)
       allow(instance).to receive(:refresh) { instance.merge!({:id => 'mock_id', :name => 'Test instance', :status => 'running'}) }
       allow(instance).to receive(:actions).and_return(actions)


### PR DESCRIPTION
* Dependent on https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/pull/43 being merged.
* Add start, stop, reboot actions.
* VPC doesn't have pause so using start.
* Logic for reset is the same as reboot with an added parameter so added optional keyword parameter to raw_reboot_guest and reused the logic. The keyword shouldn't affect the internals of the automated methods as they usually don't used parameters.
* Added the $ibm_cloud_log to the CloudSDK init, so logging should now flow between the two and the stdout logger will be suppressed.
* The rescues are to keep the cloud log in synch with what is happening. I'm reraising the same error so that the evm log will log the correct traceback. I don't know if there is a better way to handle the errors.
* Need to write spec tests before merge.
