### PR TITLE
Fix PowerVS image collector to handle elusive image IDs

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
@@ -24,14 +24,14 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers <
       images_by_id[image_id] ||= images_api.pcloud_cloudinstances_images_get(cloud_instance_id, image_id)
     rescue IbmCloudPower::ApiError => err
       error_message = JSON.parse(err.response_body)["description"]
-      _log.warn("ImageID not found: #{error_message}")
+      _log.debug("ImageID not found: #{error_message}")
     end
 
     begin
       images_by_id[image_id] ||= images_api.pcloud_cloudinstances_stockimages_get(cloud_instance_id, image_id)
     rescue IbmCloudPower::ApiError => err
       error_message = JSON.parse(err.response_body)["description"]
-      _log.warn("ImageID not found in stock catalog: #{error_message}")
+      _log.debug("ImageID not found in stock catalog: #{error_message}")
       nil
     end
   end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
@@ -20,7 +20,13 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers <
   end
 
   def image(image_id)
-    images_by_id[image_id] ||= images_api.pcloud_cloudinstances_images_get(cloud_instance_id, image_id)
+    begin
+      images_by_id[image_id] ||= images_api.pcloud_cloudinstances_images_get(cloud_instance_id, image_id)
+    rescue IbmCloudPower::ApiError => err
+      error_message = JSON.parse(err.response_body)["description"]
+      _log.warn("ImageID not found: #{error_message}")
+      nil
+    end
   end
 
   def images_by_id

--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
@@ -25,6 +25,13 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers <
     rescue IbmCloudPower::ApiError => err
       error_message = JSON.parse(err.response_body)["description"]
       _log.warn("ImageID not found: #{error_message}")
+    end
+
+    begin
+      images_by_id[image_id] ||= images_api.pcloud_cloudinstances_stockimages_get(cloud_instance_id, image_id)
+    rescue IbmCloudPower::ApiError => err
+      error_message = JSON.parse(err.response_body)["description"]
+      _log.warn("ImageID not found in stock catalog: #{error_message}")
       nil
     end
   end


### PR DESCRIPTION
Two cases that these commits address:

1) When an image ID is completely missing, instead of breaking the refresh we can continue on. The result is that the `cpu_type` will be `nil`.

2) Add an API call to the stock image catalog. Depending on how you provision a VM, the associated image reference could be to this stock catalog, which is not returned in the regular list of images for a PowerVS instance.