### PR TITLE
Refactor SDK connections

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc.rb
@@ -8,20 +8,24 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC < ManageIQ::Provi
     @connection ||= manager.connect
   end
 
+  def vpc
+    @vpc ||= connection.vpc(:region => manager.provider_region)
+  end
+
   def vms
-    connection.instances.all
+    vpc.instances.all
   end
 
   def vm_key_pairs(vm_id)
-    connection.request(:get_instance_initialization, :id => vm_id) || {}
+    vpc.request(:get_instance_initialization, :id => vm_id) || {}
   end
 
   def flavors
-    connection.request(:list_instance_profiles)[:profiles]
+    vpc.request(:list_instance_profiles)[:profiles]
   end
 
   def images
-    @images ||= connection.collection(:list_images).to_a
+    @images ||= vpc.collection(:list_images).to_a
   end
 
   def images_by_id
@@ -29,21 +33,21 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC < ManageIQ::Provi
   end
 
   def image(image_id)
-    connection.request(:get_image, :id => image_id)
+    vpc.request(:get_image, :id => image_id)
   rescue IBMCloudSdkCore::ApiException
     nil
   end
 
   def keys
-    connection.request(:list_keys)[:keys]
+    vpc.request(:list_keys)[:keys]
   end
 
   def availability_zones
-    connection.request(:list_region_zones, :region_name => manager.provider_region)[:zones]
+    vpc.request(:list_region_zones, :region_name => manager.provider_region)[:zones]
   end
 
   def security_groups
-    connection.collection(:list_security_groups)
+    vpc.collection(:list_security_groups)
   end
 
   def cloud_database_flavors
@@ -51,37 +55,37 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC < ManageIQ::Provi
   end
 
   def cloud_networks
-    connection.collection(:list_vpcs)
+    vpc.collection(:list_vpcs)
   end
 
   def cloud_subnets
-    connection.collection(:list_subnets)
+    vpc.collection(:list_subnets)
   end
 
   def floating_ips
-    connection.collection(:list_floating_ips)
+    vpc.collection(:list_floating_ips)
   end
 
   def volumes
-    connection.collection(:list_volumes)
+    vpc.collection(:list_volumes)
   end
 
   def volume(volume_id)
-    connection.request(:get_volume, :id => volume_id)
+    vpc.request(:get_volume, :id => volume_id)
   end
 
   # Fetch volume profiles from VPC. Each item has following keys :name, :family, :href.
   # @return [Array<Hash<Symbol, String>>]
   def volume_profiles
-    connection.collection(:list_volume_profiles)
+    vpc.collection(:list_volume_profiles)
   end
 
   def tags_by_crn(crn)
-    connection.cloudtools.tagging.collection(:list_tags, :attached_to => crn, :providers => ["ghost"]).to_a
+    vpc.cloudtools.tagging.collection(:list_tags, :attached_to => crn, :providers => ["ghost"]).to_a
   end
 
   def resource_instances
-    @resource_instances ||= connection.cloudtools.resource.controller.collection(:list_resource_instances)
+    @resource_instances ||= vpc.cloudtools.resource.controller.collection(:list_resource_instances)
   end
 
   def database_instances
@@ -91,6 +95,6 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC < ManageIQ::Provi
   # Fetch resource groups from ResourceController SDK.
   # @return [Enumerator]
   def resource_groups
-    connection.cloudtools.resource.manager.collection(:list_resource_groups)
+    vpc.cloudtools.resource.manager.collection(:list_resource_groups)
   end
 end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc/target_collection.rb
@@ -8,14 +8,14 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC::TargetCollection
   def images
     @images ||=
       references(:miq_templates).map do |ems_ref|
-        connection.request(:get_image, :id => ems_ref)
+        vpc.request(:get_image, :id => ems_ref)
       end
   end
 
   def vms
     @vms ||=
       references(:vms).map do |ems_ref|
