### PR TITLE
Cloud tool authentication

### DIFF
--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/authentication.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/authentication.rb
@@ -102,6 +102,7 @@ module ManageIQ
               return true if expire_time.nil?
 
               # Checks to see if the expire time will elapse in the next 10 seconds.
+              # True if now is greater than expiry time. False if now is less than expire time.
               Time.now.to_i >= (expire_time - 10)
             end
 

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/authentication.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/authentication.rb
@@ -99,11 +99,13 @@ module ManageIQ
             #
             # @return [Boolean] True is expired. False is valid.
             def expired?(expire_time)
-              return true if expire_time.nil?
+              return false if expire_time.nil? # Assume that expire check is disabled.
+
+              return true unless expire_time.match?('^\d+$') # Verify that expire_time can be converted into an integer.
 
               # Checks to see if the expire time will elapse in the next 10 seconds.
               # True if now is greater than expire time. False if now is less than expire time.
-              Time.now.to_i >= (expire_time - 10)
+              Time.now.to_i >= (expire_time.to_i - 10)
             end
 
             # Define a new logger.

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/authentication.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/authentication.rb
@@ -102,7 +102,7 @@ module ManageIQ
               return true if expire_time.nil?
 
               # Checks to see if the expire time will elapse in the next 10 seconds.
-              # True if now is greater than expiry time. False if now is less than expire time.
+              # True if now is greater than expire time. False if now is less than expire time.
               Time.now.to_i >= (expire_time - 10)
             end
 

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/authentication.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/authentication.rb
@@ -101,7 +101,12 @@ module ManageIQ
             def expired?(expire_time)
               return false if expire_time.nil? # Assume that expire check is disabled.
 
-              return true unless expire_time.match?('^\d+$') # Verify that expire_time can be converted into an integer.
+              return true unless expire_time.respond_to?(:to_i) # Verify that expire_time can be converted into an integer.
+
+              # If expire_time is a string then ensure that it only has digits.
+              if expire_time.respond_to?(:match?)
+                return true unless expire_time.match?('^\d+$') # rubocop:disable Style/SoleNestedConditional
+              end
 
               # Checks to see if the expire time will elapse in the next 10 seconds.
               # True if now is greater than expire time. False if now is less than expire time.

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/authentication.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/authentication.rb
@@ -88,14 +88,14 @@ module ManageIQ
             # @param bearer_info [Hash{Symbol=>String, Integer}] Bearer info hash from IamAuth
             # @return [Hash{Symbol=>String, Integer}] Bearer info hash from IamAuth
             def new_bearer(bearer_info)
-              raise 'Bearer token has expired.' if bearer_info[:api_key].nil?
+              raise 'Bearer token has expired and unable to refresh. An api key is not present in bearer_info hash.' if bearer_info[:api_key].nil?
 
               @logger.info('Bearer token expired. Fetching new one using API Key.')
               IamAuth.new(bearer_info[:api_key]).bearer_info
             end
 
-            # Check to see if the token expiry time has elapsed.
-            # @param expire_time [Integer, NilClass] The token expiry time provided by IAM.
+            # Check to see if the token expire_time has elapsed.
+            # @param expire_time [Integer, NilClass] The token expire_time provided by IAM.
             #
             # @return [Boolean] True is expired. False is valid.
             def expired?(expire_time)

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/common/timeout.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/common/timeout.rb
@@ -7,7 +7,7 @@ module ManageIQ
         module Common
           # A class that standardises the timeout for all object.
           class Timeout
-            def initialize(global: 10)
+            def initialize(global: 60)
               @global = global
             end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,10 @@ VCR.configure do |config|
   # config.debug_logger = $stdout # Keep for debugging tests.
   config.ignore_hosts('codeclimate.com') if ENV['CI']
   config.cassette_library_dir = File.join(ManageIQ::Providers::IbmCloud::Engine.root, 'spec/vcr_cassettes')
