### PR TITLE
Remove default 'Network Interfaces' selection

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -93,7 +93,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
   def allowed_subnets(_options = {})
     ar_subnets = ar_ems.cloud_subnets
     subnets = ar_subnets&.collect { |subnet| [subnet[:ems_ref], subnet[:name]] }
-    none = ['None', 'None']
+    none = ['None', 'None (Must attach to new public network)']
     Hash[subnets.unshift(none)]
   end
 

--- a/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_dialogs_template.yaml
@@ -172,7 +172,6 @@
             :method: :allowed_subnets
           :description: Network Interfaces
           :required: true
-          :default: None
           :display: :edit
           :data_type: :string
         :public_network:


### PR DESCRIPTION
The ':default' network selection is not functioning correctly. The
intention was to set the selection to 'None' (string) by default.
Regardless of what value is set to ':default' the provision form selects
_nothing_ by default, but displays the first item on the list (making it
appear as if a default selection has been made).

PowerVS VMs must be provisioning with at least one network interface.
The network can be selected from the 'Network Interfaces' pull-down or
by selecting the 'Attach to New Public Network' checkbox (or both). We
haven't been able to enforce these rules in the existing dialog, so the
_required_ 'Network Interfaces' selection includes a 'None' value to
allow selecting only the 'Attach to New Public Network'.

By removing the ':default' parameter from the dialog template the user
is forced to either select an existing network or 'None'. The 'None'
display value now includes a message calling out the requirement to
select 'Attach to New Public Network' since this is not enforced and
will cause the VM provisioning API call to fail.