### PR TITLE
Fix the settings_name for the IKS Refresh Worker

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager/refresh_worker.rb
@@ -3,6 +3,6 @@ class ManageIQ::Providers::IbmCloud::ContainerManager::RefreshWorker < ManageIQ:
   require_nested :WatchThread
 
   def self.settings_name
-    :event_catcher_ibm_cloud_iks
+    :ems_refresh_worker_ibm_cloud_iks
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/272#discussion_r708421698