### PR TITLE
[KASPAROV] Allow API endpoint overrides through settings

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -17,10 +17,16 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
     case options[:service]
     when "PowerIaas"
       region, guid, token, crn, tenant = creds.values_at(:region, :guid, :token, :crn, :tenant)
-      IBM::Cloud::SDK::PowerIaas.new(region, guid, token, crn, tenant)
+      IBM::Cloud::SDK::PowerIaas.new(api_endpoint_url(region), guid, token, crn, tenant)
     else
       raise ArgumentError, _("Unknown target API set: '%{service_type}'") % {:service_type => options[:service]}
     end
+  end
+
+  def api_endpoint_url(location)
+    api_endpoint_overrides = ::Settings.ems.ems_ibm_cloud_power_virtual_servers.api_endpoint_overrides
+
+    api_endpoint_overrides[location.to_sym] || location.sub(/-\d$/, '')
   end
 
   def verify_credentials(_auth_type = nil, options = {})

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,7 @@
 :ems:
   :ems_ibm_cloud_power_virtual_servers:
+    :api_endpoint_overrides:
+      :dal12: us-south
     :event_handling:
       :event_groups:
         :power:


### PR DESCRIPTION
Kasparov backport of #143 

Issue #133 is also present in Kasparov, but the fix in #143 won't merge cleanly since we switched to an openapi generated SDK post-Kasparov release.

I had to change the value format in `:api_endpoint_overrides:` in order to contain the fix within this provider. The post-Kasparov SDK moved the power cloud API endpoint URL construction into the `ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin`, but for Kasparov the `::ManagerMixin` just passes the region and the URL is constructed within the SDK.

So this patch proposes that the Kasparov `:api_endpoint_overrides:` values override only the endpoint subdomain, e.g.:
```
:ems:
  :ems_ibm_cloud_power_virtual_servers:
    :api_endpoint_overrides:
      :dal12: us-south
```

While post-Kasparov (as already merged in #143) overrides the entire URL, e.g.:
```
:ems:
  :ems_ibm_cloud_power_virtual_servers:
    :api_endpoint_overrides:
      :dal12: us-south.power-iaas.cloud.ibm.com
```

I'm not sure I fully understand any complications involved in changing user settings between releases - so please feel free to bring up any concerns with this approach.