### PR TITLE
[LASKER] Fix AvailabilityZone and Flavor duplication

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers.rb
@@ -28,8 +28,12 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::PowerVirtualServers <
   private
 
   def initialize_cloud_inventory_collections
-    add_cloud_collection(:availability_zones)
-    add_cloud_collection(:flavors)
+    add_cloud_collection(:availability_zones) do |builder|
+      builder.add_default_values(:ems_id => ->(persister) { persister.cloud_manager.id })
+    end
+    add_cloud_collection(:flavors) do |builder|
+      builder.add_default_values(:ems_id => ->(persister) { persister.cloud_manager.id })
+    end
     add_cloud_collection(:vms) do |builder|
       builder.add_default_values(:ems_id => ->(persister) { persister.cloud_manager.id })
     end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
@@ -44,7 +44,9 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC < ManageIQ::Provi
       builder.add_properties(:model_class => ::ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template)
       builder.add_default_values(:ems_id => ->(persister) { persister.cloud_manager.id })
     end
-    add_cloud_collection(:flavors)
+    add_cloud_collection(:flavors) do |builder|
+      builder.add_default_values(:ems_id => ->(persister) { persister.cloud_manager.id })
+    end
     add_cloud_collection(:vm_and_miq_template_ancestry)
     add_cloud_collection(:networks)
     add_cloud_collection(:vm_and_template_labels)


### PR DESCRIPTION
Refreshing the CloudManager and the NetworkManager was causing inventory collections which used the default default_values to set the ems_id to set it to the manager being targeted, not the manager owning the inventory_collection.