### PR TITLE
Add ems_ref to auth_key_pairs

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
@@ -190,7 +190,8 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
     collector.keys.each do |key|
       persister.auth_key_pairs.build(
         :name        => key[:name],
-        :fingerprint => key[:fingerprint]
+        :fingerprint => key[:fingerprint],
+        :ems_ref     => key[:id]
       )
     end
   end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -62,6 +62,10 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
     expect(vm.key_pairs.count).to eq(1)
     expect(vm.key_pairs.first.name).to eq('random_key_0')
     expect(vm.key_pairs.first.fingerprint).to eq('SHA256:xxxxxxx')
+
+    # Check that ems_ref is not nil and has a value which follows the guidance in https://cloud.ibm.com/apidocs/vpc#list-keys
+    expect(vm.key_pairs.first.ems_ref).to_not be_nil
+    expect(vm.key_pairs.first.ems_ref).to match(/^[-0-9a-z_]{1,64}/)
   end
 
   def assert_vm_labels


### PR DESCRIPTION
# Issue
To create the provision request the SSH key UUID is required.

# Priority
* Required to continue building VPC provisions.

# Implementation
* Add ems_ref column to persister.

# Not covered
* n/a

# Specs
* Update refresh spec to look for ems_ref on auth_keys.
* ems_ref must not be nil and follow the regex as per https://cloud.ibm.com/apidocs/vpc#list-keys

# Common files
* No common files changed
