### PR TITLE
[LASKER] Collector.image was using wrong method.

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc.rb
@@ -28,7 +28,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC < ManageIQ::Provi
   end
 
   def image(image_id)
-    connection.request(:list_images, :id => image_id)
+    connection.request(:get_image, :id => image_id)
   end
 
   def keys


### PR DESCRIPTION
Lasker backport of https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/191/commits/164c4be678a2583e10ee44035fef36957701be49

```
[ArgumentError]: unknown keyword: id  Method:[block (2 levels) in <class:LogProxy>
/opt/IBM/infrastructure-management-gemset/gems/ibm_vpc-0.1.0/lib/ibm_vpc/vpc_v1.rb:2103:in `list_images'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-ibm_cloud-5bd1e79ac4e9/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb:74:in `send_request'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-ibm_cloud-5bd1e79ac4e9/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb:49:in `request'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-ibm_cloud-5bd1e79ac4e9/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc.rb:31:in `image'
/opt/IBM/infrastructure-management-gemset/bundler/gems/bluecf-providers-ibm_cloud-5bd1e79ac4e9/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb:118:in `instance_operating_system'
```

(cherry picked from commit 164c4be678a2583e10ee44035fef36957701be49)