### PR TITLE
Added SecurityGroup class that was missing from IBM Cloud Provider power

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager < Manag
   require_nested :CloudSubnet
   require_nested :NetworkPort
   require_nested :NetworkRouter
+  require_nested :SecurityGroup
 
   include ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/security_group.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/security_group.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager::SecurityGroup < SecurityGroup
+end
+


### PR DESCRIPTION
Fixes the below error page when navigating to Network / Security Groups in the UI
![image](https://user-images.githubusercontent.com/76593/99008298-e1edda80-2513-11eb-9ed1-8f40923f3dca.png)
