### PR TITLE
Do not memoize selected sap profile

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -35,7 +35,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
 
   def sap_flavor
     if sap_image?
-      @sap_image ||= begin
+      begin
         selected_flavor_name = values&.dig(:sys_type, 1)
         ar_ems.flavors.find_by(:name => selected_flavor_name)
       end


### PR DESCRIPTION
SAP Hana profiles have pre-set processor and memory values. The
provisioning form should dynamically update the values based on the
selected profile (which is selected through the "Machine Type" field,
when the provisioning image is a SAP Hana image).

When the selected flavor is memoized the UI never retrieved the newly
selected profile to update processor and memory values accordingly.