### PR TITLE
Subclass AvailabilityZone under IbmCloud::VPC

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::CloudManager
   require_nested :AuthKeyPair
+  require_nested :AvailabilityZone
   require_nested :CloudDatabase
   require_nested :CloudDatabaseFlavor
   require_nested :EventCatcher

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/availability_zone.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/availability_zone.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmCloud::VPC::CloudManager::AvailabilityZone < ::AvailabilityZone
+end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -22,6 +22,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
         ems.reload
 
         assert_specific_flavor
+        assert_specific_availability_zone
         assert_specific_security_group
         assert_specific_cloud_volume
         assert_specific_cloud_volume_type
@@ -108,6 +109,12 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
       :type            => 'ManageIQ::Providers::IbmCloud::VPC::CloudManager::Flavor',
       :enabled         => true
     )
+  end
+
+  def assert_specific_availability_zone
+    az = check_resource_fetch(ems, :availability_zones, "ca-tor-1")
+    class_type = 'ManageIQ::Providers::IbmCloud::VPC::CloudManager::AvailabilityZone'
+    check_attribute_values(az, class_type, 'ca-tor-1')
   end
 
   # Test a resource_group record is properly persisted.


### PR DESCRIPTION
These did not have a subclass under the VPC namespace and thus fell back to `::AvailabilityZone`