-        connection.request(:get_instance, :id => ems_ref)
+        vpc.request(:get_instance, :id => ems_ref)
       rescue IBMCloudSdkCore::ApiException
         nil
       end.compact
@@ -24,63 +24,63 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC::TargetCollection
   def flavors
     @flavors ||=
       references(:flavors).map do |ems_ref|
-        connection.request(:get_instance_profile, :name => ems_ref)
+        vpc.request(:get_instance_profile, :name => ems_ref)
       end
   end
 
   def keys
     @keys ||=
       references(:auth_key_pairs).map do |ems_ref|
-        connection.request(:get_key, :id => ems_ref)
+        vpc.request(:get_key, :id => ems_ref)
       end
   end
 
   def availability_zones
     @availability_zones ||=
       references(:availability_zones).map do |ems_ref|
-        connection.request(:get_region_zone, :region_name => manager.provider_region, :name => ems_ref)
+        vpc.request(:get_region_zone, :region_name => manager.provider_region, :name => ems_ref)
       end
   end
 
   def security_groups
     @security_groups ||=
       references(:security_groups).map do |ems_ref|
-        connection.request(:get_security_group, :id => ems_ref)
+        vpc.request(:get_security_group, :id => ems_ref)
       end
   end
 
   def cloud_networks
     @cloud_networks ||=
       references(:cloud_networks).map do |ems_ref|
-        connection.request(:get_vpc, :id => ems_ref)
+        vpc.request(:get_vpc, :id => ems_ref)
       end
   end
 
   def cloud_subnets
     @cloud_subnets ||=
       references(:cloud_subnets).map do |ems_ref|
-        connection.request(:get_subnet, :id => ems_ref)
+        vpc.request(:get_subnet, :id => ems_ref)
       end
   end
 
   def floating_ips
     @floating_ips ||=
       references(:floating_ips).map do |ems_ref|
-        connection.request(:get_floating_ip, :id => ems_ref)
+        vpc.request(:get_floating_ip, :id => ems_ref)
       end
   end
 
   def volumes
     @volumes ||=
       references(:cloud_volumes).map do |ems_ref|
-        connection.request(:get_volume, :id => ems_ref)
+        vpc.request(:get_volume, :id => ems_ref)
       end
   end
 
   def volume_profiles
     @volume_profiles ||=
       references(:cloud_volume_types).map do |ems_ref|
-        connection.request(:get_volume_profile, :name => ems_ref)
+        vpc.request(:get_volume_profile, :name => ems_ref)
       end
   end
 
@@ -95,7 +95,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC::TargetCollection
   def resource_groups
     @resource_groups ||=
       references(:resource_groups).map do |ems_ref|
-        connection.cloudtools.resource.manager.request(:get_resource_group, :id => ems_ref)
+        vpc.cloudtools.resource.manager.request(:get_resource_group, :id => ems_ref)
       end
   end
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/stream.rb
@@ -6,6 +6,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher::Stream
     @stop_polling = false
     @from = Time.now.to_i
     @poll_sleep = options[:poll_sleep] || 20.seconds
+    @service_key = ems.authentication_key("events")
   end
 
   def start
@@ -18,25 +19,22 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher::Stream
   end
 
   def poll
+    events_client = ems.connect.events(:region => ems.provider_region, :service_key => @service_key).sdk_client
     loop do
       @to = Time.now.to_i
 
-      ems.with_provider_connection(:service => 'events') do |api|
-        events_client = api.sdk_client
+      # IBM Cloud Activity Tracker has a delay from the time that
+      # an event is fired to when it is available to be retrieved by the API.
+      # Therefore a 30-second timestamp offset is used to allow
+      # events to persist on the service and get retrieved.
+      events = events_client.exportv2(:from => (@from - 30).to_s, :to => (@to - 30).to_s, :hosts => "is")
+                            .result["lines"]
 
