### PR TITLE
VPC create cloud subnets functionality

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
@@ -6,6 +6,8 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager < ManageIQ::Providers::
 
   include ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
 
+  supports :cloud_subnet_create
+
   delegate :authentication_check,
            :authentication_status,
            :authentication_status_ok?,
@@ -43,5 +45,9 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager < ManageIQ::Providers::
 
   def self.description
     @description ||= "IBM Cloud VPC Network".freeze
+  end
+
+  def create_cloud_subnet(options)
+    CloudSubnet.raw_create_cloud_subnet(self, options)
   end
 end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet_spec.rb
@@ -5,20 +5,45 @@ describe ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudSubnet do
     FactoryBot.create(:ems_ibm_cloud_vpc, :provider_region => "us-east")
   end
 
+  let(:cloud_network) do
+    FactoryBot.create(:cloud_network_ibm_cloud_vpc,
+                      :ext_management_system => ems.network_manager)
+  end
+
   let(:cloud_subnet) do
     FactoryBot.create(:cloud_subnet_ibm_cloud_vpc,
                       :ext_management_system => ems.network_manager)
   end
 
-  describe '#raw_delete_cloud_subnet' do
+  describe 'cloud subnet actions' do
     let(:connection) do
       double("ManageIQ::Providers::IbmCloud::CloudTools::Vpc")
     end
 
-    it 'deletes the cloud subnet' do
-      expect(cloud_subnet).to receive(:with_provider_connection).and_yield(connection)
-      expect(connection).to receive(:request).with(:delete_subnet, :id => cloud_subnet.ems_ref)
-      cloud_subnet.raw_delete_cloud_subnet
+    before { allow(ems.network_manager).to receive(:with_provider_connection).and_yield(connection) }
+
+    context '#create_cloud_subnet' do
+      it 'creates the cloud subnet' do
+        expect(connection).to receive(:request).with(:create_subnet,
+                                                     :subnet_prototype => {
+                                                       :vpc             => {
+                                                         :id => cloud_network.ems_ref
+                                                       },
+                                                       :name            => 'test',
+                                                       :ipv4_cidr_block => '10.0.0.0/24'
+                                                     })
+
+        ems.network_manager.create_cloud_subnet({:cloud_network_id => cloud_network.id,
+                                                 :name             => 'test',
+                                                 :cidr             => '10.0.0.0/24'})
+      end
+    end
+
+    context '#raw_delete_cloud_subnet' do
+      it 'deletes the cloud subnet' do
+        expect(connection).to receive(:request).with(:delete_subnet, :id => cloud_subnet.ems_ref)
+        cloud_subnet.raw_delete_cloud_subnet
+      end
     end
   end
 end


### PR DESCRIPTION
### Task
- added the ability to create cloud subnets from the VPC provider
<img width="300" alt="Screen Shot 2021-07-06 at 1 38 21 PM" src="https://user-images.githubusercontent.com/48186199/124650125-5c82b600-de67-11eb-8845-6cc7c4628654.png">
<img width="1503" alt="Screen Shot 2021-07-06 at 1 41 57 PM" src="https://user-images.githubusercontent.com/48186199/124650136-60aed380-de67-11eb-96a4-1fcd53dc18dc.png">

### Reference
- https://cloud.ibm.com/apidocs/vpc#create-subnet