### PR TITLE
Exception for image not found during refresh

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc.rb
@@ -30,6 +30,8 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC < ManageIQ::Provi
 
   def image(image_id)
     connection.request(:get_image, :id => image_id)
+  rescue IBMCloudSdkCore::ApiException
+    nil
   end
 
   def keys


### PR DESCRIPTION
- In the event of an image not found during refresh, an exception has been added to allow the rest of the refresh to proceed as normal

Downstream issue reference: https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/19799