### PR TITLE
IBM Cloud event collection

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -1,13 +1,14 @@
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::CloudManager
   require_nested :AuthKeyPair
+  require_nested :EventCatcher
   require_nested :Flavor
-  require_nested :RefreshWorker
-  require_nested :Refresher
+  require_nested :LoggingMixin
   require_nested :Provision
   require_nested :ProvisionWorkflow
+  require_nested :RefreshWorker
+  require_nested :Refresher
   require_nested :Template
   require_nested :Vm
-  require_nested :LoggingMixin
 
   supports :provisioning
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
+  require_nested :Runner
+end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/runner.rb
@@ -1,0 +1,21 @@
+class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+  def monitor_events
+    event_monitor_handle.start
+    event_monitor_running
+    event_monitor_handle.poll do |event|
+      @queue.enq(event)
+    end
+  ensure
+    stop_event_monitor
+  end
+
+  def stop_event_monitor
+    event_monitor_handle.stop
+  end
+
+  private
+
+  def event_monitor_handle
+    @event_monitor_handle ||= self.class.parent::Stream.new(@ems)
+  end
+end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/stream.rb
@@ -1,0 +1,33 @@
+class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher::Stream
+  attr_reader :ems, :stop_polling, :poll_sleep
+
+  def initialize(ems, options = {})
+    @ems = ems
+    @stop_polling = false
+    @from = Time.now.to_i.to_s
+    @poll_sleep = options[:poll_sleep] || 20.seconds
+  end
+
+  def start
+    @stop_polling = false
+    @from = Time.now.to_i.to_s
+  end
+
+  def stop
+    @stop_polling = true
+  end
+
+  def poll
+    loop do
+      @to = Time.now.to_i.to_s
+
+      ems.with_provider_connection(:service => 'events') do |api|
+        events_client = api.sdk_client
+        events = events_client.export(:from => @from, :to => @to)
+        @from = @to
+        break if stop_polling
+      end
+      sleep(poll_sleep)
+    end
+  end
+end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
@@ -9,14 +9,20 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
     %w[auth_key]
   end
 
-  # Return a cloudtools vpc object.
+  # Return either a cloudtools vpc or activity tracker object.
   # @param options [Hash] Hash of options. Default to an empty Hash.
-  # @return [ManageIQ::Providers::IbmCloud::CloudTools::Vpc]
+  # @return [ManageIQ::Providers::IbmCloud::CloudTools::Vpc] or
+  # [ManageIQ::Providers::IbmCloud::CloudTools::ActivityTracker]
   def connect(options = {})
     key = authentication_key(options[:auth_type])
     region = options[:provider_region] || provider_region
     sdk = self.class.raw_connect(key)
-    sdk.vpc(:region => region)
+    if options[:service] == 'events'
+      service_key = authentication_key("events")
+      sdk.events(:region => region, :service_key => service_key)
+    else
+      sdk.vpc(:region => region)
+    end
   end
 
   # Same as calling connect.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,12 @@
           :critical:
           - IBM_CLOUD_POWER_VIRTUAL_SERVERS_instance_power_on
           - IBM_CLOUD_POWER_VIRTUAL_SERVERS_instance_power_off
+  :ems_ibm_cloud_vpc:
+    :event_handling:
+      :event_groups:
+        :addition:
+          :critical:
+          - is.instance.instance.create
 
 :ems_refresh:
   :ibm_vpc:
@@ -24,6 +30,8 @@
     :event_catcher:
       :event_catcher_ibm_cloud_power_virtual_servers:
         :poll: 20.seconds
+      :event_catcher_vpc:
+        :poll: 15.seconds
     :queue_worker_base:
       :ems_refresh_worker:
         :ems_refresh_worker_ibm_cloud_power_virtual_servers: {}

--- a/lib/manageiq/providers/ibm_cloud/cloud_tool.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tool.rb
@@ -55,6 +55,10 @@ module ManageIQ
           @vpc ||= CloudTools::Vpc.new(:cloudtools => self, :region => region, :version => version, :generation => generation)
         end
 
+        def events(service_key:, region: 'us-east')
+          @events ||= CloudTools::ActivityTracker.new(:cloudtools => self, :region => region, :service_key => service_key)
+        end
+
         # Get a class that accesses the IBM Cloud Resource Manager API.
         # @return [CloudTools::ResourceController] the CloudTools Resource Manager SDK wrapper.
         def resource

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools.rb
@@ -2,7 +2,6 @@
 
 require 'logging'
 require 'ibm_vpc'
