### PR TITLE
[MORPHY] VPC Delete cloud networks functionality

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
@@ -1,2 +1,24 @@
 class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork < ::CloudNetwork
+  include ProviderObjectMixin
+
+  supports :delete do
+    if ext_management_system.nil?
+      unsupported_reason_add(:delete_cloud_network, _("The Cloud Network is not connected to an active %{table}") % {
+        :table => ui_lookup(:table => "ext_management_systems")
+      })
+    end
+  end
+
+  def raw_delete_cloud_network(_options = {})
+    with_provider_connection do |connection|
+      connection.request(:delete_vpc, :id => ems_ref)
+    end
+  rescue => err
+    notification_options = {
+      :subject       => "[#{name}]",
+      :error_message => err.to_s
+    }
+    Notification.create(:type => :cloud_network_delete_error, :options => notification_options)
+    raise
+  end
 end

--- a/spec/factories/cloud_network.rb
+++ b/spec/factories/cloud_network.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :cloud_network_ibm_cloud_vpc,
+          :class  => "ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork",
+          :parent => :cloud_network
+end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -17,3 +17,9 @@ FactoryBot.define do
           :class  => "ManageIQ::Providers::IbmCloud::VPC::CloudManager",
           :parent => :ems_cloud
 end
+
+FactoryBot.define do
+  factory :ems_ibm_cloud_vpc_network,
+          :class  => "ManageIQ::Providers::IbmCloud::VPC::NetworkManager",
+          :parent => :ems_cloud
+end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork do
+  let(:ems) do
+    FactoryBot.create(:ems_ibm_cloud_vpc, :provider_region => "us-east")
+  end
+
+  let(:cloud_network) do
+    FactoryBot.create(:cloud_network_ibm_cloud_vpc,
+                      :ext_management_system => ems.network_manager)
+  end
+
+  describe '#raw_delete_cloud_network' do
+    before { NotificationType.seed }
+
+    let(:connection) do
+      double("ManageIQ::Providers::IbmCloud::CloudTools::Vpc")
+    end
+
+    it 'deletes the cloud network' do
+      expect(cloud_network).to receive(:with_provider_connection).and_yield(connection)
+      expect(connection).to receive(:request).with(:delete_vpc, :id => cloud_network.ems_ref)
+      cloud_network.raw_delete_cloud_network
+    end
+
+    it 'with cloud subnets' do
+      exception = IBMCloudSdkCore::ApiException.new(
+        :code                  => 409,
+        :error                 => "Delete VPC failed: VPC still contains subnets",
+        :transaction_id        => "1234",
+        :global_transaction_id => "5678"
+      )
+      expect(cloud_network).to receive(:with_provider_connection).and_yield(connection)
+      expect(connection).to receive(:request)
+        .with(:delete_vpc, :id => cloud_network.ems_ref)
+        .and_raise(exception)
+
+      expect { cloud_network.raw_delete_cloud_network }.to raise_error(IBMCloudSdkCore::ApiException)
+      expect(Notification.count).to eq(1)
+      expect(Notification.first)
+        .to have_attributes(:options => {:error_message => exception.to_s,
+                                         :subject       => "[#{cloud_network.name}]"})
+    end
+  end
+end


### PR DESCRIPTION
VPC Delete cloud networks functionality

(cherry picked from commit c3cb5bed72f5d5a10a9cf136e7b07e8b79d48657)

Direct backport of https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/227