-        # IBM Cloud Activity Tracker has a delay from the time that
-        # an event is fired to when it is available to be retrieved by the API.
-        # Therefore a 30-second timestamp offset is used to allow
-        # events to persist on the service and get retrieved.
-        events = events_client.exportv2(:from => (@from - 30).to_s, :to => (@to - 30).to_s, :hosts => "is")
-                              .result["lines"]
+      @from = @to
 
-        @from = @to
+      break if stop_polling
 
-        break if stop_polling
-
-        events.each { |event| yield event }
-      end
+      events.each { |event| yield event }
       sleep(poll_sleep)
     end
   end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision/cloning.rb
@@ -20,7 +20,11 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::Provision::Cloning
   # @return [String] The ID of the new instance.
   def start_clone(clone_options)
     logger(__method__).debug("Json for VPC provision task. #{JSON.dump(clone_options)}")
-    response = source.with_provider_connection { |vpc| vpc.request(:create_instance, :instance_prototype => clone_options) }
+    response = source.with_provider_connection do |connect|
+      connect.vpc(:region => source.ext_management_system.provider_region)
+             .request(:create_instance, :instance_prototype => clone_options)
+    end
+
     if response[:id].nil?
       error_msg = _('An error occurred while requesting the IBM VPC instance provision. Cannot retrieve instance id from returned server response.')
       raise MiqException::MiqProvisionError, error_msg
@@ -37,7 +41,11 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::Provision::Cloning
   # @param clone_task_ref [String] The UUID for the new provision.
   # @return [Array(Boolean, String)] 2 elements first is boolean when true signals the provision is complete. Second element is a string for logging the current status.
   def do_clone_task_check(clone_task_ref)
-    instance = source.with_provider_connection { |vpc| vpc.request(:get_instance, :id => clone_task_ref) }
+    instance = source.with_provider_connection do |connect|
+      connect.vpc(:region => source.ext_management_system.provider_region)
+             .request(:get_instance, :id => clone_task_ref)
+    end
+
     live_status = instance[:status]
     return false, _('IBM VPC instance provision has no status present.') if live_status.nil?
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
@@ -23,8 +23,8 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
   end
 
   # Used in with_provider_object to scope SDK to this instance.
-  def provider_object(vpc)
-    vpc.instances.instance(ems_ref)
+  def provider_object(connect)
+    connect.vpc(:region => ext_management_system.provider_region).instances.instance(ems_ref)
   end
 
   # Send a start action to IBM Cloud. Wait for state to change to started, then update the raw_power_state.

--- a/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
@@ -15,14 +15,7 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
   # [ManageIQ::Providers::IbmCloud::CloudTools::ActivityTracker]
   def connect(options = {})
     key = authentication_key(options[:auth_type])
-    region = options[:provider_region] || provider_region
-    sdk = self.class.raw_connect(key)
-    if options[:service] == 'events'
-      service_key = authentication_key("events")
-      sdk.events(:region => region, :service_key => service_key)
-    else
-      sdk.vpc(:region => region)
-    end
+    self.class.raw_connect(key)
   end
 
   # Same as calling connect.
@@ -30,7 +23,7 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
   # @param options [Hash] Connection options.
   # @return [ManageIQ::Providers::IbmCloud::CloudTools::Vpc]
   def verify_credentials(_auth_type = nil, options = {})
-    connect(options).cloudtools.authenticator
+    connect(options).authenticator
   end
 
   module ClassMethods

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
@@ -12,7 +12,8 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork < ::Cloud
 
   def self.raw_create_cloud_network(ext_management_system, options)
     ext_management_system.with_provider_connection do |connection|
-      connection.request(:create_vpc, :name => options[:name])
+      connection.vpc(:region => ext_management_system.parent_manager.provider_region)
+                .request(:create_vpc, :name => options[:name])
     end
   rescue => err
     _log.error("cloud_network=[#{options[:name]}], error: #{err}")
@@ -21,7 +22,8 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork < ::Cloud
 
   def raw_delete_cloud_network(_options = {})
     with_provider_connection do |connection|
