### PR TITLE
Cloudtool verify method existence

### DIFF
--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb
@@ -71,6 +71,8 @@ module ManageIQ
             end
 
             def send_request(call_back, **kwargs)
+              raise "#{client.class.name} does not contain a method #{call_back.to_sym}" unless client.respond_to?(call_back.to_sym)
+
               return client.send(call_back.to_sym) if kwargs.length.zero?
 
               client.send(call_back.to_sym, **kwargs)

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb
@@ -37,6 +37,8 @@ module ManageIQ
             # @return [Enumerator] Object to page through results.
             # @yield [Hash] Result of request.
             def collection(call_back, **kwargs)
+              raise "Provided call_back #{call_back} does not start with list. This method is for paginating list methods." unless call_back.to_s.match?(/^list/)
+
               enum_for(:each_resource, call_back, **kwargs)
             end
 

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_tools_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_tools_spec.rb
@@ -217,4 +217,18 @@ describe ManageIQ::Providers::IbmCloud::CloudTool, :vcr do
     expect(response).to be_a(Enumerator)
     expect(response.next).to be_a(Hash)
   end
+
+  it 'Raises error with non-existent method.' do
+    vpc = described_class.new(:api_key => api_key).vpc(:region => 'us-east')
+    bad_method = :list_instancess
+
+    expect { vpc.request(bad_method) }.to raise_error(StandardError, 'IbmVpc::VpcV1 does not contain a method list_instancess')
+    expect { vpc.collection(bad_method).first }.to raise_error(StandardError, 'IbmVpc::VpcV1 does not contain a method list_instancess')
+  end
+
+  it 'Raises error in collection when method is not a list.' do
+    vpc = described_class.new(:api_key => api_key).vpc(:region => 'us-east')
+
+    expect { vpc.collection(:get_instance) }.to raise_error(StandardError, 'Provided call_back get_instance does not start with list. This method is for paginating list methods.')
+  end
 end

--- a/spec/vcr_cassettes/ManageIQ_Providers_IbmCloud_CloudTool/Raises_error_with_non-existent_method_.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_IbmCloud_CloudTool/Raises_error_with_non-existent_method_.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.cloud.ibm.com/identity/token
+    body:
+      encoding: UTF-8
+      string: grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=IBM_CLOUD_VPC_API_KEY&response_type=cloud_iam
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept:
+      - application/json
+      Connection:
+      - close
+      User-Agent:
+      - http.rb/4.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json
+      Content-Language:
+      - en-US
+      Content-Length:
+      - '1524'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"eyJraWQiOiIyMDIxMDQyMDE4MzYiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwiaWQiOiJJQk1pZC0yNzAwMDFYTk5GIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiNjIxNmY0MWUtYjM0Ny00YmQ2LWE2NjYtYmM2NGU5MWExZjc3IiwiaWRlbnRpZmllciI6IjI3MDAwMVhOTkYiLCJnaXZlbl9uYW1lIjoiSmFyZWQiLCJmYW1pbHlfbmFtZSI6Ik1vb3JlIiwibmFtZSI6IkphcmVkIE1vb3JlIiwiZW1haWwiOiJqYXJlZG1AY2EuaWJtLmNvbSIsInN1YiI6ImphcmVkbUBjYS5pYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiamFyZWRtQGNhLmlibS5jb20iLCJpYW1faWQiOiJpYW0tMjcwMDAxWE5ORiIsIm5hbWUiOiJKYXJlZCBNb29yZSIsImdpdmVuX25hbWUiOiJKYXJlZCIsImZhbWlseV9uYW1lIjoiTW9vcmUiLCJlbWFpbCI6ImphcmVkbUBjYS5pYm0uY29tIn0sImFjY291bnQiOnsidmFsaWQiOnRydWUsImJzcyI6ImM1NmM5YTI2OGQyM2UxYjMzOWFjMTQ3NzQzNTgxMzNjIiwiaW1zX3VzZXJfaWQiOiI3MjI2NTkxIiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxMTYwNDQ3In0sImlhdCI6MTYyMDgyNDkyNywiZXhwIjoxNjIwODI4NTI3LCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MSwiYW1yIjpbInB3ZCJdfQ.SdhST1gOYqulKJv7wemF0A1JO3KFXaMuhbKBsdY6A0HbH188GjYdeOmA5zmZ4nDbJuNu47OPNhDO_GIru110m718GQXcOrx7d4zMBvONH_wvYyZvgldYy0IEby0UTukC9pPRv7ynGdmCbM03Auqgj8fNkrIjlySrQx8l_pd9VeXoDOdAO-B-y4KcrC9WyVrmjNn5I6CJA3D45XeUnzJ11XFseaPXyrN6UXi4b7NseVdGAfrX5WekVz7mmrj4JoSOxHQaHxYV4q66ymwGBFbUeNfASdpmBrNc6eXD2fORxcgp8N0KkCGp0Sd0svhWaM8c4EOeJr-kW3oFF6ubIA3M_g","refresh_token":"REFRESH_TOKEN","ims_user_id":"22222","token_type":"Bearer","expires_in":3600,"expiration":4102462800,"scope":"ibm
+        openid"}'
+    http_version:
+  recorded_at: Wed, 12 May 2021 13:08:50 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
# Issue
Closes #206 

* Since these methods use callbacks it can be easy to pass in methods that are not a client method. This will do a check and throw an error before attempting to make the call. 
* All methods that are potentially paginated begin 'list'. This will ensure that non-paginated methods are not passed in accidentally.

# Priority
* No dependencies

# Implementation
* Check if client responds to the method before calling it.
* In collection check that the passed in method begins with list.

# Not covered
* n/a

# Specs
* Add tests to ensure that the correct Exception is thrown in both cases.

# Common files
* Rework spec_helper so that response headers for iam requests are also filtered.
