### PR TITLE
Fix PowerVS API endpoint special cases

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -37,8 +37,16 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
   end
 
   def api_endpoint_url(location)
-    region = location.sub(/-\d$/, '')
-    "#{region}.power-iaas.cloud.ibm.com"
+    api_endpoint_overrides = ::Settings.ems.ems_ibm_cloud_power_virtual_servers.api_endpoint_overrides
+
+    if api_endpoint_overrides.key?(location.to_sym)
+      url = api_endpoint_overrides[location.to_sym]
+    else
+      region = location.sub(/-\d$/, '')
+      url = "#{region}.power-iaas.cloud.ibm.com"
+    end
+
+    url
   end
 
   def verify_credentials(_auth_type = nil, options = {})

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -20,7 +20,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
 
     power_api_client.config.api_key = auth_key
     power_api_client.config.scheme  = "https"
-    power_api_client.config.host    = "#{location}.power-iaas.cloud.ibm.com"
+    power_api_client.config.host    = api_endpoint_url(location)
     power_api_client.config.logger  = $ibm_cloud_log
     power_api_client.config.debugging = Settings.log.level_ibm_cloud == "debug"
     power_api_client.default_headers["Crn"]           = power_iaas_service.crn
@@ -34,6 +34,11 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
     else
       power_api_client
     end
+  end
+
+  def api_endpoint_url(location)
+    region = location.sub(/-\d$/, '')
+    "#{region}.power-iaas.cloud.ibm.com"
   end
 
   def verify_credentials(_auth_type = nil, options = {})

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,7 @@
 :ems:
   :ems_ibm_cloud_power_virtual_servers:
+    :api_endpoint_overrides:
+      :dal12: us-south.power-iaas.cloud.ibm.com
     :event_handling:
       :event_groups:
         :power:


### PR DESCRIPTION
fixes #133 

This PR fixes two bugs related to Power Cloud API endpoints:
- The CRN 'location' segment sometimes includes regional zone enumerations and needs to be parsed to get the correct endpoint subdomain (e.g. `eu-de-1` uses the endpoint URL `https://eu-de.power-iaas.cloud.ibm.com`)
- #133: The CRN 'location' segment is sometimes totally different than the endpoint URL (e.g. `dal12` -> `https://us-south.power-iaas.cloud.ibm.com`)