### PR TITLE
Adjust empty/initial values for select fields in DDF schemas

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
@@ -25,15 +25,16 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
           :validate   => [{:type => 'required'}],
         },
         {
-          :component => 'select',
-          :name      => 'volume_type',
-          :id        => 'volume_type',
-          :label     => _('Cloud Volume Type'),
-          :condition => {
+          :component    => 'select',
+          :name         => 'volume_type',
+          :id           => 'volume_type',
+          :label        => _('Cloud Volume Type'),
+          :includeEmpty => true,
+          :condition    => {
             :when => 'edit',
             :is   => false,
           },
-          :options   => ems.cloud_volume_types.map do |cvt|
+          :options      => ems.cloud_volume_types.map do |cvt|
             {
               :label => cvt.description,
               :value => cvt.name,
@@ -74,13 +75,14 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
           ],
         },
         {
-          :component  => 'select',
-          :name       => 'affinity_volume_id',
-          :id         => 'affinity_volume_id',
-          :label      => _('Affinity Volume'),
-          :isRequired => true,
-          :validate   => [{:type => 'required'}],
-          :condition  => {
+          :component    => 'select',
+          :name         => 'affinity_volume_id',
+          :id           => 'affinity_volume_id',
+          :label        => _('Affinity Volume'),
+          :isRequired   => true,
+          :validate     => [{:type => 'required'}],
+          :includeEmpty => true,
+          :condition    => {
             :and => [
               {
                 :not => {
@@ -94,7 +96,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
               },
             ],
           },
-          :options    => ems.cloud_volumes.map do |cv|
+          :options      => ems.cloud_volumes.map do |cv|
             {
               :value => cv.id,
               :label => cv.name,

--- a/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
@@ -25,13 +25,14 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
       @params_for_create ||= {
         :fields => [
           {
-            :component  => "select",
-            :id         => "provider_region",
-            :name       => "provider_region",
-            :label      => _("Region"),
-            :isRequired => true,
-            :validate   => [{:type => "required"}],
-            :options    => provider_region_options
+            :component    => "select",
+            :id           => "provider_region",
+            :name         => "provider_region",
+            :label        => _("Region"),
+            :isRequired   => true,
+            :includeEmpty => true,
+            :validate     => [{:type => "required"}],
+            :options      => provider_region_options
           },
           {
             :component => 'sub-form',


### PR DESCRIPTION
Because carbon has four different dropdowns, the DDF schemas need to have explicit initialValue or includeEmpty settings in order to make the form validation work.

@miq-bot assign @agrare