### PR TITLE
New volume parameter should use 'disk_type'

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -130,7 +130,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
     new_volumes.drop(1).map! do |new_volume|
       new_volume[:size] = new_volume[:size].to_i
       new_volume[:shareable] = [nil, 'null'].exclude?(new_volume[:shareable])
-      new_volume[:diskType] = storage_type
+      new_volume[:disk_type] = storage_type
       new_volume
     end
   end

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
@@ -48,25 +48,25 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provi
           {
             :name      => "disk_one",
             :size      => 1,
-            :diskType  => "tier1",
+            :disk_type => "tier1",
             :shareable => false
           },
           {
             :name      => "disk_two",
             :size      => 2,
-            :diskType  => "tier1",
+            :disk_type => "tier1",
             :shareable => false
           },
           {
             :name      => "disk_three",
             :size      => 3,
-            :diskType  => "tier1",
+            :disk_type => "tier1",
             :shareable => false
           },
           {
             :name      => "disk_four",
             :size      => 4,
-            :diskType  => "tier1",
+            :disk_type => "tier1",
             :shareable => true
           }
         ]
@@ -90,25 +90,25 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provi
         [
           {
             :name      => "disk_one",
-            :diskType  => "ssd-legacy",
+            :disk_type => "ssd-legacy",
             :size      => 0,
             :shareable => false
           },
           {
             :size      => 2,
-            :diskType  => "ssd-legacy",
+            :disk_type => "ssd-legacy",
             :shareable => false
           },
           {
             :name      => "disk_three",
             :size      => 3,
-            :diskType  => "ssd-legacy",
+            :disk_type => "ssd-legacy",
             :shareable => false
           },
           {
             :name      => "disk_four",
             :size      => 0,
-            :diskType  => "ssd-legacy",
+            :disk_type => "ssd-legacy",
             :shareable => true
           }
         ]


### PR DESCRIPTION
The OpenAPI Power gem uses 'disk_type' instead of 'diskType'.