### PR TITLE
Remove unused validate_reboot method

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -37,10 +37,6 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
     end
   end
 
-  def validate_reboot
-    validate_vm_control_powered_on
-  end
-
   def self.calculate_power_state(raw_power_state)
     case raw_power_state
     when "ACTIVE"

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
@@ -28,8 +28,8 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm do
       include_examples "Vm operation is not available"
     end
 
-    context "with :reboot" do
-      let(:state) { :reboot }
+    context "with :reboot_guest" do
+      let(:state) { :reboot_guest }
       include_examples "Vm operation is available when powered on"
     end
 


### PR DESCRIPTION
The method the API and UI use is `reboot_guest` which is already processed [here](https://github.com/ManageIQ/manageiq-providers-ibm_cloud/blob/master/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb#L3)