-      connection.request(:delete_vpc, :id => ems_ref)
+      connection.vpc(:region => ext_management_system.parent_manager.provider_region)
+                .request(:delete_vpc, :id => ems_ref)
     end
   rescue => err
     notification_options = {

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet.rb
@@ -49,7 +49,8 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudSubnet < ::CloudS
     }
 
     ext_management_system.with_provider_connection do |connection|
-      connection.request(:create_subnet, :subnet_prototype => subnet)
+      connection.vpc(:region => ext_management_system.parent_manager.provider_region)
+                .request(:create_subnet, :subnet_prototype => subnet)
     end
   rescue => err
     _log.error("subnet=[#{options[:name]}], error: #{err}")
@@ -58,7 +59,8 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudSubnet < ::CloudS
 
   def raw_delete_cloud_subnet
     with_provider_connection do |connection|
-      connection.request(:delete_subnet, :id => ems_ref)
+      connection.vpc(:region => ext_management_system.parent_manager.provider_region)
+                .request(:delete_subnet, :id => ems_ref)
     end
   rescue => err
     _log.error("subnet=[#{name}], error: #{err}")

--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager/cloud_volume.rb
@@ -96,7 +96,8 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager::CloudVolume < ::CloudV
     volume[:iops] = options[:iops].to_i if options[:volume_type] == 'custom'
 
     ext_management_system.with_provider_connection do |connection|
-      connection.request(:create_volume, :volume_prototype => volume)
+      connection.vpc(:region => ext_management_system.parent_manager.provider_region)
+                .request(:create_volume, :volume_prototype => volume)
     end
   rescue => err
     _log.error("cloud_volume=[#{options[:name]}], error: #{err}")
@@ -105,7 +106,8 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager::CloudVolume < ::CloudV
 
   def raw_delete_volume
     with_provider_connection do |connection|
-      connection.request(:delete_volume, :id => ems_ref)
+      connection.vpc(:region => ext_management_system.parent_manager.provider_region)
+                .request(:delete_volume, :id => ems_ref)
     end
   rescue => err
     _log.error("cloud_volume=[#{name}], error: #{err}")

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -39,8 +39,10 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
 
       it "with a deleted vm" do
         connection = double("IbmCloud::CloudTool")
+        vpc = double("IbmCloud::CloudTool::VPC")
         allow(ems).to receive(:connect).and_return(connection)
-        expect(connection).to receive(:request)
+        allow(connection).to receive(:vpc).with(:region => ems.provider_region).and_return(vpc)
+        expect(vpc).to receive(:request)
           .with(:get_instance, :id => target.ems_ref)
           .and_raise(
             IBMCloudSdkCore::ApiException.new(
@@ -210,8 +212,8 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
       :name     => "medium",
       :enabled  => true,
       :cpus     => 10,
-      :memory   => 42949672960,
-      :max_size => 429496729600
+      :memory   => 42_949_672_960,
+      :max_size => 429_496_729_600
     )
   end
 

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network_spec.rb
@@ -12,14 +12,19 @@ describe ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork do
 
   describe 'cloud network actions' do
     let(:connection) do
+      double("ManageIQ::Providers::IbmCloud::CloudTools")
+    end
+
+    let(:vpc) do
       double("ManageIQ::Providers::IbmCloud::CloudTools::Vpc")
     end
 
     before { allow(ems.network_manager).to receive(:with_provider_connection).and_yield(connection) }
+    before { allow(connection).to receive(:vpc).with(:region => ems.provider_region).and_return(vpc) }
 
     context '#create_cloud_network' do
       it 'creates the cloud network' do
-        expect(connection).to receive(:request).with(:create_vpc, :name => 'test')
+        expect(vpc).to receive(:request).with(:create_vpc, :name => 'test')
         ems.network_manager.create_cloud_network({:name => 'test'})
       end
     end
@@ -28,7 +33,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork do
       before { NotificationType.seed }
 
       it 'deletes the cloud network' do
-        expect(connection).to receive(:request).with(:delete_vpc, :id => cloud_network.ems_ref)
+        expect(vpc).to receive(:request).with(:delete_vpc, :id => cloud_network.ems_ref)
         cloud_network.raw_delete_cloud_network
       end
 
@@ -39,7 +44,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork do
           :transaction_id        => "1234",
           :global_transaction_id => "5678"
         )