+
+  # Used to replace the API Key with the placeholder in the saved VCR.
+  config.define_cassette_placeholder('IBM_CLOUD_VPC_API_KEY') { Rails.application.secrets.ibm_cloud_vpc[:api_key] }
+
   config.before_record do |i|
     replace_token_contents(i.response) if i.request.uri == "https://iam.cloud.ibm.com/identity/token"
     vpc_sanitizier(i) if i.request.uri.match?('iaas.cloud.ibm')

--- a/spec/vcr_cassettes/manageiq/providers/ibm_cloud/cloud_tool/can_get_a_Tagging_client.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_cloud/cloud_tool/can_get_a_Tagging_client.yml
@@ -51,5 +51,78 @@ http_interactions:
       string: '{"access_token":"eyJraWQiOiIyMDIxMDIxOTE4MzUiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwiaWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiZTQyNDhkMTktZGE2OS00NTIwLWI5MDctMzE5NWYwMmFhNDBkIiwiaWRlbnRpZmllciI6IjI3MDAwMVhOTkYiLCJnaXZlbl9uYW1lIjoiSmFyZWQiLCJmYW1pbHlfbmFtZSI6Ik1vb3JlIiwibmFtZSI6IkphcmVkIE1vb3JlIiwiZW1haWwiOiJqYXJlZG1AY2EuaWJtLmNvbSIsInN1YiI6ImphcmVkbUBjYS5pYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiamFyZWRtQGNhLmlibS5jb20iLCJpYW1faWQiOiJpYW0tMjcwMDAxWE5ORiIsIm5hbWUiOiJKYXJlZCBNb29yZSIsImdpdmVuX25hbWUiOiJKYXJlZCIsImZhbWlseV9uYW1lIjoiTW9vcmUiLCJlbWFpbCI6ImphcmVkbUBjYS5pYm0uY29tIn0sImFjY291bnQiOnsidmFsaWQiOnRydWUsImJzcyI6ImM1NmM5YTI2OGQyM2UxYjMzOWFjMTQ3NzQzNTgxMzNjIiwiaW1zX3VzZXJfaWQiOiI3MjI2NTkxIiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxMTYwNDQ3In0sImlhdCI6MTYxNTg0NzM0MywiZXhwIjoxNjE1ODUwOTQzLCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MSwiYW1yIjpbInB3ZCJdfQ.FRoBPEG5ypkuFuVfR9gik43LuYzioFDxbhztZaGo-2CPaDYVblzR-xvMu_mWrcWJhY3N-L2zL8nkvixhCJA2L7QgRREQcyjS7V-mBUdPnSnmlz3L8pMg7jBZpbGmQWQAMfeQ7tFk6N5H2NT--zNKUkjlK2btsnTLc-sbifMIOB9gg-YOdN9nVBrnAz6pN5DjB_XdzTA9IKYTFbqDyWq3NQ6tpCwo_KqZO2ucBK3hJMvpwnJeMr4WgS_Sf8Co9Ten3uqF10l-ZVLZqRMUI4g6RYWE1acKEASSb6GpLuQLlH0aNb3cLRabvoE-TnpsfsAuIf92CdmFlny1UZOI1IKSAA","refresh_token":"REFRESH_TOKEN","ims_user_id":"22222","token_type":"Bearer","expires_in":3600,"expiration":4102462800,"scope":"ibm
         openid"}'
     http_version:
