### PR TITLE
Exception handling for VM targeted refresh

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::IbmCloud::Inventory < ManageIQ::Providers::Inventory
   require_nested :Parser
   require_nested :Persister
 
-  def self.parsed_manager_name(target)
+  def self.parsed_manager_name(_ems, target)
     case target
     when InventoryRefresh::TargetCollection
       'VPC::TargetCollection'

--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc/target_collection.rb
@@ -16,7 +16,9 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC::TargetCollection
     @vms ||=
       references(:vms).map do |ems_ref|
         connection.request(:get_instance, :id => ems_ref)
-      end
+      rescue IBMCloudSdkCore::ApiException
+        nil
+      end.compact
   end
 
   def instance_types


### PR DESCRIPTION
## Task
- added exception handling in the case that a targeted refresh is attempting to fetch a VM while the it is being powered down