### PR TITLE
Persister security group relation

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
@@ -216,6 +216,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
   def security_groups
     collector.security_groups.each do |sg|
       persister.security_groups.build(
+        :cloud_network => persister.cloud_networks.lazy_find(sg&.dig(:vpc, :id)),
         :ems_ref       => sg[:id],
         :name          => sg[:name],
         :network_ports => sg[:network_interfaces].to_a.map do |nic|

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -18,7 +18,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher, :vcr => {:
       assert_ems_counts(mgmt)
       assert_specific_vm(mgmt)
       assert_specific_resource_group(mgmt, '29b1dd25de2d40b5ae5bd5f719f30db8', 'camc-test')
-      assert_specific_security_group(mgmt, 'r014-e4be0c69-6df6-4464-a9bc-384e4179ea1b', 'backup-deglazed-bagful-deflation')
+      assert_specific_security_group(mgmt, 'r014-e4be0c69-6df6-4464-a9bc-384e4179ea1b', 'backup-deglazed-bagful-deflation', 'r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3')
       assert_specific_cloud_volume_type(mgmt, 'general-purpose', 'tiered')
       assert_specific_cloud_subnet(mgmt, '0757-ef523a2f-5356-42ff-8a78-9325509465b9', 'r014-0fa2acc6-2a41-4f2b-9c89-bcea07cdcbc3', 'us-east-1')
       assert_vm_labels(mgmt, '0777_f73e8687-3813-465f-99df-ba6e4ee8f289', 4)
@@ -110,11 +110,15 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher, :vcr => {:
   # @param mgmt [VPC] The VPC EMS.
   # @param ems_ref [String] Value used by the Cloud as a ID.
   # @param name [String] The expected value of the name attribute.
+  # @param vpc_id [SString] The UUID of the associated IBM Cloud VPC.
   # @return [void]
-  def assert_specific_security_group(mgmt, ems_ref, name)
+  def assert_specific_security_group(mgmt, ems_ref, name, vpc_id)
     resource = check_resource_fetch(mgmt, :security_groups, ems_ref)
     class_type = 'ManageIQ::Providers::IbmCloud::VPC::NetworkManager::SecurityGroup'
     check_attribute_values(resource, ems_ref, class_type, name)
+
+    cloud_network = check_resource_fetch(mgmt, :cloud_networks, vpc_id)
+    check_relationship(resource, :cloud_network_id, cloud_network)
   end
 
   # Test a cloud_volume_type record is properly persisted.


### PR DESCRIPTION
# Issue
The provision requires that the security_group is filtered on the selected cloud_network.

# Priority

# Implementation
* Add association in parser.

# Not covered
* n/a

# Specs
* Add a test for the relationship in `assert_specific_security_group`.

# Common files
* No common files changed
