### PR TITLE
Operating system mapping updates

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
@@ -7,7 +7,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
 
   # Extensions to the list in operating_system.rb
   VPC_OS_NAMES = [
-    ["linux_redhat",    %w(red-7 red-8)]
+    ["linux_redhat", %w[red-7 red-8]]
   ].freeze
 
   def initialize
@@ -308,10 +308,10 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
     end
   end
 
-  def normalize_vpc_os_name(osName)
+  def normalize_vpc_os_name(os_name)
     VPC_OS_NAMES.each do |a|
       a[1].each do |n|
-        return a[0] unless osName.index(n).nil?
+        return a[0] unless os_name.index(n).nil?
       end
     end
     "unknown"

--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
@@ -131,7 +131,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
 
   def image_operating_system(persister_image, image)
     os_name = image&.dig(:operating_system, :name)
-    normalized_os_name = normalize_os(image&.dig(:operating_system, :name))
+    normalized_os_name = normalize_os(os_name)
     persister.operating_systems.build(
       :vm_or_template => persister_image,
       :product_name   => normalized_os_name,

--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
@@ -5,11 +5,6 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
 
   attr_reader :img_to_os
 
-  # Extensions to the list in operating_system.rb
-  VPC_OS_NAMES = [
-    ["linux_redhat", %w[red-7 red-8]]
-  ].freeze
-
   def initialize
     @img_to_os = {}
   end
@@ -300,20 +295,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
   end
 
   def normalize_os(os_name)
-    normalized_name = OperatingSystem.normalize_os_name(os_name)
-    if normalized_name == "unknown"
-      normalize_vpc_os_name(os_name)
-    else
-      normalized_name
-    end
-  end
-
-  def normalize_vpc_os_name(os_name)
-    VPC_OS_NAMES.each do |a|
-      a[1].each do |n|
-        return a[0] unless os_name.index(n).nil?
-      end
-    end
-    "unknown"
+    os_name.sub!("red-", "redhat-") if os_name.start_with?("red-")
+    OperatingSystem.normalize_os_name(os_name)
   end
 end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -49,7 +49,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
     expect(vm.hardware.cpu_total_cores).to eq(2)
     expect(vm.hardware.cpu_sockets).to eq(2)
     expect(vm.hardware.bitness).to eq(64)
-    expect(vm.operating_system[:product_name]).to(eq('linux_redhat'))
+    expect(vm.operating_system[:product_name]).to eq('linux_redhat')
     expect(vm.flavor.name).to eq('mx2-2x16')
     expect(vm.raw_power_state).to eq('running')
     expect(vm.power_state).to eq('on')
@@ -64,6 +64,6 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
   def assert_vm_labels
     vm = ems.vms.find_by(:ems_ref => "0777_f73e8687-3813-465f-99df-ba6e4ee8f289")
 
-    expect(vm.labels.count).to(eq(3))
+    expect(vm.labels.count).to eq(3)
   end
 end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -49,7 +49,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
     expect(vm.hardware.cpu_total_cores).to eq(2)
     expect(vm.hardware.cpu_sockets).to eq(2)
     expect(vm.hardware.bitness).to eq(64)
-    expect(vm.operating_system[:product_name]).to eq('linux_redhat')
+    expect(vm.operating_system[:product_name]).to(eq('linux_redhat'))
     expect(vm.flavor.name).to eq('mx2-2x16')
     expect(vm.raw_power_state).to eq('running')
     expect(vm.power_state).to eq('on')

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -49,7 +49,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
     expect(vm.hardware.cpu_total_cores).to eq(2)
     expect(vm.hardware.cpu_sockets).to eq(2)
     expect(vm.hardware.bitness).to eq(64)
-    expect(vm.operating_system[:product_name]).to eq('red-7-amd64')
+    expect(vm.operating_system[:product_name]).to eq('linux_redhat')
     expect(vm.flavor.name).to eq('mx2-2x16')
     expect(vm.raw_power_state).to eq('running')
     expect(vm.power_state).to eq('on')


### PR DESCRIPTION
Addresses: 
- https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/94
- https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/98

Summary:
- normalizes OS names not captured by operating_system.rb name matching logic
- add version info to image/instance OS
- add OS info for private images