### PR TITLE
PowerVS Targeted Refresh

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers/target_collection.rb
@@ -10,16 +10,13 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers::
   end
 
   def images
-    @images ||= begin
-      references(:miq_templates).map do |ems_ref|
-        images_api.pcloud_cloudinstances_images_get(cloud_instance_id, ems_ref)
-      rescue IbmCloudPower::ApiError => err
-        error_message = JSON.parse(err.response_body)["description"]
-        _log.debug("ImageID not found: #{error_message}")
-        nil
-      end
-    end
-    @images.compact
+    @images ||= references(:miq_templates).map do |ems_ref|
+      images_api.pcloud_cloudinstances_images_get(cloud_instance_id, ems_ref)
+    rescue IbmCloudPower::ApiError => err
+      error_message = JSON.parse(err.response_body)["description"]
+      _log.debug("ImageID not found: #{error_message}")
+      nil
+    end.compact
   end
 
   def flavors
@@ -31,16 +28,13 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers::
   end
 
   def volumes
-    @volumes ||= begin
-      references(:cloud_volumes).map do |ems_ref|
-        volumes_api.pcloud_cloudinstances_volumes_get(cloud_instance_id, ems_ref)
-      rescue IbmCloudPower::ApiError => err
-        error_message = JSON.parse(err.response_body)["description"]
-        _log.debug("VolumeID not found: #{error_message}")
-        nil
-      end
-    end
-    @volumes.compact
+    @volumes ||= references(:cloud_volumes).map do |ems_ref|
+      volumes_api.pcloud_cloudinstances_volumes_get(cloud_instance_id, ems_ref)
+    rescue IbmCloudPower::ApiError => err
+      error_message = JSON.parse(err.response_body)["description"]
+      _log.debug("VolumeID not found: #{error_message}")
+      nil
+    end.compact
   end
 
   def pvm_instances_by_id
@@ -48,29 +42,23 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers::
   end
 
   def pvm_instances
-    @pvm_instances ||= begin
-      references(:vms).map do |ems_ref|
-        pvm_instances_api.pcloud_pvminstances_get(cloud_instance_id, ems_ref)
-      rescue IbmCloudPower::ApiError => err
-        error_message = JSON.parse(err.response_body)["description"]
-        _log.debug("PVMInstanceID not found: #{error_message}")
-        nil
-      end
-    end
-    @pvm_instances.compact
+    @pvm_instances ||= references(:vms).map do |ems_ref|
+      pvm_instances_api.pcloud_pvminstances_get(cloud_instance_id, ems_ref)
+    rescue IbmCloudPower::ApiError => err
+      error_message = JSON.parse(err.response_body)["description"]
+      _log.debug("PVMInstanceID not found: #{error_message}")
+      nil
+    end.compact
   end
 
   def networks
-    @networks ||= begin
-      references(:cloud_networks).map do |ems_ref|
-        networks_api.pcloud_networks_get(cloud_instance_id, ems_ref)
-      rescue IbmCloudPower::ApiError => err
-        error_message = JSON.parse(err.response_body)["description"]
-        _log.debug("NetworkID not found: #{error_message}")
-        nil
-      end
-    end
-    @networks.compact
+    @networks ||= references(:cloud_networks).map do |ems_ref|
+      networks_api.pcloud_networks_get(cloud_instance_id, ems_ref)
+    rescue IbmCloudPower::ApiError => err
+      error_message = JSON.parse(err.response_body)["description"]
+      _log.debug("NetworkID not found: #{error_message}")
+      nil
+    end.compact
   end
 
   def sshkeys

