### PR TITLE
VPC create cloud networks functionality

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
@@ -47,6 +47,10 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager < ManageIQ::Providers::
     @description ||= "IBM Cloud VPC Network".freeze
   end
 
+  def create_cloud_network(options)
+    CloudNetwork.raw_create_cloud_network(self, options)
+  end
+
   def create_cloud_subnet(options)
     CloudSubnet.raw_create_cloud_subnet(self, options)
   end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
@@ -1,12 +1,22 @@
 class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork < ::CloudNetwork
   include ProviderObjectMixin
 
+  supports :create
   supports :delete do
     if ext_management_system.nil?
       unsupported_reason_add(:delete_cloud_network, _("The Cloud Network is not connected to an active %{table}") % {
         :table => ui_lookup(:table => "ext_management_systems")
       })
     end
+  end
+
+  def self.raw_create_cloud_network(ext_management_system, options)
+    ext_management_system.with_provider_connection do |connection|
+      connection.request(:create_vpc, :name => options[:name])
+    end
+  rescue => err
+    _log.error("cloud_network=[#{options[:name]}], error: #{err}")
+    raise
   end
 
   def raw_delete_cloud_network(_options = {})

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network_spec.rb
@@ -10,36 +10,45 @@ describe ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork do
                       :ext_management_system => ems.network_manager)
   end
 
-  describe '#raw_delete_cloud_network' do
-    before { NotificationType.seed }
-
+  describe 'cloud network actions' do
     let(:connection) do
       double("ManageIQ::Providers::IbmCloud::CloudTools::Vpc")
     end
 
-    it 'deletes the cloud network' do
-      expect(cloud_network).to receive(:with_provider_connection).and_yield(connection)
-      expect(connection).to receive(:request).with(:delete_vpc, :id => cloud_network.ems_ref)
-      cloud_network.raw_delete_cloud_network
+    before { allow(ems.network_manager).to receive(:with_provider_connection).and_yield(connection) }
+
+    context '#create_cloud_network' do
+      it 'creates the cloud network' do
+        expect(connection).to receive(:request).with(:create_vpc, :name => 'test')
+        ems.network_manager.create_cloud_network({:name => 'test'})
+      end
     end
 
-    it 'with cloud subnets' do
-      exception = IBMCloudSdkCore::ApiException.new(
-        :code                  => 409,
-        :error                 => "Delete VPC failed: VPC still contains subnets",
-        :transaction_id        => "1234",
-        :global_transaction_id => "5678"
-      )
-      expect(cloud_network).to receive(:with_provider_connection).and_yield(connection)
-      expect(connection).to receive(:request)
-        .with(:delete_vpc, :id => cloud_network.ems_ref)
-        .and_raise(exception)
+    context '#raw_delete_cloud_network' do
+      before { NotificationType.seed }
 
-      expect { cloud_network.raw_delete_cloud_network }.to raise_error(IBMCloudSdkCore::ApiException)
-      expect(Notification.count).to eq(1)
-      expect(Notification.first)
-        .to have_attributes(:options => {:error_message => exception.to_s,
-                                         :subject       => "[#{cloud_network.name}]"})
+      it 'deletes the cloud network' do
+        expect(connection).to receive(:request).with(:delete_vpc, :id => cloud_network.ems_ref)
+        cloud_network.raw_delete_cloud_network
+      end
+
+      it 'with cloud subnets' do
+        exception = IBMCloudSdkCore::ApiException.new(
+          :code                  => 409,
+          :error                 => "Delete VPC failed: VPC still contains subnets",
+          :transaction_id        => "1234",
+          :global_transaction_id => "5678"
+        )
+        expect(connection).to receive(:request)
+          .with(:delete_vpc, :id => cloud_network.ems_ref)
+          .and_raise(exception)
+
+        expect { cloud_network.raw_delete_cloud_network }.to raise_error(IBMCloudSdkCore::ApiException)
+        expect(Notification.count).to eq(1)
+        expect(Notification.first)
+          .to have_attributes(:options => {:error_message => exception.to_s,
+                                           :subject       => "[#{cloud_network.name}]"})
+      end
     end
   end
 end


### PR DESCRIPTION
### Task
- added the ability to create cloud networks through the VPC provider

### Notes
- since the UI form has not been implemented yet, this was tested using the console:
```
manager = ManageIQ::Providers::IbmCloud::VPC::NetworkManager.first
cloud_network = manager.create_cloud_network({:name => 'test-vpc'})
```
<img width="1093" alt="Screen Shot 2021-07-07 at 11 14 41 AM" src="https://user-images.githubusercontent.com/48186199/124791742-539eec80-df1a-11eb-9201-f46317a02488.png">

### Reference
https://cloud.ibm.com/apidocs/vpc#create-vpc