### PR TITLE
Vpc inventory resource group

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc.rb
@@ -72,4 +72,10 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC < ManageIQ::Provi
   def tags_by_crn(crn)
     connection.cloudtools.tagging.collection(:list_tags, :attached_to => crn, :providers => ["ghost"]).to_a
   end
+
+  # Fetch resource groups from ResourceController SDK.
+  # @return [Enumerator]
+  def resource_groups
+    connection.cloudtools.resource.manager.collection(:list_resource_groups)
+  end
 end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
@@ -15,6 +15,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
     instances
     volumes
     cloud_volume_types
+    resource_groups
   end
 
   def images
@@ -289,6 +290,17 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
         :ems_ref     => v[:name],
         :name        => v[:name],
         :description => v[:family]
+      )
+    end
+  end
+
+  # For each resource group save the id as ems_ref and name as name. All other properties are ignored.
+  # @return [void]
+  def resource_groups
+    collector.resource_groups.each do |resource|
+      persister.resource_groups.build(
+        :ems_ref => resource[:id],
+        :name    => resource[:name]
       )
     end
   end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
@@ -27,6 +27,9 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC < ManageIQ::Provi
     add_cloud_collection(:networks)
     add_cloud_collection(:vm_and_template_labels)
     add_cloud_collection(:vm_and_template_taggings)
+
+    # Define resource_groups method on CloudManager
+    add_cloud_collection(:resource_groups, {}, {:auto_inventory_attributes => false})  { |builder| add_resource_group(builder) }
   end
 
   def initialize_network_inventory_collections
@@ -41,5 +44,12 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC < ManageIQ::Provi
   def initialize_storage_inventory_collections
     add_storage_collection(:cloud_volumes)
     add_storage_collection(:cloud_volume_types)
+  end
+
+  # Automatically add the local model class and id of ems to the database record.
+  # @return [void]
+  def add_resource_group(builder)
+    builder.add_properties(:model_class => ::ManageIQ::Providers::IbmCloud::VPC::ResourceGroup)
+    builder.add_default_values(:ems_id => manager.id)
   end
 end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
@@ -29,7 +29,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC < ManageIQ::Provi
     add_cloud_collection(:vm_and_template_taggings)
 
     # Define resource_groups method on CloudManager
-    add_cloud_collection(:resource_groups, {}, {:auto_inventory_attributes => false})  { |builder| add_resource_group(builder) }
+    add_cloud_collection(:resource_groups, {}, {:auto_inventory_attributes => false}) { |builder| add_resource_group(builder) }
   end
 
   def initialize_network_inventory_collections

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
@@ -27,9 +27,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC < ManageIQ::Provi
     add_cloud_collection(:networks)
     add_cloud_collection(:vm_and_template_labels)
     add_cloud_collection(:vm_and_template_taggings)
-
-    # Define resource_groups method on CloudManager
-    add_cloud_collection(:resource_groups, {}, {:auto_inventory_attributes => false}) { |builder| add_resource_group(builder) }
+    add_cloud_collection(:resource_groups)
   end
 
   def initialize_network_inventory_collections
@@ -44,12 +42,5 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC < ManageIQ::Provi
   def initialize_storage_inventory_collections
     add_storage_collection(:cloud_volumes)
     add_storage_collection(:cloud_volume_types)
-  end
-
-  # Automatically add the local model class and id of ems to the database record.
-  # @return [void]
-  def add_resource_group(builder)
-    builder.add_properties(:model_class => ::ManageIQ::Providers::IbmCloud::VPC::ResourceGroup)
-    builder.add_default_values(:ems_id => manager.id)
   end
 end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -19,7 +19,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::Cl
   before_update :ensure_managers_zone
 
   # Add resource groups association to cloud manager for provisioning.