--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers/target_collection.rb
@@ -1,0 +1,125 @@
+class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers::TargetCollection < ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers
+  def initialize(_manager, _target)
+    super
+
+    parse_targets!
+  end
+
+  def availability_zones
+    []
+  end
+
+  def images
+    @images ||= begin
+      references(:miq_templates).map do |ems_ref|
+        images_api.pcloud_cloudinstances_images_get(cloud_instance_id, ems_ref)
+      rescue IbmCloudPower::ApiError => err
+        error_message = JSON.parse(err.response_body)["description"]
+        _log.debug("ImageID not found: #{error_message}")
+        nil
+      end
+    end
+    @images.compact
+  end
+
+  def flavors
+    []
+  end
+
+  def cloud_volume_types
+    []
+  end
+
+  def volumes
+    @volumes ||= begin
+      references(:cloud_volumes).map do |ems_ref|
+        volumes_api.pcloud_cloudinstances_volumes_get(cloud_instance_id, ems_ref)
+      rescue IbmCloudPower::ApiError => err
+        error_message = JSON.parse(err.response_body)["description"]
+        _log.debug("VolumeID not found: #{error_message}")
+        nil
+      end
+    end
+    @volumes.compact
+  end
+
+  def pvm_instances_by_id
+    @pvm_instances_by_id ||= pvm_instances.index_by(&:pvm_instance_id)
+  end
+
+  def pvm_instances
+    @pvm_instances ||= begin
+      references(:vms).map do |ems_ref|
+        pvm_instances_api.pcloud_pvminstances_get(cloud_instance_id, ems_ref)
+      rescue IbmCloudPower::ApiError => err
+        error_message = JSON.parse(err.response_body)["description"]
+        _log.debug("PVMInstanceID not found: #{error_message}")
+        nil
+      end
+    end
+    @pvm_instances.compact
+  end
+
+  def networks
+    @networks ||= begin
+      references(:cloud_networks).map do |ems_ref|
+        networks_api.pcloud_networks_get(cloud_instance_id, ems_ref)
+      rescue IbmCloudPower::ApiError => err
+        error_message = JSON.parse(err.response_body)["description"]
+        _log.debug("NetworkID not found: #{error_message}")
+        nil
+      end
+    end
+    @networks.compact
+  end
+
+  def sshkeys
+    []
+  end
+
+  private
+
+  def parse_targets!
+    # `target` here is an `InventoryRefresh::TargetCollection`.  This contains two types of targets,
+    # `InventoryRefresh::Target` which is essentialy an association/manager_ref pair, or an ActiveRecord::Base
+    # type object like a Vm.
+    #
+    # This gives us some flexibility in how we request a resource be refreshed.
+    target.targets.each do |target|
+      case target
+      when MiqTemplate
+        add_target(:miq_templates, target.ems_ref)
+      when Vm
+        add_target(:vms, target.ems_ref)
+      when Flavor
+        add_target(:flavors, target.ems_ref)
+      when ManageIQ::Providers::CloudManager::AuthKeyPair
+        add_target(:auth_key_pairs, target.ems_ref)
+      when AvailabilityZone
+        add_target(:availability_zones, target.ems_ref)
+      when SecurityGroup
+        add_target(:security_groups, target.ems_ref)
+      when CloudNetwork
+        add_target(:cloud_networks, target.ems_ref)
+      when CloudSubnet
+        add_target(:cloud_subnets, target.ems_ref)
+      when FloatingIp
+        add_target(:floating_ips, target.ems_ref)
+      when CloudVolume
+        add_target(:cloud_volumes, target.ems_ref)
+      when CloudVolumeType
+        add_target(:cloud_volume_types, target.ems_ref)
+      end
+    end
+  end
+
+  def add_target(association, ems_ref)
+    return if ems_ref.blank?
+
+    target.add_target(:association => association, :manager_ref => {:ems_ref => ems_ref})
+  end
+
+  def references(collection)
+    target.manager_refs_by_association&.dig(collection, :ems_ref)&.to_a&.compact || []
+  end
+end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
   require_nested :CloudManager
   require_nested :NetworkManager
   require_nested :StorageManager
+  require_nested :TargetCollection
 
   attr_reader :subnet_to_ext_ports
 

--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers/target_collection.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers::TargetCollection < ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers
+end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::PowerVirtualServers <
   require_nested :CloudManager
   require_nested :NetworkManager
   require_nested :StorageManager
+  require_nested :TargetCollection
 
   def initialize_inventory_collections
     initialize_cloud_inventory_collections
@@ -32,6 +33,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::PowerVirtualServers <
     add_network_collection(:cloud_subnets)
     add_network_collection(:network_ports)
     add_network_collection(:cloud_subnet_network_ports)
+    add_network_collection(:load_balancers)
   end
 
   def initialize_storage_inventory_collections

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers/target_collection.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::IbmCloud::Inventory::Persister::PowerVirtualServers::TargetCollection < ManageIQ::Providers::IbmCloud::Inventory::Persister::PowerVirtualServers
+  def targeted?
+    true
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,6 +54,7 @@
     :refresh_interval: 15.minutes
   :ibm_cloud_power_virtual_servers:
     :refresh_interval: 15.minutes
+    :allow_targeted_refresh: true
 :log:
   :level_ibm_cloud: info
 :workers:


### PR DESCRIPTION
Add target collections to enable targeted refresh in the PowerVS cloud manager.

note: Removed TODO list of flavors, cloud_volume_types, and sshkeys - planning to implement those in a later commit.