### PR TITLE
Make the target_collection class name more generic

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory.rb
@@ -3,10 +3,10 @@ class ManageIQ::Providers::IbmCloud::Inventory < ManageIQ::Providers::Inventory
   require_nested :Parser
   require_nested :Persister
 
-  def self.parsed_manager_name(_ems, target)
+  def self.parsed_manager_name(ems, target)
     case target
     when InventoryRefresh::TargetCollection
-      'VPC::TargetCollection'
+      "#{ManageIQ::Providers::Inflector.manager_type(ems.class)}::TargetCollection"
     else
       super
     end


### PR DESCRIPTION
Rather than hard-coding VPC::TargetCollection use the target.manager.class to build the class name

Follow-up to: https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/218#discussion_r649511782

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/21273