### PR TITLE
Added Delete VM Functionality for VPC

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
@@ -97,6 +97,16 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
     raw_reboot_guest(:force => true)
   end
 
+  supports :terminate do
+    unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports_control?
+  end
+
+  def raw_destroy
+    raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless ext_management_system
+    with_provider_object(&:delete)
+    update!(:raw_power_state => "powering-down")
+  end
+
   private
 
   # Update the saved status based on the SDK returned status.

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
@@ -103,8 +103,9 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
 
   def raw_destroy
     raise "VM has no #{ui_lookup(:table => "ext_management_systems")}, unable to destroy VM" unless ext_management_system
+
     with_provider_object(&:delete)
-    update!(:raw_power_state => "powering-down")
+    update!(:raw_power_state => "stopping")
   end
 
   private

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb
@@ -50,6 +50,7 @@ module ManageIQ
             def request(call_back, **kwargs)
               request = send_request(call_back, **kwargs)
               return if request.nil?
+
               result = request.result
               raise 'Return is not a JSON object' if result.instance_of?(String)
 

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/sdk/branch.rb
@@ -49,6 +49,7 @@ module ManageIQ
             # @return [Hash] The JSON return of the operation with symbolic key names.
             def request(call_back, **kwargs)
               request = send_request(call_back, **kwargs)
+              return if request.nil?
               result = request.result
               raise 'Return is not a JSON object' if result.instance_of?(String)
 

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/vpc_sdk/instance.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/vpc_sdk/instance.rb
@@ -68,6 +68,10 @@ module ManageIQ
               InstanceActions.new(:vpc => @parent, :instance_id => id)
             end
 
+            def delete
+              @parent.request(:delete_instance, :id => id)
+            end
+
             # Wait for the VM instance to be have a started status.
             # @param sleep_time [Integer] The time to sleep between refreshes.
             # @param timeout [Integer] The number of seconds before raising an error.

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
@@ -86,4 +86,36 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm, :vcr do
       expect(vm.power_state).to eq('on')
     end
   end
+
+  describe '#raw_destroy' do
+    before(:each) do
+      allow(vm).to receive(:provider_object).and_return(instance)
+    end
+
+    let(:parent) do
+      vpc = double("ManageIQ::Providers::IbmCloud::CloudTools::Vpc")
+      allow(vpc).to receive(:logger).and_return(Logger.new(nil))
+      allow(vpc).to receive_messages(:cloudtools => nil, :region => nil, :version => nil, :request => nil)
+      vpc
+    end
+
+    let(:actions) do
+      actions = ManageIQ::Providers::IbmCloud::CloudTools::VpcSdk::InstanceActions.new(:vpc => parent, :instance_id => nil)
+      allow(actions).to receive(:create).and_return({:this => 'mock'})
+      actions
+    end
+
+    let(:instance) do
+      instance = ManageIQ::Providers::IbmCloud::CloudTools::VpcSdk::Instance.new(:vpc => parent, :data => {})
+      allow(instance).to receive(:refresh) { instance.merge!({:id => 'mock_id', :name => 'Test instance', :status => 'running'}) }
+      allow(instance).to receive(:actions).and_return(actions)
+      instance.refresh
+      instance
+    end
+
+    it 'deletes the virtual machine' do
+      expect(parent).to receive(:request).with(:delete_instance, :id => instance.id)
+      vm.raw_destroy
+    end
+  end
 end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
@@ -99,16 +99,9 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm, :vcr do
       vpc
     end
 
-    let(:actions) do
-      actions = ManageIQ::Providers::IbmCloud::CloudTools::VpcSdk::InstanceActions.new(:vpc => parent, :instance_id => nil)
-      allow(actions).to receive(:create).and_return({:this => 'mock'})
-      actions
-    end
-
     let(:instance) do
       instance = ManageIQ::Providers::IbmCloud::CloudTools::VpcSdk::Instance.new(:vpc => parent, :data => {})
       allow(instance).to receive(:refresh) { instance.merge!({:id => 'mock_id', :name => 'Test instance', :status => 'running'}) }
-      allow(instance).to receive(:actions).and_return(actions)
       instance.refresh
       instance
     end


### PR DESCRIPTION
# Implementation
- enable delete VM option in UI
- use provider object to make request and delete instance with respective ID

<img width="967" alt="Screen Shot 2021-06-07 at 5 30 00 PM" src="https://user-images.githubusercontent.com/48186199/121090114-12e67300-c7b6-11eb-9b0c-9987c6b5bd99.png">

# WIP 
- rspec tests

# Reference
- https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/146