### PR TITLE
Added NetworkRouter class that was missing from IBM Cloud Provider

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager < ManageIQ::Providers::
   require_nested :SecurityGroup
   require_nested :CloudNetwork
   require_nested :FloatingIp
+  require_nested :NetworkRouter
 
   include ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/network_router.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/network_router.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::NetworkRouter < ::NetworkRouter
+end


### PR DESCRIPTION
Fixes the below error page when navigating to `Network` / `Network Routers` in the UI

![image](https://user-images.githubusercontent.com/76593/97624825-08812100-19fe-11eb-9116-e45fb9ab299c.png)
