### PR TITLE
Add supports :storage_manager and block_storage_manager function to IBM Cloud

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -11,6 +11,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::Cl
   require_nested :Vm
 
   supports :provisioning
+  supports :storage_manager
 
   include ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
   delegate :cloud_volumes, :to => :storage_manager
@@ -51,6 +52,10 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::Cl
 
   def image_name
     'ibm_cloud'
+  end
+
+  def block_storage_manager
+    storage_manager
   end
 
   def self.hostname_required?


### PR DESCRIPTION
Add supports :storage_manager and block_storage_manager function for storage manager access on UI side: https://github.com/ManageIQ/manageiq-ui-classic/pull/7821/files

@miq-bot add_reviewer @agrare
@miq-bot add-label enhancement