### PR TITLE
[MORPHY] Exception handling for VM targeted refresh

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc/target_collection.rb
@@ -16,7 +16,9 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC::TargetCollection
     @vms ||=
       references(:vms).map do |ems_ref|
         connection.request(:get_instance, :id => ems_ref)
-      end
+      rescue IBMCloudSdkCore::ApiException
+        nil
+      end.compact
   end
 
   def instance_types

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -34,6 +34,25 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
     context "vm target" do
       let(:target) { ems.vms.find_by(:ems_ref => "0757_81687d4a-4676-4eeb-9fd7-55f9c7fffb69") }
 
+      it "with a deleted vm" do
+        connection = double("IbmCloud::CloudTool")
+        allow(ems).to receive(:connect).and_return(connection)
+        expect(connection).to receive(:request)
+          .with(:get_instance, :id => target.ems_ref)
+          .and_raise(
+            IBMCloudSdkCore::ApiException.new(
+              :code                  => 404,
+              :error                 => "Error: Instance not found",
+              :transaction_id        => "1234",
+              :global_transaction_id => "5678"
+            )
+          )
+
+        EmsRefresh.refresh(target)
+
+        expect(target.reload).to be_archived
+      end
+
       it "doesn't impact other inventory" do
         assert_inventory_not_changed do
           with_vcr("vm_target") { EmsRefresh.refresh(target) }


### PR DESCRIPTION
Merge pull request #225 from nasark/delete_vm_exception

Exception handling for VM targeted refresh

(cherry picked from commit df54ee7eb59c02070e072564f8df7feb2da1a4b7)

Morphy backport of https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/225

Depends:
- [x] https://github.com/ManageIQ/manageiq/pull/21281