### PR TITLE
Don't require cloud_tools in lib/manageiq-providers-ibm_cloud.rb

### DIFF
--- a/lib/manageiq-providers-ibm_cloud.rb
+++ b/lib/manageiq-providers-ibm_cloud.rb
@@ -1,3 +1,2 @@
 require "manageiq/providers/ibm_cloud/engine"
 require "manageiq/providers/ibm_cloud/version"
-require_relative "manageiq/providers/ibm_cloud/cloud_tool"


### PR DESCRIPTION
This is causing issues during the build because it is requiring runtime packages to be present during the build due to the eager loading of this class

https://github.com/ManageIQ/manageiq-rpm_build/pull/137#issuecomment-781568150