### PR TITLE
VPC Add availability_zone relation to subnet.

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
@@ -237,13 +237,14 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
   def cloud_subnets
     collector.cloud_subnets.each do |cs|
       persister.cloud_subnets.build(
-        :cloud_network    => persister.cloud_networks.lazy_find(cs&.dig(:vpc, :id)),
-        :cidr             => cs[:ipv4_cidr_block],
-        :ems_ref          => cs[:id],
-        :name             => cs[:name],
-        :status           => "active",
-        :ip_version       => cs[:ip_version],
-        :network_protocol => cs[:ip_version]
+        :cloud_network     => persister.cloud_networks.lazy_find(cs&.dig(:vpc, :id)),
+        :availability_zone => persister.availability_zones.lazy_find(cs&.dig(:zone, :name)),
+        :cidr              => cs[:ipv4_cidr_block],
+        :ems_ref           => cs[:id],
+        :name              => cs[:name],
+        :status            => "active",
+        :ip_version        => cs[:ip_version],
+        :network_protocol  => cs[:ip_version]
       )
     end
   end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -69,4 +69,23 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
 
     expect(vm.labels.count).to eq(4)
   end
+
+  # Test the components of a cloud subnet.
+  def assert_specific_cloud_subnet
+    cloud_subnet = ems.cloud_subnets.find_by(:ems_ref => '0757-ef523a2f-5356-42ff-8a78-9325509465b9')
+
+    # Test cloud_network relationship.
+    cloud_network = ems.cloud_network.find_by(:ems_ref => 'r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3')
+    expect(cloud_subnet.cloud_network_id).to eq(cloud_network.id)
+
+    # Test availability_zone relationship.
+    availability_zone = ems.availability_zone.find_by(:ems_ref => 'us-east-1')
+    expect(cloud_subnet.availability_zone_id).to eq(availability_zone.id)
+
+    # Test remaining fields.
+    expect(cloud_subnet.cidr).to eq('127.0.0.0/24')
+    expect(cloud_subnet.name).to eq('b-subneet-washington-dc-1')
+    expect(cloud_subnet.ip_version).to eq('ipv4')
+    expect(cloud_subnet.network_protocol).to eq('ipv4')
+  end
 end


### PR DESCRIPTION
# Issue
The VPC subnet must be contained within both the selected zone and VPC.

# Priority
* Required to continue building VPC provisions.

# Implementation
Add relationship between availability zone and cloud subnets.

# Not covered
* n/a

# Specs
* Add new assert_specific_cloud_subnet method to refresher spec.
* Test relationships for cloud_network & availability_zone
* Test remaining strings.

# Common files
* No common files changed
