### PR TITLE
VPC delete cloud subnets functionality

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/cloud_subnet.rb
@@ -51,25 +51,6 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager::CloudS
     }
   end
 
-  def delete_cloud_subnet_queue(userid)
-    task_opts = {
-      :action => "creating cloud subnet, userid: #{userid}",
-      :userid => userid
-    }
-
-    queue_opts = {
-      :class_name  => self.class.name,
-      :method_name => 'raw_delete_cloud_subnet',
-      :instance_id => id,
-      :priority    => MiqQueue::HIGH_PRIORITY,
-      :role        => 'ems_operations',
-      :zone        => ext_management_system.my_zone,
-      :args        => []
-    }
-
-    MiqTask.generic_action_with_callback(task_opts, queue_opts)
-  end
-
   def raw_delete_cloud_subnet
     cloud_instance_id = ext_management_system.parent_manager.uid_ems
     ext_management_system.with_provider_connection(:service => 'PCloudNetworksApi') do |api|

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet.rb
@@ -14,30 +14,12 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudSubnet < ::CloudS
     end
   end
 
-  def delete_cloud_subnet_queue(userid)
-    task_opts = {
-      :action => "deleting Cloud Subnet for user #{userid}",
-      :userid => userid
-    }
-
-    queue_opts = {
-      :class_name  => self.class.name,
-      :method_name => 'raw_delete_cloud_subnet',
-      :instance_id => id,
-      :priority    => MiqQueue::HIGH_PRIORITY,
-      :role        => 'ems_operations',
-      :zone        => ext_management_system.my_zone,
-      :args        => []
-    }
-
-    MiqTask.generic_action_with_callback(task_opts, queue_opts)
-  end
-
   def raw_delete_cloud_subnet
     with_provider_connection do |connection|
       connection.request(:delete_subnet, :id => ems_ref)
     end
   rescue => err
     _log.error("subnet=[#{name}], error: #{err}")
+    raise
   end
 end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet.rb
@@ -1,2 +1,43 @@
 class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudSubnet < ::CloudSubnet
+  include ProviderObjectMixin
+
+  supports :delete do
+    if ext_management_system.nil?
+      unsupported_reason_add(:delete, _("The subnet is not connected to an active %{table}") % {
+        :table => ui_lookup(:table => "ext_management_systems")
+      })
+    end
+    if number_of(:vms) > 0
+      unsupported_reason_add(:delete, _("The subnet has an active %{table}") % {
+        :table => ui_lookup(:table => "vm_cloud")
+      })
+    end
+  end
+
+  def delete_cloud_subnet_queue(userid)
+    task_opts = {
+      :action => "deleting Cloud Subnet for user #{userid}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'raw_delete_cloud_subnet',
+      :instance_id => id,
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def raw_delete_cloud_subnet
+    with_provider_connection do |connection|
+      connection.request(:delete_subnet, :id => ems_ref)
+    end
+  rescue => err
+    _log.error("subnet=[#{name}], error: #{err}")
+  end
 end

--- a/spec/factories/cloud_subnet.rb
+++ b/spec/factories/cloud_subnet.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :cloud_subnet_ibm_cloud_vpc,
+          :class  => "ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudSubnet",
+          :parent => :cloud_subnet
+end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudSubnet do
+  let(:ems) do
+    FactoryBot.create(:ems_ibm_cloud_vpc, :provider_region => "us-east")
+  end
+
+  let(:cloud_subnet) do
+    FactoryBot.create(:cloud_subnet_ibm_cloud_vpc,
+                      :ext_management_system => ems.network_manager)
+  end
+
+  describe '#raw_delete_cloud_subnet' do
+    let(:connection) do
+      double("ManageIQ::Providers::IbmCloud::CloudTools::Vpc")
+    end
+
+    it 'deletes the cloud subnet' do
+      expect(cloud_subnet).to receive(:with_provider_connection).and_yield(connection)
+      expect(connection).to receive(:request).with(:delete_subnet, :id => cloud_subnet.ems_ref)
+      cloud_subnet.raw_delete_cloud_subnet
+    end
+  end
+end


### PR DESCRIPTION
- Added the ability to delete cloud subnets for the VPC provider
- The option to delete should not appear on the UI if there are VM instances attached to the subnet