### PR TITLE
Fix PowerVS CloudSubnet missing supports create

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/cloud_subnet.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager::CloudSubnet < ::CloudSubnet
+  supports :create
   supports :delete do
     if number_of(:vms) > 0
       unsupported_reason_add(:delete, _("The Network has active VMIs related to it"))


### PR DESCRIPTION
The PowerVS CloudSubnet subclass was missing `supports :create` even though it had params_for_create