### PR TITLE
Fix tenant_id method conflicting with the column

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
@@ -52,7 +52,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers <
   end
 
   def sshkeys
-    @sshkeys ||= tenants_api.pcloud_tenants_get(tenant_id).ssh_keys
+    @sshkeys ||= tenants_api.pcloud_tenants_get(pcloud_tenant_id).ssh_keys
   end
 
   def system_pools
@@ -79,8 +79,8 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers <
     @cloud_instance_id ||= cloud_manager.uid_ems
   end
 
-  def tenant_id
-    cloud_manager.tenant_id(connection)
+  def pcloud_tenant_id
+    cloud_manager.pcloud_tenant_id(connection)
   end
 
   def images_api

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/auth_key_pair.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::AuthKeyPair < ManageIQ::Providers::CloudManager::AuthKeyPair
   def self.raw_create_key_pair(ext_management_system, create_options)
     ext_management_system.with_provider_connection(:service => "PCloudTenantsSSHKeysApi") do |api|
-      tenant_id = ext_management_system.tenant_id(api.api_client)
+      tenant_id = ext_management_system.pcloud_tenant_id(api.api_client)
       ssh_key   = IbmCloudPower::SSHKey.new(
         :name    => create_options['name'],
         :ssh_key => create_options['public_key']

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -55,7 +55,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
     true
   end
 
-  def tenant_id(connection = nil)
+  def pcloud_tenant_id(connection = nil)
     connection ||= connect
     parse_crn(connection.default_headers["Crn"])[:scope].split("/").last
   end


### PR DESCRIPTION
The PowerVirtualServers tenant_id method overwrites the default accessor for the tenant_id column and attempts a connection to IBM Cloud