-  has_many :resource_groups, :foreign_key => :ems_id, :dependent => :destroy
+  has_many :resource_groups, :foreign_key => :ems_id, :dependent => :destroy # rubocop:disable Rails/InverseOf # ':inverse_of => :resource_group' throws error.
 
   supports :label_mapping
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -18,6 +18,9 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::Cl
   before_create :ensure_managers
   before_update :ensure_managers_zone
 
+  # Add resource groups association to cloud manager for provisioning.
+  has_many :resource_groups, :foreign_key => :ems_id, :dependent => :destroy
+
   supports :label_mapping
 
   def ensure_managers

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/resource_group.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/resource_group.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 # Create local ResourceGroup class. Keep it generic in case it needs to be used in multiple managers.
-class ManageIQ::Providers::IbmCloud::VPC::ResourceGroup < ResourceGroup
+class ManageIQ::Providers::IbmCloud::VPC::CloudManager::ResourceGroup < ResourceGroup
 end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/resource_group.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/resource_group.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Create local ResourceGroup class. Keep it generic in case it needs to be used in multiple managers.
+class ManageIQ::Providers::IbmCloud::VPC::ResourceGroup < ResourceGroup
+end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -157,7 +157,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher, :vcr => {:
   # @param ems_ref [String] Value used by the Cloud as a ID.
   # @return [ApplicationRecord] The result of the find.
   def check_resource_fetch(mgmt, method, ems_ref)
-    expect(mgmt).to respond_to(method.to_sym), "ems does not respond to #{ems_method}"
+    expect(mgmt).to respond_to(method.to_sym), "ems does not respond to #{method}"
 
     resource = mgmt.send(method.to_sym).find_by(:ems_ref => ems_ref)
     expect(resource).not_to be_nil, "#{mgmt.class.name}.#{method} with ems_ref #{ems_ref} was not found in db."

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -27,6 +27,8 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher, :vcr => {:
     expect(ems.miq_templates.count).to eq(57)
     expect(ems.key_pairs.count).to eq(2)
     expect(ems.availability_zones.count).to eq(3)
+    expect(ems.resource_groups.count).to eq(3)
+    expect(ems.resource_groups.first.name).to eq('camc-test')
 
     # Network Manager
     expect(ems.floating_ips.count).to eq(4)

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -29,14 +29,14 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher, :vcr => {:
   # @return [void]
   def assert_ems_counts(mgmt)
     # Cloud Manager
-    cloud_manger = {
+    cloud_manager = {
       :availability_zones => 3,
       :key_pairs          => 2,
       :miq_templates      => 57,
       :resource_groups    => 3,
       :vms                => 6,
     }.freeze
-    check_counts(mgmt, cloud_manger)
+    check_counts(mgmt, cloud_manager)
 
     # Network Manager
     network_manager = {

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -10,41 +10,69 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher, :vcr => {:
 
   it "tests the refresh" do
     2.times do
-      ems.refresh
-      ems.reload
+      mgmt = ems
+      mgmt.refresh
+      mgmt.reload
 
-      assert_ems_counts
-      assert_specific_vm
-      assert_specific_cloud_volume_type
-      assert_specific_cloud_subnet
-      assert_vm_labels
+      assert_ems_counts(mgmt)
+      assert_specific_vm(mgmt)
+      assert_specific_resource_group(mgmt, '29b1dd25de2d40b5ae5bd5f719f30db8', 'camc-test')
+      assert_specific_security_group(mgmt, 'r014-e4be0c69-6df6-4464-a9bc-384e4179ea1b', 'backup-deglazed-bagful-deflation')
+      assert_specific_cloud_volume_type(mgmt, 'general-purpose', 'tiered')
+      assert_specific_cloud_subnet(mgmt, '0757-ef523a2f-5356-42ff-8a78-9325509465b9', 'r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3', 'us-east-1')
+      assert_vm_labels(mgmt, '0777_f73e8687-3813-465f-99df-ba6e4ee8f289', 4)
     end
   end
 
-  def assert_ems_counts
+  # Test that the refresh has persisted the same number of items as expected from the Cloud.
+  # @param mgmt [VPC] The VPC EMS.
+  # @return [void]
+  def assert_ems_counts(mgmt)
     # Cloud Manager
-    expect(ems.vms.count).to eq(6)
-    expect(ems.miq_templates.count).to eq(57)
-    expect(ems.key_pairs.count).to eq(2)
-    expect(ems.availability_zones.count).to eq(3)
-    expect(ems.resource_groups.count).to eq(3)
-    expect(ems.resource_groups.first.name).to eq('camc-test')
+    cloud_manger = {
+      :availability_zones => 3,
+      :key_pairs          => 2,
+      :miq_templates      => 57,
+      :resource_groups    => 3,
+      :vms                => 6,
+    }.freeze
+    check_counts(mgmt, cloud_manger)
 
     # Network Manager
-    expect(ems.floating_ips.count).to eq(4)
-    expect(ems.security_groups.count).to eq(2)
-    expect(ems.security_groups.first.name).to eq('nebulizer-bobtail-hacked-yield-linseed-sandpit')
-    expect(ems.cloud_networks.count).to eq(2)
-    expect(ems.cloud_subnets.count).to eq(4)
+    network_manager = {
+      :cloud_networks  => 2,
+      :cloud_subnets   => 4,
+      :floating_ips    => 4,
+      :security_groups => 2,
+    }.freeze
+    check_counts(mgmt, network_manager)
 
     # Storage Manager
-    expect(ems.cloud_volumes.count).to eq(15)
-    expect(ems.cloud_volume_types.count).to eq(4)
+    storage_manger = {
+      :cloud_volume_types => 4,
+      :cloud_volumes      => 15,
+    }
+    check_counts(mgmt, storage_manger)
   end
 
-  def assert_specific_vm
-    vm = ems.vms.find_by(:ems_ref => "0777_249ba858-a4eb-4f2c-ba6c-72254a781d0d")
-    expect(vm.ipaddresses.count).to eq(1)
+  # Test a resource_group record is properly persisted.
+  # @param mgmt [VPC] The VPC EMS.
+  # @param ems_ref [String] Value used by the Cloud as a ID.
+  # @param name [String] The expected value of the name attribute.
+  # @return [void]
+  def assert_specific_resource_group(mgmt, ems_ref, name)
+    resource = check_resource_fetch(mgmt, :resource_groups, ems_ref)
+    class_type = 'ManageIQ::Providers::IbmCloud::VPC::CloudManager::ResourceGroup'
+    check_attribute_values(resource, ems_ref, class_type, name)
+  end
+
+  # Test a specific VMs's configuration.
+  # @param mgmt [VPC] The VPC EMS.
+  # @return [void]
+  def assert_specific_vm(mgmt)
+    vm = check_resource_fetch(mgmt, :vms, '0777_249ba858-a4eb-4f2c-ba6c-72254a781d0d')
+
+    check_count(vm, :ipaddresses, 1)
     expect(vm.availability_zone.name).to eq('us-east-3')
     expect(vm.cpu_total_cores).to eq(2)
     expect(vm.hardware.memory_mb).to eq(16_384)
@@ -67,33 +95,115 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher, :vcr => {:
     expect(vm.key_pairs.first.ems_ref).to match(/^[-0-9a-z_]{1,64}/)
   end
 
-  def assert_vm_labels
-    vm = ems.vms.find_by(:ems_ref => "0777_f73e8687-3813-465f-99df-ba6e4ee8f289")
-    expect(vm.labels.count).to eq(4)
+  # Test a resource_group record is properly persisted.
+  # @param mgmt [VPC] The VPC EMS.
+  # @param vm_ref [String] A VM uuid with labels attached to it.
+  # @param count [String] The expected number of labels with associated vm_ref VM.
+  # @return [void]
+  def assert_vm_labels(mgmt, vm_ref, count)
+    vm = check_resource_fetch(mgmt, :vms, vm_ref)
+    check_count(vm, :labels, count)
   end
 
-  def assert_specific_cloud_volume_type
-    cvt = ems.cloud_volume_types.find_by(:ems_ref => 'general-purpose')
-    expect(cvt.name).to eq('general-purpose')
-    expect(cvt.description).to eq('tiered')
+  # Test a security_group record is properly persisted.
+  # @param mgmt [VPC] The VPC EMS.
+  # @param ems_ref [String] Value used by the Cloud as a ID.
+  # @param name [String] The expected value of the name attribute.
+  # @return [void]
+  def assert_specific_security_group(mgmt, ems_ref, name)
+    resource = check_resource_fetch(mgmt, :security_groups, ems_ref)
+    class_type = 'ManageIQ::Providers::IbmCloud::VPC::NetworkManager::SecurityGroup'
+    check_attribute_values(resource, ems_ref, class_type, name)
+  end
+
+  # Test a cloud_volume_type record is properly persisted.
+  # @param mgmt [VPC] The VPC EMS.
+  # @param ems_ref [String] Value used by the Cloud as a ID.
+  # @param description [String] The expected value of the description attribute.
+  def assert_specific_cloud_volume_type(mgmt, ems_ref, description)
+    resource = check_resource_fetch(mgmt, :cloud_volume_types, ems_ref)
+    class_type = 'ManageIQ::Providers::IbmCloud::VPC::StorageManager::CloudVolumeType'
+    check_attribute_values(resource, ems_ref, class_type, ems_ref, {:description => description})
   end
 
   # Test the components of a cloud subnet.
-  def assert_specific_cloud_subnet
-    cloud_subnet = ems.cloud_subnets.find_by(:ems_ref => '0757-ef523a2f-5356-42ff-8a78-9325509465b9')
+  # @param mgmt [VPC] The VPC EMS.
+  # @param ems_ref [String] Value used by the Cloud as a ID.
+  # @param network_ref [String] The associated VPC uuid.
+  # @param zone_ref [String] The name of the zone the subnet is attached to.
+  # @return [void]
+  def assert_specific_cloud_subnet(mgmt, ems_ref, network_ref, zone_ref)
+    cloud_subnet = check_resource_fetch(mgmt, :cloud_subnets, ems_ref)
 
     # Test cloud_network relationship.
-    cloud_network = ems.cloud_networks.find_by(:ems_ref => 'r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3')
-    expect(cloud_subnet.cloud_network_id).to eq(cloud_network.id)
+    cloud_network = check_resource_fetch(mgmt, :cloud_networks, network_ref)
+    check_relationship(cloud_subnet, :cloud_network_id, cloud_network)
 
     # Test availability_zone relationship.
-    availability_zone = ems.availability_zones.find_by(:ems_ref => 'us-east-1')
-    expect(cloud_subnet.availability_zone_id).to eq(availability_zone.id)
+    availability_zone = check_resource_fetch(mgmt, :availability_zones, zone_ref)
+    check_relationship(cloud_subnet, :availability_zone_id, availability_zone)
 
     # Test remaining fields.
-    expect(cloud_subnet.cidr).to eq('127.0.0.0/24')
-    expect(cloud_subnet.name).to eq('b-subneet-washington-dc-1')
-    expect(cloud_subnet.ip_version).to eq('ipv4')
-    expect(cloud_subnet.network_protocol).to eq('ipv4')
+    class_type = 'ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudSubnet'
+    ip_version = 'ipv4'
+
+    additional_values = {:cidr => '127.0.0.0/24', :ip_version => ip_version, :network_protocol => ip_version}
+    check_attribute_values(cloud_subnet, ems_ref, class_type, 'b-subneet-washington-dc-1', additional_values)
+  end
+
+  # Fetch an ApplicationRecord using the ems_ref. Test that the method exists and an item with ems_ref is present.
+  # @param mgmt [VPC] The VPC EMS.
+  # @param method [Symbol] The method to use to call the association record.
+  # @param ems_ref [String] Value used by the Cloud as a ID.
+  # @return [ApplicationRecord] The result of the find.
+  def check_resource_fetch(mgmt, method, ems_ref)
+    expect(mgmt).to respond_to(method.to_sym), "ems does not respond to #{ems_method}"
+
+    resource = mgmt.send(method.to_sym).find_by(:ems_ref => ems_ref)
+    expect(resource).not_to be_nil, "#{mgmt.class.name}.#{method} with ems_ref #{ems_ref} was not found in db."
+    resource
+  end
+
+  # Compare the attributes of 'resource' to the provided values.
+  # @param resource [ApplicationRecord]
+  # @param ems_ref [String] Value used by the Cloud as a ID.
+  # @param class_type [String] The class that the resource is supposed to represent.
+  # @param name [String] The value of the name attribute.
+  # @param additional_values [Hash] Values that are unique to the class.
+  # @return [void]
+  def check_attribute_values(resource, ems_ref, class_type, name, additional_values = {})
+    default_values = {:ems_ref => ems_ref, :type => class_type, :name => name}
+    values = default_values.merge(additional_values)
+    expect(resource).to have_attributes(values)
+  end
+
+  # Check that a relationship is properly persisted.
+  # @param resource [ApplicationRecord] The instance that holds the has_many relationship.
+  # @param fk_key [String] The foreign key field to verify against.
+  # @param assoc [ApplicationRecord] The other side of the relationship.
+  # @return [void]
+  def check_relationship(resource, fk_name, assoc)
+    fk_value = resource.send(fk_name.to_sym)
+    pk_assoc = assoc.id
+    expect(fk_value).to eq(pk_assoc), "Association between #{resource.class.name} id #{fk_value} does not match expected #{assoc.class.name} id #{pk_assoc}"
+  end
+
+  # Check that a relationship has the expected number of items.
+  # @param resource [ApplicationRecord] The instance that holds the relationship.
+  # @param method [Symbol] The method name to retrieve the relationship.
+  # @param expected [Integer] The expected number of items.
+  # @return [void]
+  def check_count(resource, method, expected)
+    expect(resource).to respond_to(method.to_sym), "ems does not respond to #{method}"
+    actual = resource.send(method.to_sym).count
+    expect(actual).to eq(expected), "Resource #{resource.class.name}.#{method} has #{actual} items expected #{expected}"
+  end
+
+  # Test a number of resource counts.
+  # @param resource [ApplicationRecord] The instance that holds the relationship.
+  # @param resources [Hash<Symbol, Integer>] A hash where the key represents a method and the value represents the expected count.
+  # @return [void]
+  def check_counts(resource, resources)
+    resources.each_pair { |key, value| check_count(resource, key, value) }
   end
 end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -10,6 +10,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher, :vcr => {:
 
   it "tests the refresh" do
     2.times do
+      # Storing ems as a variable and passing it directly reduces the complexity of the runtime. Which appears to increase runtime performance.
       mgmt = ems
       mgmt.refresh
       mgmt.reload

--- a/spec/vcr_cassettes/ManageIQ_Providers_IbmCloud_VPC_CloudManager_Refresher/tests_the_refresh.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_IbmCloud_VPC_CloudManager_Refresher/tests_the_refresh.yml
@@ -2550,5 +2550,70 @@ http_interactions:
       encoding: UTF-8
       string: '{"first":{"href":"https://us-east.iaas.cloud.ibm.com/v1/volume/profiles?limit=50"},"limit":50,"total_count":4,"profiles":[{"name":"10iops-tier","family":"tiered","href":"https://us-east.iaas.cloud.ibm.com/v1/volume/profiles/10iops-tier"},{"name":"5iops-tier","family":"tiered","href":"https://us-east.iaas.cloud.ibm.com/v1/volume/profiles/5iops-tier"},{"name":"custom","family":"custom","href":"https://us-east.iaas.cloud.ibm.com/v1/volume/profiles/custom"},{"name":"general-purpose","family":"tiered","href":"https://us-east.iaas.cloud.ibm.com/v1/volume/profiles/general-purpose"}]}'
     http_version:
-  recorded_at: Wed, 21 Apr 2021 22:18:39 GMT
+  recorded_at: Mon, 26 Apr 2021 17:58:11 GMT
+- request:
+    method: get
+    uri: https://resource-controller.cloud.ibm.com/v2/resource_groups
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - ibm_cloud_resource_controller-ruby-sdk-2.0.1 x86_64-apple-darwin20.3.0 ruby-2.6.7
+      X-Ibmcloud-Sdk-Analytics:
+      - service_name=resource_manager;service_version=V2;operation_id=list_resource_groups
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer eyJraWQiOiIyMDIxMDQyMDE4MzYiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwiaWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiM2QwNzE5NmMtYTYyZC00OTZiLWI1NWQtMzdiODMzMTkzNTc5IiwiaWRlbnRpZmllciI6IjI3MDAwMVhOTkYiLCJnaXZlbl9uYW1lIjoiSmFyZWQiLCJmYW1pbHlfbmFtZSI6Ik1vb3JlIiwibmFtZSI6IkphcmVkIE1vb3JlIiwiZW1haWwiOiJqYXJlZG1AY2EuaWJtLmNvbSIsInN1YiI6ImphcmVkbUBjYS5pYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiamFyZWRtQGNhLmlibS5jb20iLCJpYW1faWQiOiJpYW0tMjcwMDAxWE5ORiIsIm5hbWUiOiJKYXJlZCBNb29yZSIsImdpdmVuX25hbWUiOiJKYXJlZCIsImZhbWlseV9uYW1lIjoiTW9vcmUiLCJlbWFpbCI6ImphcmVkbUBjYS5pYm0uY29tIn0sImFjY291bnQiOnsidmFsaWQiOnRydWUsImJzcyI6ImM1NmM5YTI2OGQyM2UxYjMzOWFjMTQ3NzQzNTgxMzNjIiwiaW1zX3VzZXJfaWQiOiI3MjI2NTkxIiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxMTYwNDQ3In0sImlhdCI6MTYxOTQ1OTg0NSwiZXhwIjoxNjE5NDYzNDQ1LCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MSwiYW1yIjpbInB3ZCJdfQ.hSgbpT_Ig8yYs1lVvuScQIG56qJMilvVGmo2jNwaOVuww7fn0Iw65BoKggJjJZPaeYMa-Z2h4RgIiOkrkHSQdi87E8PnDkT-PZKY1xRCSVCIInk7KIthw1wKrOlC03Lu34OYjuQtIepH5qZZyzeSAaUv1z9ZJtk_dNtqMDcaXpbh2EfmQZzZfKj05TUGfPS_-ITv0xHJkiFYIAB4zzAaVqM8zVvhro1TH1HDW6rL22OILRjC8JDjS-kwSJQRSfhcfWl5ZwUFdlTPX0yRlr0oqmn9CKigTGWRS5ZCJW76t9vlHRcnYdrUjKd2tfBnxjIr3DG6fiuRJus5FLGnVytysg
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Express
+      Transaction-Id:
+      - '25059829917'
+      X-Request-Id:
+      - '25059829917'
+      "-Request-Id":
+      - '25059829917'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Limit:
+      - '500'
+      X-Ratelimit-Remaining:
+      - '499'
+      X-Ratelimit-Reset:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"81d-i65+Aq39zx/y7MnkcbzumHl8/28"
+      X-Response-Time:
+      - 150.300ms
+      X-Envoy-Upstream-Service-Time:
+      - '159'
+      Server:
+      - istio-envoy
+      Expires:
+      - Mon, 26 Apr 2021 17:58:11 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 26 Apr 2021 17:58:11 GMT
+      Content-Length:
+      - '2077'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"resources":[{"id":"29b1dd25de2d40b5ae5bd5f719f30db8","crn":"crn:v1:bluemix:public:resource-controller::a/c56c9a268d23e1b339ac14774358133c::resource-group:29b1dd25de2d40b5ae5bd5f719f30db8","account_id":"c56c9a268d23e1b339ac14774358133c","name":"camc-test","state":"ACTIVE","default":false,"enable_reclamation":false,"quota_id":"a3d7b8d01e261c24677937c29ab33f3c","quota_url":"/v2/quota_definitions/a3d7b8d01e261c24677937c29ab33f3c","payment_methods_url":"/v2/resource_groups/29b1dd25de2d40b5ae5bd5f719f30db8/payment_methods","resource_linkages":[],"teams_url":"/v2/resource_groups/29b1dd25de2d40b5ae5bd5f719f30db8/teams","created_at":"2019-01-22T12:50:50.278Z","updated_at":"2019-01-22T12:50:50.278Z"},{"id":"345c433098294722ba52d9039133e8cf","crn":"crn:v1:bluemix:public:resource-controller::a/c56c9a268d23e1b339ac14774358133c::resource-group:345c433098294722ba52d9039133e8cf","account_id":"c56c9a268d23e1b339ac14774358133c","name":"default","state":"ACTIVE","default":true,"enable_reclamation":false,"quota_id":"a3d7b8d01e261c24677937c29ab33f3c","quota_url":"/v2/quota_definitions/a3d7b8d01e261c24677937c29ab33f3c","payment_methods_url":"/v2/resource_groups/345c433098294722ba52d9039133e8cf/payment_methods","resource_linkages":[],"teams_url":"/v2/resource_groups/345c433098294722ba52d9039133e8cf/teams","created_at":"2017-09-17T06:45:26.325Z","updated_at":"2018-05-24T08:29:49.065Z"},{"id":"c315f4fc1e3e4d5ca4cc2a2c38e40ef6","crn":"crn:v1:bluemix:public:resource-controller::a/c56c9a268d23e1b339ac14774358133c::resource-group:c315f4fc1e3e4d5ca4cc2a2c38e40ef6","account_id":"c56c9a268d23e1b339ac14774358133c","name":"cloudforms","state":"ACTIVE","default":false,"enable_reclamation":false,"quota_id":"a3d7b8d01e261c24677937c29ab33f3c","quota_url":"/v2/quota_definitions/a3d7b8d01e261c24677937c29ab33f3c","payment_methods_url":"/v2/resource_groups/c315f4fc1e3e4d5ca4cc2a2c38e40ef6/payment_methods","resource_linkages":[],"teams_url":"/v2/resource_groups/c315f4fc1e3e4d5ca4cc2a2c38e40ef6/teams","created_at":"2020-03-31T01:21:57.714Z","updated_at":"2020-03-31T01:21:57.714Z"}]}'
+    http_version:
+  recorded_at: Mon, 26 Apr 2021 17:58:11 GMT
 recorded_with: VCR 5.1.0


### PR DESCRIPTION
# Issue
Resource groups are used in provisioning. This adds resource_group persistence to the collector.

# Priority
* Provision will be dependent on this.

# Implementation
* Add generic ResourceGroup to VPC namespace.
* Add has_many relation to CloudManager
* Add CloudTool call for resource_groups  in collector
* Add builder in parser.
* Add generic add_resource_group to persister incase NetworkManager requires it later.
* Add specific add_cloud_collection to CloudManager persistence.

# Not covered
* n/a

# Specs
* Add test to check for number of resource groups persisted.
* Add test to check the name of the first resource group.

# Common files
* No common files changed
