### PR TITLE
#156 Fix instance_actions issues with creating actions.

### DIFF
--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/vpc_sdk/instance.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/vpc_sdk/instance.rb
@@ -65,7 +65,7 @@ module ManageIQ
             end
 
             def actions
-              InstanceActions.new(:vpc => self, :instance_id => id)
+              InstanceActions.new(:vpc => @parent, :instance_id => id)
             end
 
             # Wait for the VM instance to be have a started status.

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/vpc_sdk/instance_actions.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/vpc_sdk/instance_actions.rb
@@ -33,7 +33,7 @@ module ManageIQ
             # @param force [Boolean] If set to true, the action will be forced immediately, and all queued actions deleted. Ignored for the start action.
             def create(action, force: false)
               logger.info("Sending action request for #{action} with force #{force}.")
-              @parent.response(:create_instance_action, :instance_id => @instance_id, :action => action, :force => force)
+              @parent.request(:create_instance_action, :instance_id => @instance_id, :type => action, :force => force)
             end
           end
         end


### PR DESCRIPTION
# Summary
As part of the VPC SDK transition, classes that emulated the structure of the previous SDK were created. This was to prevent a rewrite of the VM actions code. As part of the rewrite the original specs were updated. However, because the original SDK was tested in its repository, the VM actions spec bypassed using VCRs by mocking the network methods. Which meant that although the VM spec passed it wasn't testing the entire stack. Running the VM actions manually uncovered the errors.

# Priority
* This should backported to the 2.3 release as soon as possible.

# Implementation
* Instance should pass in the VPC object and not itself to InstanceActions
* The VPC method is 'request' not 'response'.

# Specs
* No changes. I'd like to add tests within the cloud_tools_spec, but the rewrite is in PR #155. 
* Issue #158 added for updating specs when merged.

# Common files
* No common files were updated.
