### PR TITLE
[MORPHY] Fix instance provision workflow

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow/general.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow/general.rb
@@ -32,7 +32,7 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::ProvisionWorkflow::Gene
   # @param _options [void]
   # @return [Array<Hash<String: String>>] An array of hashes with ems_ref as key and name as value.
   def guest_access_key_pairs_to_keys(_options = {})
-    @guest_access_key_pairs_to_keys ||= string_dropdown(ar_ems.key_pairs)
+    @guest_access_key_pairs_to_keys ||= string_dropdown(ar_ems.key_pairs, :key => :name)
   rescue => e
     logger(__method__).ui_exception(e)
   end


### PR DESCRIPTION
Fixes: https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/20420

This was caused due to schema changes that were made on master

Keys:
- schema change: https://github.com/ManageIQ/manageiq-schema/pull/568
- string dropdown now maps to the key name
- since there is no `ems_ref` available, I am using the VPC API to find the key ID using the key name, which can then be used in the payload to make a provision instance request
![a154d21e-1731-4c0c-b2be-35c0c0438019](https://user-images.githubusercontent.com/48186199/135306078-dfa0113a-2ee9-410a-9fa5-21eec5d95208.jpeg)
