### PR TITLE
VPC Delete cloud networks functionality

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
@@ -9,7 +9,7 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork < ::Cloud
     end
   end
 
-  def raw_delete_cloud_network(_options)
+  def raw_delete_cloud_network(_options = {})
     with_provider_connection do |connection|
       connection.request(:delete_vpc, :id => ems_ref)
     end
@@ -19,6 +19,6 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork < ::Cloud
       :error_message => err.to_s
     }
     Notification.create(:type => :cloud_network_delete_error, :options => notification_options)
-    raise err
+    raise
   end
 end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
@@ -1,2 +1,24 @@
 class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork < ::CloudNetwork
+  include ProviderObjectMixin
+
+  supports :delete do
+    if ext_management_system.nil?
+      unsupported_reason_add(:delete_cloud_network, _("The Cloud Network is not connected to an active %{table}") % {
+        :table => ui_lookup(:table => "ext_management_systems")
+      })
+    end
+  end
+
+  def raw_delete_cloud_network(_options)
+    with_provider_connection do |connection|
+      connection.request(:delete_vpc, :id => ems_ref)
+    end
+  rescue => err
+    notification_options = {
+      :subject       => "[#{name}]",
+      :error_message => err.to_s
+    }
+    Notification.create(:type => :cloud_network_delete_error, :options => notification_options)
+    raise err
+  end
 end

--- a/spec/factories/cloud_network.rb
+++ b/spec/factories/cloud_network.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :cloud_network_ibm_cloud_vpc,
+          :class  => "ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork",
+          :parent => :cloud_network
+end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -19,6 +19,12 @@ FactoryBot.define do
 end
 
 FactoryBot.define do
+  factory :ems_ibm_cloud_vpc_network,
+          :class  => "ManageIQ::Providers::IbmCloud::VPC::NetworkManager",
+          :parent => :ems_cloud
+end
+
+FactoryBot.define do
   factory :ems_ibm_cloud_object_storage_object,
           :class  => "ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager",
           :parent => :ems_storage

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network_spec.rb
@@ -2,32 +2,44 @@
 
 describe ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork do
   let(:ems) do
-    FactoryBot.create(:ems_ibm_cloud_vpc, :provider_region => "us-east").tap do |ems|
-      ems.authentications << FactoryBot.create(:authentication, :auth_key => 'IBM_CLOUD_VPC_API_KEY')
-    end
+    FactoryBot.create(:ems_ibm_cloud_vpc, :provider_region => "us-east")
   end
 
   let(:cloud_network) do
     FactoryBot.create(:cloud_network_ibm_cloud_vpc,
-                      :ext_management_system => ems.network_manager,
-                      :name                  => 'test',
-                      :ems_ref               => 'test_id')
+                      :ext_management_system => ems.network_manager)
   end
 
   describe '#raw_delete_cloud_network' do
     before { NotificationType.seed }
 
     let(:connection) do
-      vpc = double("ManageIQ::Providers::IbmCloud::CloudTools::Vpc")
-      allow(vpc).to receive(:logger).and_return(Logger.new(nil))
-      allow(vpc).to receive_messages(:cloudtools => nil, :region => nil, :version => nil, :request => nil)
-      vpc
+      double("ManageIQ::Providers::IbmCloud::CloudTools::Vpc")
     end
 
     it 'deletes the cloud network' do
       expect(cloud_network).to receive(:with_provider_connection).and_yield(connection)
       expect(connection).to receive(:request).with(:delete_vpc, :id => cloud_network.ems_ref)
-      cloud_network.raw_delete_cloud_network(:options => {})
+      cloud_network.raw_delete_cloud_network
+    end
+
+    it 'with cloud subnets' do
+      exception = IBMCloudSdkCore::ApiException.new(
+        :code                  => 409,
+        :error                 => "Delete VPC failed: VPC still contains subnets",
+        :transaction_id        => "1234",
+        :global_transaction_id => "5678"
+      )
+      expect(cloud_network).to receive(:with_provider_connection).and_yield(connection)
+      expect(connection).to receive(:request)
+        .with(:delete_vpc, :id => cloud_network.ems_ref)
+        .and_raise(exception)
+
+      expect { cloud_network.raw_delete_cloud_network }.to raise_error(IBMCloudSdkCore::ApiException)
+      expect(Notification.count).to eq(1)
+      expect(Notification.first)
+        .to have_attributes(:options => {:error_message => exception.to_s,
+                                         :subject       => "[#{cloud_network.name}]"})
     end
   end
 end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork do
+  let(:ems) do
+    FactoryBot.create(:ems_ibm_cloud_vpc, :provider_region => "us-east").tap do |ems|
+      ems.authentications << FactoryBot.create(:authentication, :auth_key => 'IBM_CLOUD_VPC_API_KEY')
+    end
+  end
+
+  let(:cloud_network) do
+    FactoryBot.create(:cloud_network_ibm_cloud_vpc,
+                      :ext_management_system => ems.network_manager,
+                      :name                  => 'test',
+                      :ems_ref               => 'test_id')
+  end
+
+  describe '#raw_delete_cloud_network' do
+    before { NotificationType.seed }
+
+    let(:connection) do
+      vpc = double("ManageIQ::Providers::IbmCloud::CloudTools::Vpc")
+      allow(vpc).to receive(:logger).and_return(Logger.new(nil))
+      allow(vpc).to receive_messages(:cloudtools => nil, :region => nil, :version => nil, :request => nil)
+      vpc
+    end
+
+    it 'deletes the cloud network' do
+      expect(cloud_network).to receive(:with_provider_connection).and_yield(connection)
+      expect(connection).to receive(:request).with(:delete_vpc, :id => cloud_network.ems_ref)
+      cloud_network.raw_delete_cloud_network(:options => {})
+    end
+  end
+end


### PR DESCRIPTION
- added the ability to delete cloud networks
- by design, VPC does not allow cloud networks to be deleted if there are subnets still present in the network, therefore in this scenario an exception is raised and a notification is displayed on the UI

Delete cloud network option:
<img width="749" alt="Screen Shot 2021-06-22 at 5 48 11 PM" src="https://user-images.githubusercontent.com/48186199/123004047-19faad00-d382-11eb-89b5-b05f36d764cc.png">

Notification in the case that subnets are still present:
<img width="1142" alt="Screen Shot 2021-06-21 at 5 59 12 PM" src="https://user-images.githubusercontent.com/48186199/123004091-28e15f80-d382-11eb-98da-e5e511f87c60.png">
