### PR TITLE
Add resize VM functionality

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
@@ -182,12 +182,13 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
   def flavors
     collector.flavors.each do |flavor|
       memory = flavor&.dig(:memory, :value)
-      memory_mb = Integer(memory) * 1024 if memory
+      disk = flavor[:disks].first&.dig(:size, :value) || 0
       persister.flavors.build(
         :ems_ref         => flavor[:name],
         :name            => flavor[:name],
         :cpu_total_cores => flavor&.dig(:vcpu_count, :value),
-        :memory          => memory_mb,
+        :memory          => memory&.gigabytes,
+        :root_disk_size  => disk&.gigabytes,
         :enabled         => true
       )
     end

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/vpc_sdk/instance.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/vpc_sdk/instance.rb
@@ -72,6 +72,15 @@ module ManageIQ
               @parent.request(:delete_instance, :id => id)
             end
 
+            def resize(instance, new_flavor_name)
+              @parent.request(:update_instance,
+                              :id             => instance[:id],
+                              :instance_patch => {
+                                :name    => instance[:name],
+                                :profile => {:name => new_flavor_name}
+                              })
+            end
+
             # Wait for the VM instance to be have a started status.
             # @param sleep_time [Integer] The time to sleep between refreshes.
             # @param timeout [Integer] The number of seconds before raising an error.

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -103,7 +103,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
     expect(flavor).to have_attributes(
       :name            => 'bx2-2x8',
       :cpu_total_cores => 2,
-      :memory          => 8_192,
+      :memory          => 8_589_934_592,
       :ems_ref         => 'bx2-2x8',
       :type            => 'ManageIQ::Providers::IbmCloud::VPC::CloudManager::Flavor',
       :enabled         => true


### PR DESCRIPTION
- added the ability to resize/reconfigure VMs

Restrictions when resizing VMs from IBM Cloud:
- VM must be in a `stopped` or `stopping` state
- new flavor must be of the same profile family/architecture as old flavor
- unable to resize to a flavor with a disk if current flavor doesn't have a disk

If the user selects a flavor that doesn't meet the above requirements then an error is thrown and displayed via notifications, indicating the incompatibility of the new flavor selected

Depends on:
* [x] [Add error notification for resizing VMs](https://github.com/ManageIQ/manageiq/pull/21543)

Ref:
- https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/263

@miq-bot add_label enhancement
@miq-bot assign @agrare 