### PR TITLE
Provision update rest

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision/cloning.rb
@@ -20,7 +20,7 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::Provision::Cloning
   # @return [String] The ID of the new instance.
   def start_clone(clone_options)
     logger(__method__).debug("Json for VPC provision task. #{JSON.dump(clone_options)}")
-    response = source.with_provider_object { |vpc| vpc.request(:create_instance, :instance_prototype => clone_options) }
+    response = source.with_provider_connection { |vpc| vpc.request(:create_instance, :instance_prototype => clone_options) }
     if response[:id].nil?
       error_msg = _('An error occurred while requesting the IBM VPC instance provision. Cannot retrieve instance id from returned server response.')
       raise MiqException::MiqProvisionError, error_msg
@@ -37,7 +37,7 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::Provision::Cloning
   # @param clone_task_ref [String] The UUID for the new provision.
   # @return [Array(Boolean, String)] 2 elements first is boolean when true signals the provision is complete. Second element is a string for logging the current status.
   def do_clone_task_check(clone_task_ref)
-    instance = source.with_provider_object { |vpc| vpc.request(:get_instance, :id => clone_task_ref) }
+    instance = source.with_provider_connection { |vpc| vpc.request(:get_instance, :id => clone_task_ref) }
     live_status = instance[:status]
     return false, _('IBM VPC instance provision has no status present.') if live_status.nil?
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/template.rb
@@ -12,13 +12,6 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template < ManageIQ::Pro
     end
   end
 
-  # Get a new CloudTool VPC object.
-  # @param connection [ManageIQ::Providers::IbmCloud::CloudTools::Vpc] An existing connection.
-  # @return [ManageIQ::Providers::IbmCloud::CloudTools::Vpc] The passed in connection or a new one.
-  def provider_object(connection = nil)
-    connection || ext_management_system.connect
-  end
-
   # Method used to translate pluralized.
   # @param number [Integer] 1 for singular, 2 for plural.
   # @return [String] The desired format.


### PR DESCRIPTION
# Issue
Closes #205 
Update the way the SDK REST is called.

# Priority
* Not dependent on anything.

# Implementation
* Change method from `with_provider_object` to `with_provider_connection`
* Remove `provider_object` from Template

# Not covered
* n/a

# Specs
* No updates

# Common files
* No common files changed
