### PR TITLE
[KASPAROV] Add api endpoints for new regions

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,13 @@
   :ems_ibm_cloud_power_virtual_servers:
     :api_endpoint_overrides:
       :dal12: us-south
+      :syd04: syd
+      :tok04: tok
+      :lon04: lon
+      :lon06: lon
+      :mon01: mon
+      :tor01: tor
+      :sao01: sao
     :event_handling:
       :event_groups:
         :power:


### PR DESCRIPTION
Include 'api_endpoint_overrides' values for new Power Virtual Service
instance regions.

Since we moved to a new, OpenAPI generated, IBM Cloud SDK gem post `kasparov` a different approach is required to address #167 (see `master`/`lasker` fix in #168).