### PR TITLE
Fix VPC event catch poll sequence

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher/stream.rb
@@ -32,9 +32,10 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher::Stream
 
       @from = @to
 
+      events.each { |event| yield event }
+
       break if stop_polling
 
-      events.each { |event| yield event }
       sleep(poll_sleep)
     end
   end


### PR DESCRIPTION
Fix yield / break sequence (yield first to be sure any events get
queued, then break if stop_polling).

@agrare caught this when reviewing the PowerVS event catcher https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/279#discussion_r747636876