### PR TITLE
Added EventParser class

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/runner.rb
@@ -13,6 +13,11 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher::Runner < M
     event_monitor_handle.stop
   end
 
+  def queue_event(event)
+    event_hash = ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventParser.event_to_hash(event, @cfg[:ems_id])
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+  end
+
   private
 
   def event_monitor_handle

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/stream.rb
@@ -23,9 +23,12 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher::Stream
 
       ems.with_provider_connection(:service => 'events') do |api|
         events_client = api.sdk_client
-        events = events_client.export(:from => @from, :to => @to)
+        events = events_client.exportv2(:from => @from, :to => @to, :hosts => "is").result["lines"]
         @from = @to
+
         break if stop_polling
+
+        events.each { |event| yield event}
       end
       sleep(poll_sleep)
     end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_parser.rb
@@ -1,0 +1,27 @@
+module ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventParser
+  def self.event_to_hash(event, ems_id)
+    event_hash = {
+      :event_type => event["action"],
+      :source     => "IBM_CLOUD_VPC",
+      :ems_id     => ems_id,
+      :ems_ref    => event["_id"],
+      :timestamp  => event["eventTime"],
+      :full_data  => event
+    }
+
+    case event_hash[:event_type]
+    when 'is.instance.instance.create'
+      parse_vm_event!(event, event_hash)
+    end
+
+    event_hash
+  end
+
+  def self.parse_vm_event!(event, event_hash)
+    return if event['responseData'].nil?
+
+    event_hash[:vm_uid_ems] = event.dig('responseData', 'id')
+    event_hash[:vm_ems_ref] = event.dig('responseData', 'id')
+    event_hash[:vm_name]    = event.dig('responseData', 'name')
+  end
+end


### PR DESCRIPTION
- added the EventParser class which will create the relevant schemas and add the necessary details when a `create instance` event is captured (to be used when implementing functionality to trigger targeted refreshes)
- modified event collection API call to return events that are hosted by "is". This means that events will be filtered so that we only receive VPC related events (see: https://cloud.ibm.com/docs/vpc?topic=vpc-at-events)
- modified event collection API call to return a hash array of events