### PR TITLE
Fix endpoint parsing for new PowerVS regions

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -43,6 +43,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
       url = api_endpoint_overrides[location.to_sym]
     else
       region = location.sub(/-\d$/, '')
+      region = region.sub(/\d\d$/, '')
       url = "#{region}.power-iaas.cloud.ibm.com"
     end
 


### PR DESCRIPTION
New Power Virtual Servers regions are formatted as "{region}{zone}",
without a '-' and always with two zone digits.