### PR TITLE
Add spec test for storage manager inventory

### DIFF
--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -66,6 +66,8 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
       expect(ems.network_manager.cloud_networks.count).to eq(3)
       expect(ems.network_manager.cloud_subnets.count).to eq(3)
       expect(ems.network_manager.network_ports.count).to eq(4)
+      expect(ems.storage_manager.cloud_volumes.count).to eq(13)
+      expect(ems.storage_manager.cloud_volume_types.count).to eq(4)
     end
 
     def assert_specific_vm


### PR DESCRIPTION
Add a spec test that would have caught https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/175, introduced by https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/152

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/21126