### PR TITLE
The CloudVolume create size should be in bytes

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
@@ -18,8 +18,9 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
           :component  => 'text-field',
           :name       => 'size',
           :id         => 'size',
-          :label      => _('Size (GB)'),
+          :label      => _('Size (in bytes)'),
           :type       => 'number',
+          :step       => 1.gigabytes,
           :isRequired => true,
           :validate   => [{:type => 'required'}],
         },
@@ -113,7 +114,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
     ext_management_system.with_provider_connection(:service => 'PCloudVolumesApi') do |api|
       volume_params = IbmCloudPower::CreateDataVolume.new(
         'name'            => options['name'],
-        'size'            => options['size'].to_f,
+        'size'            => options['size'] / 1.0.gigabyte,
         'disk_type'       => options['volume_type'],
         'shareable'       => options['multi_attachment'],
         'affinity_policy' => options['affinity_policy'],


### PR DESCRIPTION
For consistency with the other providers the size that is passed in
raw_create_volume should be in bytes, then converted to GB before
passing to the provider API.

Follow-up to: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/129
Ref: https://github.com/ManageIQ/manageiq-ui-classic/pull/7399#issuecomment-776929179