### PR TITLE
Cloud tool resource manager

### DIFF
--- a/lib/manageiq/providers/ibm_cloud/cloud_tool.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tool.rb
@@ -55,6 +55,12 @@ module ManageIQ
           @vpc ||= CloudTools::Vpc.new(:cloudtools => self, :region => region, :version => version, :generation => generation)
         end
 
+        # Get a class that accesses the IBM Cloud Resource Manager API.
+        # @return [CloudTools::ResourceController] the CloudTools Resource Manager SDK wrapper.
+        def resource
+          @resource ||= CloudTools::ResourceController.new(:cloudtools => self)
+        end
+
         private
 
         # Set a new logger

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/resource_controller.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/resource_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'ibm_cloud_resource_controller'
+
+%w[controller manager].each { |mod| require_relative File.join('resource_controller', mod) }
+
+module ManageIQ
+  module Providers
+    module IbmCloud
+      module CloudTools
+        # CloudTools wrapper class to enhance the IBM Tagging SDK.
+        class ResourceController
+          def initialize(cloudtools:)
+            @cloudtools = cloudtools
+          end
+
+          attr_reader :cloudtools
+
+          # Interface for logging.
+          # @return [Logger]
+          def logger
+            @cloudtools.logger
+          end
+
+          def controller
+            Controller.new(:cloudtools => @cloudtools)
+          end
+
+          def manager
+            Manager.new(:cloudtools => @cloudtools)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/resource_controller/common.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/resource_controller/common.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module ManageIQ
+  module Providers
+    module IbmCloud
+      module CloudTools
+        class ResourceController
+          # CloudTools wrapper class to enhance the IBM Resource Controller Resource Manager SDK.
+          class Common < Sdk::Branch
+            private
+
+            # Create a generator that removes the need for pagination.
+            # @param call_back [String] The method name to use for pagination.
+            # @param call_back [String] The method name to use for pagination.
+            #
+            # @return [Enumerator] Object to page through results.
+            # @yield [Hash] Result of request.
+            def each_resource(call_back, **kwargs)
+              response = request(call_back, **kwargs)
+              resources = response[:resources]
+              resources.each { |value| yield value }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/resource_controller/common.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/resource_controller/common.rb
@@ -10,8 +10,9 @@ module ManageIQ
             private
 
             # Create a generator that removes the need for pagination.
+            # Some of the list methods look like they have pagination properties but the default SDK doesn't allow passing in the start argument.
             # @param call_back [String] The method name to use for pagination.
-            # @param call_back [String] The method name to use for pagination.
+            # @param kwargs [Hash{Symbol => String, Number}] Key pairs to be passed into the request.
             #
             # @return [Enumerator] Object to page through results.
             # @yield [Hash] Result of request.

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/resource_controller/controller.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/resource_controller/controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative 'common'
+
+module ManageIQ
+  module Providers
+    module IbmCloud
+      module CloudTools
+        class ResourceController
+          # CloudTools wrapper class to enhance the IBM Resource Controller Resource Manager SDK.
+          class Controller < Common
+            private
+
+            # Return a ResourceController SDK instance. Requires an internet connection.
+            # @return [IbmCloudResourceController::ResourceControllerV2]
+            def sdk_client
+              IbmCloudResourceController::ResourceControllerV2.new(:authenticator => @cloudtools.authenticator)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/resource_controller/manager.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/resource_controller/manager.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative 'common'
+
+module ManageIQ
+  module Providers
+    module IbmCloud
+      module CloudTools
+        class ResourceController
+          # CloudTools wrapper class to enhance the IBM Resource Controller Resource Manager SDK.
+          class Manager < Common
+            private
+
+            # Return a ResourceManager SDK instance. Requires an internet connection.
+            # @return [IbmCloudResourceController::ResourceManagerV2]
+            def sdk_client
+              IbmCloudResourceController::ResourceManagerV2.new(:authenticator => @cloudtools.authenticator)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb
@@ -22,7 +22,7 @@ module ManageIQ
               @cloudtools.logger
             end
 
