### PR TITLE
Fix SAP profile (flavor) memory units

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
@@ -255,7 +255,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
           :ems_ref     => value.profile_id,
           :name        => value.profile_id,
           :cpus        => value.cores,
-          :memory      => value.memory,
+          :memory      => value.memory&.gigabytes,
           :description => description
         )
       end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -44,7 +44,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
 
   def sap_flavor_memory(_options = {})
     if sap_flavor
-      {"2" => sap_flavor.memory}
+      {"2" => (sap_flavor.memory / 1.0.gigabyte).to_i}
     end
   end
 


### PR DESCRIPTION
The Power Cloud API returns SAP profile memory in gigabytes, but the flavor table stores memory in bytes.

I also included 1dbb48b to write the core value to both `cpus` and `cpu_cores`, to be consistent with Azure and IBM Cloud VPC providers:
https://github.com/ManageIQ/manageiq-providers-azure/blob/master/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb#L43-L44
https://github.com/ManageIQ/manageiq-providers-ibm_cloud/blob/master/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb#L182-L183

But `manageiq-providers-google` omits it:
https://github.com/ManageIQ/manageiq-providers-google/blob/master/app/models/manageiq/providers/google/inventory/parser.rb#L73

And `manageiq-providers-azure_stack` seems to treat `cpu_cores` == sockets. (bug?)
https://github.com/ManageIQ/manageiq-providers-azure_stack/blob/master/app/models/manageiq/providers/azure_stack/inventory/parser/cloud_manager.rb#L36-L37

Thoughts @agrare ?