-require 'ibm_cloud_activity_tracker'
 
 require_relative 'cloud_tools/sdk'
 dir_name = File.basename(__FILE__).split('.')[0]

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools.rb
@@ -2,6 +2,7 @@
 
 require 'logging'
 require 'ibm_vpc'
+require 'ibm_cloud_activity_tracker'
 
 require_relative 'cloud_tools/sdk'
 dir_name = File.basename(__FILE__).split('.')[0]

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/activity_tracker.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/activity_tracker.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module ManageIQ
+  module Providers
+    module IbmCloud
+      module CloudTools
+        class ActivityTracker < Sdk::Branch
+          def initialize(cloudtools:, region:, service_key:)
+            super(:cloudtools => cloudtools)
+            service_url = "https://api.#{region}.logging.cloud.ibm.com"
+            @sdk_params = {:service_url => service_url, :service_key => service_key}
+          end
+
+          # Return a new Activty Tracker SDK instance.
+          def sdk_client
+            @sdk_params[:authenticator] = @cloudtools.authenticator
+            @sdk_client ||= IbmCloudActivityTracker::ActivityTrackerApiV1.new(@sdk_params)
+          end
+
+          private
+
+          # Create a generator that removes the need for pagination.
+          # @param call_back [String] The method name to use for pagination.
+          # @param array_key [String] The specific key in the returned array to use.
+          #
+          # @return [Enumerator] Object to page through results.
+          # @yield [Hash] Result of request.
+          def each_resource(call_back, array_key: nil, **kwargs)
+            start = kwargs[:start]
+
+            loop do
+              # Send request.
+              response = request(call_back, :start => start, **kwargs)
+              array_key = get_common(response.keys) if array_key.nil?
+
+              resources = response.fetch(array_key.to_sym)
+
+              resources&.each { |value| yield value }
+
+              # VPC has a next key that holds the next URL.
+              return unless response.key?(:next)
+
+              # The :next data structure is a hash with a href member.
+              next_url = response.dig(:next, :href)
+              return unless next_url
+
+              start = Addressable::URI.parse(next_url).query_values['start']
+            end
+          end
+
+          #  Try to determine
+          def get_common(array_keys)
+            keys = array_keys - [:limit, :first, :total_count, :next]
+            return keys.first unless keys.empty?
+
+            raise "No array key found in #{array_keys}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/manageiq-providers-ibm_cloud.gemspec
+++ b/manageiq-providers-ibm_cloud.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ibm_cloud_power", "~> 1.0"
   spec.add_dependency "ibm_cloud_resource_controller", "~> 2.0"
   spec.add_dependency "ibm-cloud-sdk", "~> 0.1"
+  spec.add_dependency "ibm_cloud_activity_tracker", "~> 0.1"
   spec.add_dependency "ibm_cloud_global_tagging", "~> 0.1"
   spec.add_dependency "ibm_vpc", "~> 0.1"
 

--- a/systemd/manageiq-providers-ibm_cloud_vpc_cloud_manager_event_catcher.target
+++ b/systemd/manageiq-providers-ibm_cloud_vpc_cloud_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=manageiq.target

--- a/systemd/manageiq-providers-ibm_cloud_vpc_cloud_manager_event_catcher@.service
+++ b/systemd/manageiq-providers-ibm_cloud_vpc_cloud_manager_event_catcher@.service
@@ -1,0 +1,13 @@
+[Unit]
+PartOf=manageiq-providers-ibm_cloud_vpc_cloud_manager_event_catcher.target
+[Install]
+WantedBy=manageiq-providers-ibm_cloud_vpc_cloud_manager_event_catcher.target
+[Service]
+WorkingDirectory=/var/www/miq/vmdb
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher --heartbeat --guid=%i
+User=manageiq
+Restart=no
+Type=notify
+Slice=manageiq-providers-ibm_cloud_vpc_cloud_manager_event_catcher.slice


### PR DESCRIPTION
As part of the work to implement event handling scenarios for VPC, I've completed the logic to collect events from IBM Cloud's event service called IBM Cloud Activity Tracker. A SDK has been generated for this service.

Moving forward the events will need to be parsed and used to queue targeted refreshes.

Note: A service key for IBM Cloud Activity Tracker is required in order to use the SDK (See: https://cloud.ibm.com/docs/activity-tracker?topic=activity-tracker-service_keys). For the time being, I created a record for the service key in my local environment to be passed in. But ideally this can be provided via a form when creating the provider.

Ref: https://cloud.ibm.com/apidocs/activity-tracker#export

Depends on:
* [x] [Add IBM Cloud Activity Tracker gem](https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/pull/60)