-            # Get an instatiated instance of the Cloud SDK.
+            # Get an instantiated instance of the Cloud SDK.
             # @return [Object] The specific Cloud SDK object for the class.
             def client
               client = sdk_client
@@ -55,7 +55,7 @@ module ManageIQ
 
             private
 
-            # @return [Object] The instaniated client.
+            # @return [Object] The instantiated client.
             def sdk_client
               raise NotImplementedError, 'Implement sdk_client method in subclass.'
             end
@@ -63,7 +63,7 @@ module ManageIQ
             # Main logic for enumerator is implemented here in subclasses.
             # @param call_back [Symbol] A method on the SDK client.
             # @param kwargs [Any] Should be notated as **kwargs. Captures all keyword args and passes them downstream.
-            # @return [Object] The instaniated client.
+            # @return [Object] The instantiated client.
             def each_resource(_call_back, _kwargs)
               raise NotImplementedError, 'Implement each_resource method in subclass.'
             end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_tools_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_tools_spec.rb
@@ -197,4 +197,24 @@ describe ManageIQ::Providers::IbmCloud::CloudTool, :vcr do
     expect(response.next).to be_a(Hash)
     expect(response.next).to be_a(Hash)
   end
+
+  it 'Can get resource controller' do
+    resource = described_class.new(:api_key => api_key).resource
+    expect(resource).to be_a(ManageIQ::Providers::IbmCloud::CloudTools::ResourceController)
+    manager = resource.controller
+    expect(manager).to be_a(ManageIQ::Providers::IbmCloud::CloudTools::ResourceController::Controller)
+    response = manager.collection('list_resource_instances', :limit => 2)
+    expect(response).to be_a(Enumerator)
+    expect(response.next).to be_a(Hash)
+  end
+
+  it 'Can get resource manager' do
+    resource = described_class.new(:api_key => api_key).resource
+    expect(resource).to be_a(ManageIQ::Providers::IbmCloud::CloudTools::ResourceController)
+    manager = resource.manager
+    expect(manager).to be_a(ManageIQ::Providers::IbmCloud::CloudTools::ResourceController::Manager)
+    response = manager.collection('list_resource_groups')
+    expect(response).to be_a(Enumerator)
+    expect(response.next).to be_a(Hash)
+  end
 end