-  recorded_at: Mon, 15 Mar 2021 22:29:06 GMT
+  recorded_at: Mon, 19 Apr 2021 20:28:06 GMT
+- request:
+    method: get
+    uri: https://tags.global-search-tagging.cloud.ibm.com/v3/tags?limit=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - ibm_cloud_global_tagging-ruby-sdk-0.1.0 x86_64-apple-darwin20.3.0 ruby-2.6.7
+      X-Ibmcloud-Sdk-Analytics:
+      - service_name=global_tagging;service_version=V1;operation_id=list_tags
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer eyJraWQiOiIyMDIxMDMyMTE4MzUiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwiaWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiMmM4M2VmN2MtZDVmZi00NjAwLTg2MDYtMGQ3ZGUyMTI2NDZiIiwiaWRlbnRpZmllciI6IjI3MDAwMVhOTkYiLCJnaXZlbl9uYW1lIjoiSmFyZWQiLCJmYW1pbHlfbmFtZSI6Ik1vb3JlIiwibmFtZSI6IkphcmVkIE1vb3JlIiwiZW1haWwiOiJqYXJlZG1AY2EuaWJtLmNvbSIsInN1YiI6ImphcmVkbUBjYS5pYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiamFyZWRtQGNhLmlibS5jb20iLCJpYW1faWQiOiJpYW0tMjcwMDAxWE5ORiIsIm5hbWUiOiJKYXJlZCBNb29yZSIsImdpdmVuX25hbWUiOiJKYXJlZCIsImZhbWlseV9uYW1lIjoiTW9vcmUiLCJlbWFpbCI6ImphcmVkbUBjYS5pYm0uY29tIn0sImFjY291bnQiOnsidmFsaWQiOnRydWUsImJzcyI6ImM1NmM5YTI2OGQyM2UxYjMzOWFjMTQ3NzQzNTgxMzNjIiwiaW1zX3VzZXJfaWQiOiI3MjI2NTkxIiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxMTYwNDQ3In0sImlhdCI6MTYxODg2NDA4MywiZXhwIjoxNjE4ODY3NjgzLCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MSwiYW1yIjpbInB3ZCJdfQ.R3jgHche9Ze6mSyfd4O5TKG4Idjfh2OxqCoO3PMkK5clNobIXSWmsIpbLMh32KQYMu8Eo3Oyat4bcin3lpaPk9mAQPGVW-f7FP7MaCP_XTby4PHsG2FxSFJeH1adExdhYGFPgmzsmPjRlY78IC2NBC_9HwkJFZVYwnxqQ43yFg-2EP6yA_ukP2mfNtzcu6MEu9z2e32m-kUCJrYbQXl2HGowHXrGPByUgrBJVRGRjww-vRX_WtW1V0ODxOJVl9k3o4RKekvrlWnqU83gw2NCxd2rH7ZrCw2NImJPAot68Iss_IJdtBB5HRD8_0Cis_38rloy2bWfmNWelNp2KzjLmA
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src
+        ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+      X-Dns-Prefetch-Control:
+      - 'off'
+      Expect-Ct:
+      - max-age=0
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - no-referrer
+      X-Xss-Protection:
+      - 1; mode=block
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-store
+      Transaction-Id:
+      - gst-9d0e5474-feb6-4a6a-a00b-66603a1730b1
+      X-Global-Transaction-Id:
+      - gst-9d0e5474-feb6-4a6a-a00b-66603a1730b1
+      Ghost-Endpoint:
+      - ibm:yp:us-south:Kubernetes
+      Ghost-Instance:
+      - Kubernetes_6f8ff9546f-l2jvl
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '78'
+      X-Envoy-Upstream-Service-Time:
+      - '115'
+      Server:
+      - istio-envoy
+      Date:
+      - Mon, 19 Apr 2021 20:28:06 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"total_count":431,"offset":0,"limit":1,"items":[{"name":"a-b:c_e4.32:6784"}]}'
+    http_version:
+  recorded_at: Mon, 19 Apr 2021 20:28:06 GMT
 recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/manageiq/providers/ibm_cloud/cloud_tool/can_get_a_VPC_client_with_expired_auth.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_cloud/cloud_tool/can_get_a_VPC_client_with_expired_auth.yml
