### PR TITLE
Use consistent value types for 'affinity_policy'

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
@@ -54,7 +54,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
           :name         => 'affinity_policy',
           :id           => 'affinity_policy',
           :label        => _('Affinity Policy'),
-          :initialValue => nil,
+          :initialValue => 'Off',
           :condition    => {
             :when => 'edit',
             :is   => false,
@@ -62,7 +62,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
           :options      => [
             {
               :label => 'Off',
-              :value => nil,
+              :value => 'Off',
             },
             {
               :label => 'Affinity',
@@ -87,7 +87,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
               {
                 :not => {
                   :when => 'affinity_policy',
-                  :is   => nil,
+                  :is   => 'Off',
                 },
               },
               {
@@ -120,8 +120,8 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
         'size'            => options['size'].to_i / 1.0.gigabyte,
         'disk_type'       => options['volume_type'],
         'shareable'       => options['multi_attachment'],
-        'affinity_policy' => options['affinity_policy'],
-        'affinity_volume' => options['affinity_volume_id']
+        'affinity_policy' => options['affinity_policy'] == 'Off' ? nil : options['affinity_policy'],
+        'affinity_volume' => options['affinity_policy'] == 'Off' ? nil : options['affinity_volume_id']
       )
 
       volume = api.pcloud_cloudinstances_volumes_post(


### PR DESCRIPTION
The Power Cloud API new volume create call
(https://cloud.ibm.com/apidocs/power-cloud#pcloud-cloudinstances-volumes-post)
can set `affinityPolicy` to only 'affinity' or 'anti-affinity'. When no
affinity policy is required the 'affinityPolicy' is omitted (or set to
nil).

I attempted to implement this directly in params_for_create ddf
definition, but for some reason the 'affinity_policy' :label was set in
the resulting options instead of its :value. This caused the API call to
send '"affinityPolicy": "Off"', which is invalid.

This fix sets the off :value to 'Off' (same as the :label), both to be
consistent and to eliminate the need to distinguish between :label and
:value. That change requires additional logic in the 'raw_create_volume'
method in order to handle the 'Off' case correctly.