### PR TITLE
Add Toronto and Osaka regions.

### DIFF
--- a/db/fixtures/ibm_cloud_vpc_regions.yml
+++ b/db/fixtures/ibm_cloud_vpc_regions.yml
@@ -7,6 +7,10 @@ us-east:
   :name: us-east
   :hostname: us-east.iaas.cloud.ibm.com
   :description: US East (Washington DC)
+ca-tor:
+  :name: ca-tor
+  :hostname: ca-tor.iaas.cloud.ibm.com
+  :description: Canada (Toronto)
 eu-gb:
   :name: eu-gb
   :hostname: eu-gb.iaas.cloud.ibm.com
@@ -19,6 +23,10 @@ jp-tok:
   :name: jp-tok
   :hostname: jp-tok.iaas.cloud.ibm.com
   :description: Japan (Tokyo)
+jp-osa:
+  :name: jp-osa
+  :hostname: jp-osa.iaas.cloud.ibm.com
+  :description: Japan (Osaka)
 au-syd:
   :name: au-syd
   :hostname: au-syd.iaas.cloud.ibm.com

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager_spec.rb
@@ -13,7 +13,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager do
   end
 
   it "verifies regions options" do
-    expect(described_class.provider_region_options.count).to eq(6)
+    expect(described_class.provider_region_options.count).to eq(8)
   end
 
   it "does not create orphaned network_manager" do


### PR DESCRIPTION
# Issue
VPC has added two regions since the last update. Toronto and Osaka. This change will add the two regions to be selectable during VPC provider configuration.

# Priority
* Needed for configuring ca-tor region in VPC provision.

# Implementation
* Add the two regions to db/fixtures/ibm_cloud_vpc_regions.yml


# Not covered
* n/a

# Specs
* Manually tested in UI.
* cloud_manager_spec.rb updated to look for 8 regions instead of 6.

# Common files
* No common files changed
