### PR TITLE
Update 'ibm_cloud_power' gem

### DIFF
--- a/manageiq-providers-ibm_cloud.gemspec
+++ b/manageiq-providers-ibm_cloud.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ibm_cloud_iam", "~> 1.0"
-  spec.add_dependency "ibm_cloud_power", "~> 1.0"
+  spec.add_dependency "ibm_cloud_power", "~> 1.1", ">= 1.1.1"
   spec.add_dependency "ibm_cloud_resource_controller", "~> 2.0"
   spec.add_dependency "ibm-cloud-sdk", "~> 0.1"
   spec.add_dependency "ibm_cloud_activity_tracker", "~> 0.1"


### PR DESCRIPTION
The 'ibm_cloud_power' gem v1.1.1 includes a fix to the SAPProfile API
that is required for refresh to work in PowerVS regions that support SAP
profiles.