### PR TITLE
Fix PowerVS system_pools (flavors) parser

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
@@ -235,11 +235,11 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
   end
 
   def flavors
-    collector.system_pools.each do |type|
+    collector.system_pools.each_value do |value|
       persister.flavors.build(
         :type    => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SystemType",
-        :ems_ref => type,
-        :name    => type
+        :ems_ref => value.type,
+        :name    => value.type
       )
     end
   end


### PR DESCRIPTION
The 'system_pools' collector returns a nested hash. The top level key
seems to match the lower level 'type' value, but is not documented in
the API docs
(https://cloud.ibm.com/apidocs/power-cloud#pcloud-systempools-get).