### PR TITLE
Storage managers shouldn't delegate zone to parent_manager

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -19,6 +19,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
           :foreign_key => :parent_ems_id,
           :class_name  => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager",
           :autosave    => true,
+          :inverse_of  => :parent_manager,
           :dependent   => :destroy
 
   has_many :system_types,

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
@@ -11,7 +11,6 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager < Manag
            :authentication_status_ok?,
            :authentications,
            :authentication_for_summary,
-           :zone,
            :connect,
            :verify_credentials,
            :with_provider_connection,

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -20,6 +20,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::Cl
           :autosave    => true,
           :dependent   => :destroy,
           :inverse_of  => :parent_manager
+
   before_create :ensure_managers
   before_update :ensure_managers_zone
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
@@ -9,7 +9,6 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager < ManageIQ::Providers::
            :authentication_status_ok?,
            :authentications,
            :authentication_for_summary,
-           :zone,
            :connect,
            :verify_credentials,
            :with_provider_connection,


### PR DESCRIPTION
The zone_id is synced as part of the parent_managers ensure_manager_zone
callback