### PR TITLE
VPC event targeted refresh for VMs

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/stream.rb
@@ -4,13 +4,13 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher::Stream
   def initialize(ems, options = {})
     @ems = ems
     @stop_polling = false
-    @from = Time.now.to_i.to_s
+    @from = Time.now.to_i
     @poll_sleep = options[:poll_sleep] || 20.seconds
   end
 
   def start
     @stop_polling = false
-    @from = Time.now.to_i.to_s
+    @from = Time.now.to_i
   end
 
   def stop
@@ -19,16 +19,23 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher::Stream
 
   def poll
     loop do
-      @to = Time.now.to_i.to_s
+      @to = Time.now.to_i
 
       ems.with_provider_connection(:service => 'events') do |api|
         events_client = api.sdk_client
-        events = events_client.exportv2(:from => @from, :to => @to, :hosts => "is").result["lines"]
+
+        # IBM Cloud Activity Tracker has a delay from the time that
+        # an event is fired to when it is available to be retrieved by the API.
+        # Therefore a 30-second timestamp offset is used to allow
+        # events to persist on the service and get retrieved.
+        events = events_client.exportv2(:from => (@from - 30).to_s, :to => (@to - 30).to_s, :hosts => "is")
+                              .result["lines"]
+
         @from = @to
 
         break if stop_polling
 
-        events.each { |event| yield event}
+        events.each { |event| yield event }
       end
       sleep(poll_sleep)
     end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_parser.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventParser
   def self.event_to_hash(event, ems_id)
     event_hash = {
       :event_type => event["action"],
-      :source     => "IBM_CLOUD_VPC",
+      :source     => "IBMCloud-VPC",
       :ems_id     => ems_id,
       :ems_ref    => event["_id"],
       :timestamp  => event["eventTime"],
@@ -10,7 +10,7 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventParser
     }
 
     case event_hash[:event_type]
-    when 'is.instance.instance.create'
+    when /^is\.instance/
       parse_vm_event!(event, event_hash)
     end
 
@@ -18,10 +18,10 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventParser
   end
 
   def self.parse_vm_event!(event, event_hash)
-    return if event['responseData'].nil?
+    vm_ref = event.dig('target', 'id').match(/::instance:(?<instance_id>\S+)$/)
+    return if vm_ref.nil?
 
-    event_hash[:vm_uid_ems] = event.dig('responseData', 'id')
-    event_hash[:vm_ems_ref] = event.dig('responseData', 'id')
-    event_hash[:vm_name]    = event.dig('responseData', 'name')
+    event_hash[:vm_uid_ems] = vm_ref.named_captures["instance_id"]
+    event_hash[:vm_ems_ref] = vm_ref.named_captures["instance_id"]
   end
 end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_target_parser.rb
@@ -1,0 +1,28 @@
+class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventTargetParser
+  attr_reader :ems_event
+
+  def initialize(ems_event)
+    @ems_event = ems_event
+  end
+
+  def parse
+    parse_ems_event_targets(ems_event)
+  end
+
+  def parse_ems_event_targets(event)
+    target_collection = InventoryRefresh::TargetCollection.new(
+      :manager => event.ext_management_system,
+      :event   => event
+    )
+
+    case event[:event_type]
+    when /^is\.instance/
+      target_collection.add_target(
+        :association => :vms,
+        :manager_ref => {:ems_ref => event[:vm_ems_ref]}
+      )
+    end
+
+    target_collection.targets
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,37 @@
         :addition:
           :critical:
           - is.instance.instance.create
+          - is.instance.action.create
+          - is.instance.console-access-token.create
+          - is.instance.volume-attachment.create
+          - is.instance.network-interface.create
+        :update:
+          :critical:
+          - is.instance.instance.update
+          - is.instance.instance.read
+          - is.instance.console.read
+          - is.instance.network-interface_floating-ip.attach
+          - is.instance.network-interface_floating-ip.detach
+          - is.instance.volume-attachment.update
+          - is.instance.volume-attachment.read
+          - is.instance.network-interface.update
+          - is.instance.network-interface.read
+          - is.instance.network-interface_floating-ip.read
+          - is.instance.disk.read
+          - is.instance.disk.update
+        :deletion:
+          :critical:
+          - is.instance.instance.delete
+          - is.instance.action.delete
+          - is.instance.volume-attachment.delete
+          - is.instance.network-interface.delete
+          - is.instance.disk.wipe
+          - is.instance.gpu.wipe
+        :power:
+          :critical:
+          - is.instance.instance.start
+          - is.instance.instance.stop
+          - is.instance.instance.volume-stop
 
 :ems_refresh:
   :ibm_vpc:


### PR DESCRIPTION
- added event-based targeted refresh for VMs

Depends on:
* [x] [Add IBM Cloud VPC VM event handler](https://github.com/ManageIQ/manageiq-content/pull/689)

Ref:
- https://cloud.ibm.com/docs/vpc?topic=vpc-at-events#events-compute