### PR TITLE
#209 remove resource_groups relation

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -23,9 +23,6 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::Cl
   before_create :ensure_managers
   before_update :ensure_managers_zone
 
-  # Add resource groups association to cloud manager for provisioning.
-  has_many :resource_groups, :foreign_key => :ems_id, :dependent => :destroy # rubocop:disable Rails/InverseOf # ':inverse_of => :resource_group' throws error.
-
   supports :label_mapping
 
   def ensure_managers


### PR DESCRIPTION
# Issue
ResourceGroups was merged with a relation that was moved to core. This removes it from the provider.

# Priority
* No dependencies

# Implementation
* Remove relation from CloudManager

# Not covered
* n/a

# Specs
* No updates

# Common files
* No common files changed