--- a/spec/vcr_cassettes/ManageIQ_Providers_IbmCloud_CloudTool/Can_get_resource_controller.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_IbmCloud_CloudTool/Can_get_resource_controller.yml
@@ -1,0 +1,125 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.cloud.ibm.com/identity/token
+    body:
+      encoding: UTF-8
+      string: grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=IBM_CLOUD_VPC_API_KEY&response_type=cloud_iam
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept:
+      - application/json
+      Connection:
+      - close
+      User-Agent:
+      - http.rb/4.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transaction-Id:
+      - 7c7c87ed2fba411eab47904b21246b0d
+      Cache-Control:
+      - no-cache, no-store
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json
+      Content-Language:
+      - en-US
+      Content-Length:
+      - '1524'
+      X-Envoy-Upstream-Service-Time:
+      - '268'
+      Server:
+      - istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 26 Apr 2021 16:48:13 GMT
+      Connection:
+      - close
+      Set-Cookie:
+      - sessioncookie="ffcfbc9e0090bd6e"; Path=/; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"eyJraWQiOiIyMDIxMDQyMDE4MzYiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwiaWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiNWJlZDRmZWMtOTMxMy00YjI1LTg2YTEtYTNiN2Q3NmY5MTRkIiwiaWRlbnRpZmllciI6IjI3MDAwMVhOTkYiLCJnaXZlbl9uYW1lIjoiSmFyZWQiLCJmYW1pbHlfbmFtZSI6Ik1vb3JlIiwibmFtZSI6IkphcmVkIE1vb3JlIiwiZW1haWwiOiJqYXJlZG1AY2EuaWJtLmNvbSIsInN1YiI6ImphcmVkbUBjYS5pYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiamFyZWRtQGNhLmlibS5jb20iLCJpYW1faWQiOiJpYW0tMjcwMDAxWE5ORiIsIm5hbWUiOiJKYXJlZCBNb29yZSIsImdpdmVuX25hbWUiOiJKYXJlZCIsImZhbWlseV9uYW1lIjoiTW9vcmUiLCJlbWFpbCI6ImphcmVkbUBjYS5pYm0uY29tIn0sImFjY291bnQiOnsidmFsaWQiOnRydWUsImJzcyI6ImM1NmM5YTI2OGQyM2UxYjMzOWFjMTQ3NzQzNTgxMzNjIiwiaW1zX3VzZXJfaWQiOiI3MjI2NTkxIiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxMTYwNDQ3In0sImlhdCI6MTYxOTQ1NTY5MCwiZXhwIjoxNjE5NDU5MjkwLCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MSwiYW1yIjpbInB3ZCJdfQ.hIFRbiPB1E5MZsvoWE9GEKYj-G4hwarqkfxspP_k5cr0n2ws-XcL7RAnzPr8Q-mejhRdQy88HhWjFPgciVIu4juKyav2eJqXEvq4cCC_1tnXrJr2SOTbCg8NKWnZhL9oc9YTv8grCx6ADI6dkvcLpU0wZigEWXnjMT2igkxlTGYRqM2aciiJcuysAeiaFNXCrvmWR6HwycUJcYl-OtwaaubgonttTa9UShIGJIMqH5RAeo718P_WQbTva29P0yqyqjYj5-yoPf9NbWiUIKFOXFFx8F8DQ2gK_OcPR-98FtqAo2cP0RJO2yQKurveBw19l4f9sf03WcxK16vFB5hE6w","refresh_token":"REFRESH_TOKEN","ims_user_id":"22222","token_type":"Bearer","expires_in":3600,"expiration":4102462800,"scope":"ibm
+        openid"}'
+    http_version:
+  recorded_at: Mon, 26 Apr 2021 16:48:13 GMT
+- request:
+    method: get
+    uri: https://resource-controller.cloud.ibm.com/v2/resource_instances?limit=2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - ibm_cloud_resource_controller-ruby-sdk-2.0.1 x86_64-apple-darwin20.3.0 ruby-2.6.7
+      X-Ibmcloud-Sdk-Analytics:
+      - service_name=resource_controller;service_version=V2;operation_id=list_resource_instances
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer eyJraWQiOiIyMDIxMDQyMDE4MzYiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwiaWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiNWJlZDRmZWMtOTMxMy00YjI1LTg2YTEtYTNiN2Q3NmY5MTRkIiwiaWRlbnRpZmllciI6IjI3MDAwMVhOTkYiLCJnaXZlbl9uYW1lIjoiSmFyZWQiLCJmYW1pbHlfbmFtZSI6Ik1vb3JlIiwibmFtZSI6IkphcmVkIE1vb3JlIiwiZW1haWwiOiJqYXJlZG1AY2EuaWJtLmNvbSIsInN1YiI6ImphcmVkbUBjYS5pYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiamFyZWRtQGNhLmlibS5jb20iLCJpYW1faWQiOiJpYW0tMjcwMDAxWE5ORiIsIm5hbWUiOiJKYXJlZCBNb29yZSIsImdpdmVuX25hbWUiOiJKYXJlZCIsImZhbWlseV9uYW1lIjoiTW9vcmUiLCJlbWFpbCI6ImphcmVkbUBjYS5pYm0uY29tIn0sImFjY291bnQiOnsidmFsaWQiOnRydWUsImJzcyI6ImM1NmM5YTI2OGQyM2UxYjMzOWFjMTQ3NzQzNTgxMzNjIiwiaW1zX3VzZXJfaWQiOiI3MjI2NTkxIiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxMTYwNDQ3In0sImlhdCI6MTYxOTQ1NTY5MCwiZXhwIjoxNjE5NDU5MjkwLCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MSwiYW1yIjpbInB3ZCJdfQ.hIFRbiPB1E5MZsvoWE9GEKYj-G4hwarqkfxspP_k5cr0n2ws-XcL7RAnzPr8Q-mejhRdQy88HhWjFPgciVIu4juKyav2eJqXEvq4cCC_1tnXrJr2SOTbCg8NKWnZhL9oc9YTv8grCx6ADI6dkvcLpU0wZigEWXnjMT2igkxlTGYRqM2aciiJcuysAeiaFNXCrvmWR6HwycUJcYl-OtwaaubgonttTa9UShIGJIMqH5RAeo718P_WQbTva29P0yqyqjYj5-yoPf9NbWiUIKFOXFFx8F8DQ2gK_OcPR-98FtqAo2cP0RJO2yQKurveBw19l4f9sf03WcxK16vFB5hE6w
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Request-Id:
+      - f3433bbd-d789-43d3-afee-390642b5e333
+      Retry-After:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      Transaction-Id:
+      - bss-28600fbda8ecbbd6
+      X-Global-K8fdic-Transaction-Id:
+      - f3433bbd-d789-43d3-afee-390642b5e333
+      X-Global-Transaction-Id:
+      - bss-28600fbda8ecbbd6
+      X-Ratelimit-Limit:
+      - '120'
+      X-Ratelimit-Remaining:
+      - '119'
+      X-Ratelimit-Reset:
+      - '0'
+      X-Request-Id:
+      - f3433bbd-d789-43d3-afee-390642b5e333
+      X-Transaction-Id:
+      - bss-28600fbda8ecbbd6
+      X-Envoy-Upstream-Service-Time:
+      - '264'
+      Server:
+      - istio-envoy
+      Expires:
+      - Mon, 26 Apr 2021 16:48:14 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Apr 2021 16:48:14 GMT
+      Content-Length:
+      - '2436'
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"rows_count":1,"next_url":"/v2/resource_instances?start=bmV4dF9kb2NpZD1nMUFBQUFEX2VKekxZV0JnWU01Z1RtSFFTa2xLemk5S2RVaEpNdFZMeXRWTlR0Wk5TVTNKVEU0c1NVMHhNakxYUzg3SkwwMUp6Q3ZSeTBzdHlRSHFZVXBTQUpKSi12X19fODhDODkyY3l2allXclF2TUNReE1ERHFacUVhYVVLY2tRWWdJLTJSakN4OXd5S1ZlQUJrNUFZajhveDBBQm5wajJxa3hQb1BJQ01sZDJWbEFRQlhnRTZyJmxpbWl0PTImYWNjb3VudF9pZD1jNTZjOWEyNjhkMjNlMWIzMzlhYzE0Nzc0MzU4MTMzYw","resources":[{"id":"crn:v1:bluemix:public:container-registry:eu-gb:a/c56c9a268d23e1b339ac14774358133c:e3c2e605-9af4-59fc-b966-d23265b8dd38::","guid":"crn:v1:bluemix:public:container-registry:eu-gb:a/c56c9a268d23e1b339ac14774358133c:e3c2e605-9af4-59fc-b966-d23265b8dd38::","url":"/v2/resource_instances/crn:v1:bluemix:public:container-registry:eu-gb:a%2Fc56c9a268d23e1b339ac14774358133c:e3c2e605-9af4-59fc-b966-d23265b8dd38::","created_at":"2018-01-10T14:10:17.405Z","updated_at":"2018-01-10T14:10:17.405Z","deleted_at":null,"created_by":"","updated_by":"","deleted_by":"","scheduled_reclaim_at":null,"restored_at":null,"scheduled_reclaim_by":"","restored_by":"","name":"Container
+        Registry","region_id":"eu-gb","account_id":"c56c9a268d23e1b339ac14774358133c","reseller_channel_id":"","resource_plan_id":"public.bluemix.container.registry.free","resource_group_id":"345c433098294722ba52d9039133e8cf","target_crn":"crn:v1:bluemix:public::eu-gb:::environment:bluemix-eu-gb","create_time":1515593417405,"allow_cleanup":false,"crn":"crn:v1:bluemix:public:container-registry:eu-gb:a/c56c9a268d23e1b339ac14774358133c:e3c2e605-9af4-59fc-b966-d23265b8dd38::","state":"active","type":"container-registry_instance","resource_id":"public.bluemix.container.registry","dashboard_url":null,"last_operation":null,"resource_aliases_url":"/v2/resource_instances/crn:v1:bluemix:public:container-registry:eu-gb:a%2Fc56c9a268d23e1b339ac14774358133c:e3c2e605-9af4-59fc-b966-d23265b8dd38::/resource_aliases","resource_bindings_url":"/v2/resource_instances/crn:v1:bluemix:public:container-registry:eu-gb:a%2Fc56c9a268d23e1b339ac14774358133c:e3c2e605-9af4-59fc-b966-d23265b8dd38::/resource_bindings","resource_keys_url":"/v2/resource_instances/crn:v1:bluemix:public:container-registry:eu-gb:a%2Fc56c9a268d23e1b339ac14774358133c:e3c2e605-9af4-59fc-b966-d23265b8dd38::/resource_keys","plan_history":[{"resource_plan_id":"public.bluemix.container.registry.free","start_date":"2018-01-10T14:10:17.405Z","requestor_id":""}],"migrated":false,"controlled_by":"","locked":false}]}
+
+        '
+    http_version:
+  recorded_at: Mon, 26 Apr 2021 16:48:13 GMT
+recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/ManageIQ_Providers_IbmCloud_CloudTool/Can_get_resource_manager.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_IbmCloud_CloudTool/Can_get_resource_manager.yml
@@ -1,0 +1,120 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.cloud.ibm.com/identity/token
+    body:
+      encoding: UTF-8
+      string: grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=IBM_CLOUD_VPC_API_KEY&response_type=cloud_iam
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept:
+      - application/json
+      Connection:
+      - close
+      User-Agent:
+      - http.rb/4.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transaction-Id:
+      - 960408706f39432ea561937d6f5718f6
+      Cache-Control:
+      - no-cache, no-store
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json
+      Content-Language:
+      - en-US
+      Content-Length:
+      - '1524'
+      X-Envoy-Upstream-Service-Time:
+      - '99'
+      Server:
+      - istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 26 Apr 2021 15:29:12 GMT
+      Connection:
+      - close
+      Set-Cookie:
+      - sessioncookie="3951cc356c8e5468"; Path=/; HttpOnly
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"eyJraWQiOiIyMDIxMDQyMDE4MzYiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwiaWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiODc5YmU0ZDUtYWJkZi00ZDgzLWI3MmItNDg3MGJkY2Q2Yzc4IiwiaWRlbnRpZmllciI6IjI3MDAwMVhOTkYiLCJnaXZlbl9uYW1lIjoiSmFyZWQiLCJmYW1pbHlfbmFtZSI6Ik1vb3JlIiwibmFtZSI6IkphcmVkIE1vb3JlIiwiZW1haWwiOiJqYXJlZG1AY2EuaWJtLmNvbSIsInN1YiI6ImphcmVkbUBjYS5pYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiamFyZWRtQGNhLmlibS5jb20iLCJpYW1faWQiOiJpYW0tMjcwMDAxWE5ORiIsIm5hbWUiOiJKYXJlZCBNb29yZSIsImdpdmVuX25hbWUiOiJKYXJlZCIsImZhbWlseV9uYW1lIjoiTW9vcmUiLCJlbWFpbCI6ImphcmVkbUBjYS5pYm0uY29tIn0sImFjY291bnQiOnsidmFsaWQiOnRydWUsImJzcyI6ImM1NmM5YTI2OGQyM2UxYjMzOWFjMTQ3NzQzNTgxMzNjIiwiaW1zX3VzZXJfaWQiOiI3MjI2NTkxIiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxMTYwNDQ3In0sImlhdCI6MTYxOTQ1MDk0OSwiZXhwIjoxNjE5NDU0NTQ5LCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MSwiYW1yIjpbInB3ZCJdfQ.Cu1lgiTEr6HVTaxUH2wN3bIJYjGuEom8H8rxpmXijAMlttYjHacgtCptYGIfTcBpl5cE2ytag5Y1d2UIyMhygRdQ9h9lBBTcIgDDk7nLB9a_2TDlmWRBImQJdC4LBCoAQdEmwMFnHHnnhCygMtR9ssX68-cl-S78wEE3yzoFMPIy04G5S7HJNJqVfDSka_2j-Qg4h1FFNse7mVuxcRjZUCbymbjt4Z75rQdVQMlCLPS6UDXNBQgcJavQhSrmxYrI7aClJ2tWJlh8bznO0JXmutJBVl51EfcCceC0CbwpqB_Kjpy4ZZQh89m3bffaxYrGlkp_jbn8N470tMjufHeaow","refresh_token":"REFRESH_TOKEN","ims_user_id":"22222","token_type":"Bearer","expires_in":3600,"expiration":4102462800,"scope":"ibm
+        openid"}'
+    http_version:
+  recorded_at: Mon, 26 Apr 2021 15:29:13 GMT
+- request:
+    method: get
+    uri: https://resource-controller.cloud.ibm.com/v2/resource_groups
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - ibm_cloud_resource_controller-ruby-sdk-2.0.1 x86_64-apple-darwin20.3.0 ruby-2.6.7
+      X-Ibmcloud-Sdk-Analytics:
+      - service_name=resource_manager;service_version=V2;operation_id=list_resource_groups
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer eyJraWQiOiIyMDIxMDQyMDE4MzYiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwiaWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiODc5YmU0ZDUtYWJkZi00ZDgzLWI3MmItNDg3MGJkY2Q2Yzc4IiwiaWRlbnRpZmllciI6IjI3MDAwMVhOTkYiLCJnaXZlbl9uYW1lIjoiSmFyZWQiLCJmYW1pbHlfbmFtZSI6Ik1vb3JlIiwibmFtZSI6IkphcmVkIE1vb3JlIiwiZW1haWwiOiJqYXJlZG1AY2EuaWJtLmNvbSIsInN1YiI6ImphcmVkbUBjYS5pYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiamFyZWRtQGNhLmlibS5jb20iLCJpYW1faWQiOiJpYW0tMjcwMDAxWE5ORiIsIm5hbWUiOiJKYXJlZCBNb29yZSIsImdpdmVuX25hbWUiOiJKYXJlZCIsImZhbWlseV9uYW1lIjoiTW9vcmUiLCJlbWFpbCI6ImphcmVkbUBjYS5pYm0uY29tIn0sImFjY291bnQiOnsidmFsaWQiOnRydWUsImJzcyI6ImM1NmM5YTI2OGQyM2UxYjMzOWFjMTQ3NzQzNTgxMzNjIiwiaW1zX3VzZXJfaWQiOiI3MjI2NTkxIiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxMTYwNDQ3In0sImlhdCI6MTYxOTQ1MDk0OSwiZXhwIjoxNjE5NDU0NTQ5LCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MSwiYW1yIjpbInB3ZCJdfQ.Cu1lgiTEr6HVTaxUH2wN3bIJYjGuEom8H8rxpmXijAMlttYjHacgtCptYGIfTcBpl5cE2ytag5Y1d2UIyMhygRdQ9h9lBBTcIgDDk7nLB9a_2TDlmWRBImQJdC4LBCoAQdEmwMFnHHnnhCygMtR9ssX68-cl-S78wEE3yzoFMPIy04G5S7HJNJqVfDSka_2j-Qg4h1FFNse7mVuxcRjZUCbymbjt4Z75rQdVQMlCLPS6UDXNBQgcJavQhSrmxYrI7aClJ2tWJlh8bznO0JXmutJBVl51EfcCceC0CbwpqB_Kjpy4ZZQh89m3bffaxYrGlkp_jbn8N470tMjufHeaow
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Express
+      Transaction-Id:
+      - '18601131293'
+      X-Request-Id:
+      - '18601131293'
+      "-Request-Id":
+      - '18601131293'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Limit:
+      - '500'
+      X-Ratelimit-Remaining:
+      - '499'
+      X-Ratelimit-Reset:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"81d-i65+Aq39zx/y7MnkcbzumHl8/28"
+      X-Response-Time:
+      - 1874.987ms
+      X-Envoy-Upstream-Service-Time:
+      - '1879'
+      Server:
+      - istio-envoy
+      Expires:
+      - Mon, 26 Apr 2021 15:29:15 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Apr 2021 15:29:15 GMT
+      Content-Length:
+      - '2077'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"resources":[{"id":"29b1dd25de2d40b5ae5bd5f719f30db8","crn":"crn:v1:bluemix:public:resource-controller::a/c56c9a268d23e1b339ac14774358133c::resource-group:29b1dd25de2d40b5ae5bd5f719f30db8","account_id":"c56c9a268d23e1b339ac14774358133c","name":"camc-test","state":"ACTIVE","default":false,"enable_reclamation":false,"quota_id":"a3d7b8d01e261c24677937c29ab33f3c","quota_url":"/v2/quota_definitions/a3d7b8d01e261c24677937c29ab33f3c","payment_methods_url":"/v2/resource_groups/29b1dd25de2d40b5ae5bd5f719f30db8/payment_methods","resource_linkages":[],"teams_url":"/v2/resource_groups/29b1dd25de2d40b5ae5bd5f719f30db8/teams","created_at":"2019-01-22T12:50:50.278Z","updated_at":"2019-01-22T12:50:50.278Z"},{"id":"345c433098294722ba52d9039133e8cf","crn":"crn:v1:bluemix:public:resource-controller::a/c56c9a268d23e1b339ac14774358133c::resource-group:345c433098294722ba52d9039133e8cf","account_id":"c56c9a268d23e1b339ac14774358133c","name":"default","state":"ACTIVE","default":true,"enable_reclamation":false,"quota_id":"a3d7b8d01e261c24677937c29ab33f3c","quota_url":"/v2/quota_definitions/a3d7b8d01e261c24677937c29ab33f3c","payment_methods_url":"/v2/resource_groups/345c433098294722ba52d9039133e8cf/payment_methods","resource_linkages":[],"teams_url":"/v2/resource_groups/345c433098294722ba52d9039133e8cf/teams","created_at":"2017-09-17T06:45:26.325Z","updated_at":"2018-05-24T08:29:49.065Z"},{"id":"c315f4fc1e3e4d5ca4cc2a2c38e40ef6","crn":"crn:v1:bluemix:public:resource-controller::a/c56c9a268d23e1b339ac14774358133c::resource-group:c315f4fc1e3e4d5ca4cc2a2c38e40ef6","account_id":"c56c9a268d23e1b339ac14774358133c","name":"cloudforms","state":"ACTIVE","default":false,"enable_reclamation":false,"quota_id":"a3d7b8d01e261c24677937c29ab33f3c","quota_url":"/v2/quota_definitions/a3d7b8d01e261c24677937c29ab33f3c","payment_methods_url":"/v2/resource_groups/c315f4fc1e3e4d5ca4cc2a2c38e40ef6/payment_methods","resource_linkages":[],"teams_url":"/v2/resource_groups/c315f4fc1e3e4d5ca4cc2a2c38e40ef6/teams","created_at":"2020-03-31T01:21:57.714Z","updated_at":"2020-03-31T01:21:57.714Z"}]}'
+    http_version:
+  recorded_at: Mon, 26 Apr 2021 15:29:15 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
# Issue
Provisioning requires the resource groups being set. This will allow for cloud_tool to hook into the Resource Controller SDK

# Priority
* Depends on https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/191
* Will have other PRs that depend on this soon.

# Implementation
* Resource controller methods can be reached via cloud_tool.resource.controller
* Resource manager methods can be reached via cloud_tool.resource.manager
* Remove string validation from last cloud_tool update.
* Add bearer_info hash validation on init.

# Not covered
* No pagination. Some of the list methods appear to have the capability but the SDK method doesn't support it. 

# Specs
* Add new test for fetching a controller based method.
* Add new test for fetching a manager based method.

# Common files
* No common files changed