@@ -1,0 +1,173 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.cloud.ibm.com/identity/token
+    body:
+      encoding: UTF-8
+      string: grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=IBM_CLOUD_VPC_API_KEY&response_type=cloud_iam
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept:
+      - application/json
+      Connection:
+      - close
+      User-Agent:
+      - http.rb/4.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transaction-Id:
+      - 96922690a5034df8a48c61fc15524e6d
+      Cache-Control:
+      - no-cache, no-store
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json
+      Content-Language:
+      - en-US
+      Content-Length:
+      - '1524'
+      X-Envoy-Upstream-Service-Time:
+      - '129'
+      Server:
+      - istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 19 Apr 2021 19:12:20 GMT
+      Connection:
+      - close
+      Set-Cookie:
+      - sessioncookie="9bbf9124490465c1"; Path=/; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"eyJraWQiOiIyMDIxMDMyMTE4MzUiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwiaWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiNTkzYzZmOGUtOTllZS00ZDgzLTg2NmUtZDY5ZWQ5NTQ4ZTlmIiwiaWRlbnRpZmllciI6IjI3MDAwMVhOTkYiLCJnaXZlbl9uYW1lIjoiSmFyZWQiLCJmYW1pbHlfbmFtZSI6Ik1vb3JlIiwibmFtZSI6IkphcmVkIE1vb3JlIiwiZW1haWwiOiJqYXJlZG1AY2EuaWJtLmNvbSIsInN1YiI6ImphcmVkbUBjYS5pYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiamFyZWRtQGNhLmlibS5jb20iLCJpYW1faWQiOiJpYW0tMjcwMDAxWE5ORiIsIm5hbWUiOiJKYXJlZCBNb29yZSIsImdpdmVuX25hbWUiOiJKYXJlZCIsImZhbWlseV9uYW1lIjoiTW9vcmUiLCJlbWFpbCI6ImphcmVkbUBjYS5pYm0uY29tIn0sImFjY291bnQiOnsidmFsaWQiOnRydWUsImJzcyI6ImM1NmM5YTI2OGQyM2UxYjMzOWFjMTQ3NzQzNTgxMzNjIiwiaW1zX3VzZXJfaWQiOiI3MjI2NTkxIiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxMTYwNDQ3In0sImlhdCI6MTYxODg1OTUzNywiZXhwIjoxNjE4ODYzMTM3LCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MSwiYW1yIjpbInB3ZCJdfQ.MQb4QGtP5WV5DvIH8qouiSpZY44BnjOqFm4t1kD3Ax_cu_HASrwcPksNKK2tpOxXW1IFsq3aURD1ZbJvpF8zuePniJpmyQ3e8OqgfKghaygql31aErYSZLhlYY_RoRGqQuB1LUdMRVbhC_tp2QTvdo5sMk5rsvX02d8CwkuWlVEUN4NtVJqbPqKWewyfqnN8iqz-2Q4hW8bclAKANxrH7GxO2UYj6PnTVXWaIdww8LFnpWpqyVG1yTfOyJ3zJUbPmUqr1k06SpHpRAUQASB8jsQDfAtU-8zzjKkG-j6rmVru4J-B0CtIDbYfdpjuRA4m61ySSs42_6HEu2K9_4h_uw","refresh_token":"REFRESH_TOKEN","ims_user_id":"22222","token_type":"Bearer","expires_in":3600,"expiration":4102462800,"scope":"ibm
+        openid"}'
+    http_version:
+  recorded_at: Mon, 19 Apr 2021 19:12:19 GMT
+- request:
+    method: post
+    uri: https://iam.cloud.ibm.com/identity/token
+    body:
+      encoding: UTF-8
+      string: grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=IBM_CLOUD_VPC_API_KEY&response_type=cloud_iam
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept:
+      - application/json
+      Connection:
+      - close
+      User-Agent:
+      - http.rb/4.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transaction-Id:
+      - eafa41856a8540cf986072172394a229
+      Cache-Control:
+      - no-cache, no-store
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json
+      Content-Language:
+      - en-US
+      Content-Length:
+      - '1524'
+      X-Envoy-Upstream-Service-Time:
+      - '35'
+      Server:
+      - istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 19 Apr 2021 19:12:20 GMT
+      Connection:
+      - close
+      Set-Cookie:
+      - sessioncookie="b9542aca57251c45"; Path=/; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"eyJraWQiOiIyMDIxMDMyMTE4MzUiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwiaWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiZjY0YjUzYWMtNzM4Ny00OWZjLTg2MzgtYWViMDJiM2NkZTAxIiwiaWRlbnRpZmllciI6IjI3MDAwMVhOTkYiLCJnaXZlbl9uYW1lIjoiSmFyZWQiLCJmYW1pbHlfbmFtZSI6Ik1vb3JlIiwibmFtZSI6IkphcmVkIE1vb3JlIiwiZW1haWwiOiJqYXJlZG1AY2EuaWJtLmNvbSIsInN1YiI6ImphcmVkbUBjYS5pYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiamFyZWRtQGNhLmlibS5jb20iLCJpYW1faWQiOiJpYW0tMjcwMDAxWE5ORiIsIm5hbWUiOiJKYXJlZCBNb29yZSIsImdpdmVuX25hbWUiOiJKYXJlZCIsImZhbWlseV9uYW1lIjoiTW9vcmUiLCJlbWFpbCI6ImphcmVkbUBjYS5pYm0uY29tIn0sImFjY291bnQiOnsidmFsaWQiOnRydWUsImJzcyI6ImM1NmM5YTI2OGQyM2UxYjMzOWFjMTQ3NzQzNTgxMzNjIiwiaW1zX3VzZXJfaWQiOiI3MjI2NTkxIiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxMTYwNDQ3In0sImlhdCI6MTYxODg1OTUzNywiZXhwIjoxNjE4ODYzMTM3LCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MSwiYW1yIjpbInB3ZCJdfQ.PdnsiJtdeOfT882QHxnZ4iP-8ke0wVtm7np7PSdwF96Pb9UlBuq9xtcNwtooL4IHpO1LpxS9Frp3hR6dLec6JGPaFaTzUK9NmKFMBRw-LRiOaV1chZg18672caw_GB5IB0SIAf-dBWs7MAy8d4JrRnBwD0DFtPZ73R-FtxHkqfxSDwN6YCkHZ-e3SmSk0Cou-Btjy_IeLctq00k4WFzGVGDJMPRwzK_KkbUMYpc5y72dGaaaHMHA9kREEayJdLGJz2nheMABl2bK6D5Jmh6ai9LuC6kWwhYrohiESFCUNyhuEyx0hfUes8PPO7u2QsjTW7r_SvNebquaP_eQtu7jGQ","refresh_token":"REFRESH_TOKEN","ims_user_id":"22222","token_type":"Bearer","expires_in":3600,"expiration":4102462800,"scope":"ibm
+        openid"}'
+    http_version:
+  recorded_at: Mon, 19 Apr 2021 19:12:20 GMT
+- request:
+    method: get
+    uri: https://us-east.iaas.cloud.ibm.com/v1/subnets?generation=2&version=2021-01-01
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - ibm_vpc-ruby-sdk-0.1.0 x86_64-apple-darwin20.3.0 ruby-2.6.7
+      X-Ibmcloud-Sdk-Analytics:
+      - service_name=vpc;service_version=V1;operation_id=list_subnets
+      Accept:
+      - application/json
+      Authorization: Bearer xxxxxx
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 19 Apr 2021 19:12:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=ddb31b3fbea79fabdecc7abf8bd2fb0821618859540; expires=Wed, 19-May-21
+        19:12:20 GMT; path=/; domain=.iaas.cloud.ibm.com; HttpOnly; SameSite=Lax;
+        Secure
+      Cf-Ray:
+      - 6428719fce843fde-YYZ
+      Cache-Control:
+      - max-age=0, no-cache, no-store, must-revalidate
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - '098d2557e400003fde842c7000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Pragma:
+      - no-cache
+      X-Content-Type-Options:
+      - nosniff
+      X-Request-Id:
+      - 6d03770b-e3b7-423f-b6cb-6339cd5a281a
+      X-Trace-Id:
+      - 65d07250fd4bb982
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - cloudflare
+    body:
+      encoding: UTF-8
+      string: '{"limit":50,"first":{"href":"https://us-east.iaas.cloud.ibm.com/v1/subnets?limit=50"},"total_count":4,"subnets":[{"id":"0757-ef523a2f-5356-42ff-8a78-9325509465b9","crn":"crn:v1:bluemix:public:is:us-east-1:a/c56c9a268d23e1b339ac14774358133c::subnet:0757-ef523a2f-5356-42ff-8a78-9325509465b9","href":"https://us-east.iaas.cloud.ibm.com/v1/subnets/0757-ef523a2f-5356-42ff-8a78-9325509465b9","name":"b-subneet-washington-dc-1","resource_type":"subnet","available_ipv4_address_count":250,"ipv4_cidr_block":"127.0.0.0/24","ip_version":"ipv4","zone":{"name":"us-east-1","href":"https://us-east.iaas.cloud.ibm.com/v1/regions/us-east/zones/us-east-1"},"vpc":{"id":"r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3","crn":"crn:v1:bluemix:public:is:us-east:a/c56c9a268d23e1b339ac14774358133c::vpc:r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3","href":"https://us-east.iaas.cloud.ibm.com/v1/vpcs/r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3","name":"b-vpc-washington-dc","resource_type":"vpc"},"status":"available","total_ipv4_address_count":256,"created_at":"2020-10-23T20:08:07Z","network_acl":{"id":"r014-082ad1d3-fce2-43e3-b7d3-dc2095967814","crn":"crn:v1:bluemix:public:is:us-east:a/c56c9a268d23e1b339ac14774358133c::network-acl:r014-082ad1d3-fce2-43e3-b7d3-dc2095967814","href":"https://us-east.iaas.cloud.ibm.com/v1/network_acls/r014-082ad1d3-fce2-43e3-b7d3-dc2095967814","name":"moving-perfected-sprang-isolation"},"public_gateway":{"id":"r014-8ce8eccc-2f61-4ddc-9c4c-5ad693974f34","crn":"crn:v1:bluemix:public:is:us-east-1:a/c56c9a268d23e1b339ac14774358133c::public-gateway:r014-8ce8eccc-2f61-4ddc-9c4c-5ad693974f34","href":"https://us-east.iaas.cloud.ibm.com/v1/public_gateways/r014-8ce8eccc-2f61-4ddc-9c4c-5ad693974f34","name":"pgw-78648670-156b-11eb-b106-4d01d2f29e8a","resource_type":"public_gateway"},"resource_group":{"id":"345c433098294722ba52d9039133e8cf","href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/345c433098294722ba52d9039133e8cf","name":"default"},"routing_table":{"id":"r014-05bca06d-0ada-4941-8cd6-d641610f628d","href":"https://us-east.iaas.cloud.ibm.com/v1/vpcs/r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3/routing_tables/r014-05bca06d-0ada-4941-8cd6-d641610f628d","name":"refute-dotted-lethargic-snowbound-online-matron","resource_type":"routing_table"}},{"id":"0767-14d27cd3-66c4-429c-8ab7-6b0e948d345a","crn":"crn:v1:bluemix:public:is:us-east-2:a/c56c9a268d23e1b339ac14774358133c::subnet:0767-14d27cd3-66c4-429c-8ab7-6b0e948d345a","href":"https://us-east.iaas.cloud.ibm.com/v1/subnets/0767-14d27cd3-66c4-429c-8ab7-6b0e948d345a","name":"b-subnet-washington-dc-2","resource_type":"subnet","available_ipv4_address_count":250,"ipv4_cidr_block":"127.0.0.0/24","ip_version":"ipv4","zone":{"name":"us-east-2","href":"https://us-east.iaas.cloud.ibm.com/v1/regions/us-east/zones/us-east-2"},"vpc":{"id":"r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3","crn":"crn:v1:bluemix:public:is:us-east:a/c56c9a268d23e1b339ac14774358133c::vpc:r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3","href":"https://us-east.iaas.cloud.ibm.com/v1/vpcs/r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3","name":"b-vpc-washington-dc","resource_type":"vpc"},"status":"available","total_ipv4_address_count":256,"created_at":"2020-10-23T20:06:47Z","network_acl":{"id":"r014-082ad1d3-fce2-43e3-b7d3-dc2095967814","crn":"crn:v1:bluemix:public:is:us-east:a/c56c9a268d23e1b339ac14774358133c::network-acl:r014-082ad1d3-fce2-43e3-b7d3-dc2095967814","href":"https://us-east.iaas.cloud.ibm.com/v1/network_acls/r014-082ad1d3-fce2-43e3-b7d3-dc2095967814","name":"moving-perfected-sprang-isolation"},"public_gateway":{"id":"r014-5edbf6a1-7251-4925-9b9c-5905ca6b923a","crn":"crn:v1:bluemix:public:is:us-east-2:a/c56c9a268d23e1b339ac14774358133c::public-gateway:r014-5edbf6a1-7251-4925-9b9c-5905ca6b923a","href":"https://us-east.iaas.cloud.ibm.com/v1/public_gateways/r014-5edbf6a1-7251-4925-9b9c-5905ca6b923a","name":"pgw-48cc88e0-156b-11eb-b5c7-eb70e3cf761d","resource_type":"public_gateway"},"resource_group":{"id":"345c433098294722ba52d9039133e8cf","href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/345c433098294722ba52d9039133e8cf","name":"default"},"routing_table":{"id":"r014-05bca06d-0ada-4941-8cd6-d641610f628d","href":"https://us-east.iaas.cloud.ibm.com/v1/vpcs/r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3/routing_tables/r014-05bca06d-0ada-4941-8cd6-d641610f628d","name":"refute-dotted-lethargic-snowbound-online-matron","resource_type":"routing_table"}},{"id":"0777-da420f1d-7d0d-456e-9ecc-6f94b6b9b2d8","crn":"crn:v1:bluemix:public:is:us-east-3:a/c56c9a268d23e1b339ac14774358133c::subnet:0777-da420f1d-7d0d-456e-9ecc-6f94b6b9b2d8","href":"https://us-east.iaas.cloud.ibm.com/v1/subnets/0777-da420f1d-7d0d-456e-9ecc-6f94b6b9b2d8","name":"b-subnet-washington-dc-3","resource_type":"subnet","available_ipv4_address_count":250,"ipv4_cidr_block":"127.0.0.0/24","ip_version":"ipv4","zone":{"name":"us-east-3","href":"https://us-east.iaas.cloud.ibm.com/v1/regions/us-east/zones/us-east-3"},"vpc":{"id":"r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3","crn":"crn:v1:bluemix:public:is:us-east:a/c56c9a268d23e1b339ac14774358133c::vpc:r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3","href":"https://us-east.iaas.cloud.ibm.com/v1/vpcs/r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3","name":"b-vpc-washington-dc","resource_type":"vpc"},"status":"available","total_ipv4_address_count":256,"created_at":"2020-10-23T20:05:14Z","network_acl":{"id":"r014-082ad1d3-fce2-43e3-b7d3-dc2095967814","crn":"crn:v1:bluemix:public:is:us-east:a/c56c9a268d23e1b339ac14774358133c::network-acl:r014-082ad1d3-fce2-43e3-b7d3-dc2095967814","href":"https://us-east.iaas.cloud.ibm.com/v1/network_acls/r014-082ad1d3-fce2-43e3-b7d3-dc2095967814","name":"moving-perfected-sprang-isolation"},"public_gateway":{"id":"r014-3de85aef-2106-4769-848c-4eadcfb176a0","crn":"crn:v1:bluemix:public:is:us-east-3:a/c56c9a268d23e1b339ac14774358133c::public-gateway:r014-3de85aef-2106-4769-848c-4eadcfb176a0","href":"https://us-east.iaas.cloud.ibm.com/v1/public_gateways/r014-3de85aef-2106-4769-848c-4eadcfb176a0","name":"pgw-108be660-156b-11eb-b5c7-eb70e3cf761d","resource_type":"public_gateway"},"resource_group":{"id":"345c433098294722ba52d9039133e8cf","href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/345c433098294722ba52d9039133e8cf","name":"default"},"routing_table":{"id":"r014-05bca06d-0ada-4941-8cd6-d641610f628d","href":"https://us-east.iaas.cloud.ibm.com/v1/vpcs/r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3/routing_tables/r014-05bca06d-0ada-4941-8cd6-d641610f628d","name":"refute-dotted-lethargic-snowbound-online-matron","resource_type":"routing_table"}},{"id":"0777-8da6464b-e4bf-4cd6-8e9f-09a9f0f619c5","crn":"crn:v1:bluemix:public:is:us-east-3:a/c56c9a268d23e1b339ac14774358133c::subnet:0777-8da6464b-e4bf-4cd6-8e9f-09a9f0f619c5","href":"https://us-east.iaas.cloud.ibm.com/v1/subnets/0777-8da6464b-e4bf-4cd6-8e9f-09a9f0f619c5","name":"cloudformsvpc","resource_type":"subnet","available_ipv4_address_count":247,"ipv4_cidr_block":"127.0.0.0/24","ip_version":"ipv4","zone":{"name":"us-east-3","href":"https://us-east.iaas.cloud.ibm.com/v1/regions/us-east/zones/us-east-3"},"vpc":{"id":"r014-7186c34c-67cc-4c07-aa40-326ecb895b53","crn":"crn:v1:bluemix:public:is:us-east:a/c56c9a268d23e1b339ac14774358133c::vpc:r014-7186c34c-67cc-4c07-aa40-326ecb895b53","href":"https://us-east.iaas.cloud.ibm.com/v1/vpcs/r014-7186c34c-67cc-4c07-aa40-326ecb895b53","name":"cloudformvpx","resource_type":"vpc"},"status":"available","total_ipv4_address_count":256,"created_at":"2020-03-31T02:16:01Z","network_acl":{"id":"r014-3cb58cb2-6a61-4fea-a78f-55c39ba03ad3","crn":"crn:v1:bluemix:public:is:us-east:a/c56c9a268d23e1b339ac14774358133c::network-acl:r014-3cb58cb2-6a61-4fea-a78f-55c39ba03ad3","href":"https://us-east.iaas.cloud.ibm.com/v1/network_acls/r014-3cb58cb2-6a61-4fea-a78f-55c39ba03ad3","name":"napped-pessimist-thing-revolving-graduate-punctuate"},"public_gateway":{"id":"r014-1bdb4895-dd7d-4b15-a172-3d82c13428d4","crn":"crn:v1:bluemix:public:is:us-east-3:a/c56c9a268d23e1b339ac14774358133c::public-gateway:r014-1bdb4895-dd7d-4b15-a172-3d82c13428d4","href":"https://us-east.iaas.cloud.ibm.com/v1/public_gateways/r014-1bdb4895-dd7d-4b15-a172-3d82c13428d4","name":"pgw-91367280-72f5-11ea-9ebe-bbb9ec18e692","resource_type":"public_gateway"},"resource_group":{"id":"29b1dd25de2d40b5ae5bd5f719f30db8","href":"https://resource-controller.cloud.ibm.com/v2/resource_groups/29b1dd25de2d40b5ae5bd5f719f30db8","name":"camc-test"},"routing_table":{"id":"r014-a89ca341-dfd9-4b11-b2ee-0c7632b125da","href":"https://us-east.iaas.cloud.ibm.com/v1/vpcs/r014-7186c34c-67cc-4c07-aa40-326ecb895b53/routing_tables/r014-a89ca341-dfd9-4b11-b2ee-0c7632b125da","name":"playtime-untoasted-basin-dexterity-outlook-bundle","resource_type":"routing_table"}}]}
+
+        '
+    http_version:
+  recorded_at: Mon, 19 Apr 2021 19:12:21 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
# Issue
Long running instance does not automatically update token when expired. The original implementation checked expiry on init of a class, but since cloud tool memoizes the child classes this is insufficient for the desired goal. The new implementation checks expiry before every request. This is beneficial when using a REPL for testing code chunks.

# Priority
* Required to add resource groups to CloudTool for provisioning.

# Implementation
* On each request check the expiry. If the token is expired then fetch a new one.
* Trivial change to the timeout from 10 to 60 seconds. The tagging API sometimes takes more than 10 seconds to respond.

# Not covered
* n/a

# Specs
* Updated cloud_tools_spec with new functionality.
* New test to check that an instantiated vpc instance will refresh when the expiry_time has elapsed.
* Updates to existing tests to accommodate the changed behaviour.
* Added and updated VCRs for new test functionality.

# Common files
* Add `define_cassette_placeholder` to `spec_helper` for `IBM_CLOUD_VPC_API_KEY`. Without it the API Key is saved to the VCR file.