-        expect(connection).to receive(:request)
+        expect(vpc).to receive(:request)
           .with(:delete_vpc, :id => cloud_network.ems_ref)
           .and_raise(exception)
 

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet_spec.rb
@@ -17,14 +17,19 @@ describe ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudSubnet do
 
   describe 'cloud subnet actions' do
     let(:connection) do
+      double("ManageIQ::Providers::IbmCloud::CloudTools")
+    end
+
+    let(:vpc) do
       double("ManageIQ::Providers::IbmCloud::CloudTools::Vpc")
     end
 
     before { allow(ems.network_manager).to receive(:with_provider_connection).and_yield(connection) }
+    before { allow(connection).to receive(:vpc).with(:region => ems.provider_region).and_return(vpc) }
 
     context '#create_cloud_subnet' do
       it 'creates the cloud subnet' do
-        expect(connection).to receive(:request).with(:create_subnet,
+        expect(vpc).to receive(:request).with(:create_subnet,
                                                      :subnet_prototype => {
                                                        :vpc             => {
                                                          :id => cloud_network.ems_ref
@@ -41,7 +46,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudSubnet do
 
     context '#raw_delete_cloud_subnet' do
       it 'deletes the cloud subnet' do
-        expect(connection).to receive(:request).with(:delete_subnet, :id => cloud_subnet.ems_ref)
+        expect(vpc).to receive(:request).with(:delete_subnet, :id => cloud_subnet.ems_ref)
         cloud_subnet.raw_delete_cloud_subnet
       end
     end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/storage_manager/cloud_volume_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/storage_manager/cloud_volume_spec.rb
@@ -10,14 +10,19 @@ describe ManageIQ::Providers::IbmCloud::VPC::StorageManager::CloudVolume do
 
   describe 'cloud volume actions' do
     let(:connection) do
+      double("ManageIQ::Providers::IbmCloud::CloudTools")
+    end
+
+    let(:vpc) do
       double("ManageIQ::Providers::IbmCloud::CloudTools::Vpc")
     end
 
     before { allow(ems.storage_manager).to receive(:with_provider_connection).and_yield(connection) }
+    before { allow(connection).to receive(:vpc).with(:region => ems.provider_region).and_return(vpc) }
 
     context '#raw_create_volume' do
       it 'creates a cloud volume' do
-        expect(connection).to receive(:request).with(:create_volume,
+        expect(vpc).to receive(:request).with(:create_volume,
                                                      :volume_prototype => {
                                                        :profile  => {
                                                          :name => '5iops-tier'
@@ -36,7 +41,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::StorageManager::CloudVolume do
       end
 
       it 'creates a custom profile cloud volume' do
-        expect(connection).to receive(:request).with(:create_volume,
+        expect(vpc).to receive(:request).with(:create_volume,
                                                      :volume_prototype => {
                                                        :profile  => {
                                                          :name => 'custom'
@@ -59,7 +64,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::StorageManager::CloudVolume do
 
     context '#raw_delete_volume' do
       it 'deletes the cloud volume' do
-        expect(connection).to receive(:request).with(:delete_volume, :id => cloud_volume.ems_ref)
+        expect(vpc).to receive(:request).with(:delete_volume, :id => cloud_volume.ems_ref)
         cloud_volume.raw_delete_volume
       end
     end


### PR DESCRIPTION
In the case of adding other SDKs for inventory collection, this was done so that we no longer need to re-authenticate for a connection other than VPC since we will now be using the same `CloudTool` object. In the near future this will be relevant for cloud database collection