### PR TITLE
VPC Metrics Capture

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -6,6 +6,8 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::Cl
   require_nested :EventCatcher
   require_nested :Flavor
   require_nested :LoggingMixin
+  require_nested :MetricsCapture
+  require_nested :MetricsCollectorWorker
   require_nested :Provision
   require_nested :ProvisionWorkflow
   require_nested :RefreshWorker
@@ -13,6 +15,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::Cl
   require_nested :Template
   require_nested :Vm
 
+  supports :metrics
   supports :provisioning
   supports :storage_manager
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_capture.rb
@@ -1,0 +1,168 @@
+class ManageIQ::Providers::IbmCloud::VPC::CloudManager::MetricsCapture < ManageIQ::Providers::CloudManager::MetricsCapture
+  delegate :ext_management_system, :to => :target
+
+  VIM_STYLE_COUNTERS = {
+    "cpu_usage_rate_average"     => {
+      :counter_key           => "cpu_usage_rate_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 1,
+      :rollup                => "average",
+      :unit_key              => "percent",
+      :capture_interval_name => "realtime",
+    }.freeze,
+    "disk_usage_rate_average"    => {
+      :counter_key           => "disk_usage_rate_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 2,
+      :rollup                => "average",
+      :unit_key              => "kilobytespersecond",
+      :capture_interval_name => "realtime",
+    }.freeze,
+    "net_usage_rate_average"     => {
+      :counter_key           => "net_usage_rate_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 2,
+      :rollup                => "average",
+      :unit_key              => "kilobytespersecond",
+      :capture_interval_name => "realtime",
+    }.freeze,
+    "mem_usage_absolute_average" => {
+      :counter_key           => "mem_usage_absolute_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 1,
+      :rollup                => "average",
+      :unit_key              => "percent",
+      :capture_interval_name => "realtime",
+    }.freeze,
+  }.freeze
+
+  def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
+    require 'rest-client'
+
+    raise _("No EMS defined") if ext_management_system.nil?
+
+    end_time ||= Time.zone.now
+    end_time = end_time.utc
+    start_time ||= end_time - 4.hours
+    start_time = start_time.utc
+    # Due to API limitations, the maximum period of time that can be sampled over is 36000 seconds (10 hours)
+    sample_window = (end_time.to_i - start_time.to_i) > 36_000 ? 36_000 : end_time.to_i - start_time.to_i
+
+    counters_by_mor = {target.ems_ref => VIM_STYLE_COUNTERS}
+    counter_values_by_mor = {target.ems_ref => {}}
+
+    metrics_endpoint = ext_management_system.endpoints.find_by(:role => "metrics")
+    raise _("Missing monitoring instance id") if metrics_endpoint.nil?
+
+    instance_id = metrics_endpoint.options["monitoring_instance_id"]
+
+    response = RestClient::Request.execute(
+      :method  => :post,
+      :url     => "https://#{ext_management_system.provider_region}.monitoring.cloud.ibm.com/api/data",
+      :headers => {
+        'Content-Type'  => 'application/json',
+        'Authorization' => "Bearer #{iam_access_token}",
+        'IBMInstanceID' => instance_id
+      },
+      :payload => JSON.generate(get_metrics_query(target.name, sample_window))
+    )
+    data = JSON.parse(response.body)
+    dataset = consolidate_data(data["data"])
+
+    store_datapoints_with_interpolation!(end_time.to_i, dataset[:timestamps], dataset[:cpu_usage_rate_average], "cpu_usage_rate_average", counter_values_by_mor[target.ems_ref])
+    store_datapoints_with_interpolation!(end_time.to_i, dataset[:timestamps], dataset[:mem_usage_absolute_average], "mem_usage_absolute_average", counter_values_by_mor[target.ems_ref])
+    store_datapoints_with_interpolation!(end_time.to_i, dataset[:timestamps], dataset[:net_usage_rate_average], "net_usage_rate_average", counter_values_by_mor[target.ems_ref])
+    store_datapoints_with_interpolation!(end_time.to_i, dataset[:timestamps], dataset[:disk_usage_rate_average], "disk_usage_rate_average", counter_values_by_mor[target.ems_ref])
+
+    return counters_by_mor, counter_values_by_mor
+  rescue RestClient::ExceptionWithResponse => err
+    log_header = "[#{interval_name}] for: [#{target.class.name}], [#{target.id}], [#{target.name}]"
+    _log.error("#{log_header} Unhandled exception during perf data collection: [#{err}], class: [#{err.class}]")
+    _log.log_backtrace(err)
+    raise
+  end
+
+  def get_metrics_query(instance_name, sample_window)
+    # :last refers to the window of time in which data will be retrieved
+    # :sampling refers to the data resolution, data will be sampled every 60 seconds
+    {
+      :last           => sample_window,
+      :sampling       => 60,
+      :filter         => "ibm_resource_name = '#{instance_name}'",
+      :metrics        => [
+        {
+          :id           => "ibm_is_instance_cpu_usage_percentage",
+          :aggregations => {
+            :time => "avg"
+          }
+        },
+        {
+          :id           => "ibm_is_instance_memory_usage_percentage",
+          :aggregations => {
+            :time => "avg"
+          }
+        },
+        {
+          :id           => "ibm_is_instance_network_in_bytes",
+          :aggregations => {
+            :time => "avg"
+          }
+        },
+        {
+          :id           => "ibm_is_instance_network_out_bytes",
+          :aggregations => {
+            :time => "avg"
+          }
+        },
+        {
+          :id           => "ibm_is_instance_volume_read_bytes",
+          :aggregations => {
+            :time => "avg"
+          }
+        },
+        {
+          :id           => "ibm_is_instance_volume_write_bytes",
+          :aggregations => {
+            :time => "avg"
+          }
+        }
+      ],
+      :dataSourceType => "host"
+    }
+  end
+
+  def iam_access_token
+    @iam_access_token ||= IBMCloudSdkCore::IAMTokenManager.new(:apikey => ext_management_system.authentication_key("default")).access_token
+  end
+
+  def store_datapoints_with_interpolation!(end_time, timestamps, datapoints, counter_key, counter_values_by_mor)
+    timestamps.zip(datapoints).each do |timestamp, datapoint|
+      counter_values_by_mor.store_path(Time.at(timestamp).utc, counter_key, datapoint)
+
+      # Interpolate data to expected 20 second intervals
+      [timestamp + 20, timestamp + 40].each do |interpolated_ts|
+        # Make sure we don't interpolate past the requested range
+        next if interpolated_ts > end_time
+
+        counter_values_by_mor.store_path(Time.at(interpolated_ts).utc, counter_key, datapoint)
+      end
+    end
+  end
+
+  def consolidate_data(datapoints)
+    dataset = {:timestamps => [], :cpu_usage_rate_average => [], :mem_usage_absolute_average => [], :net_usage_rate_average => [], :disk_usage_rate_average => []}
+    datapoints.each do |datapoint|
+      dataset[:timestamps] << datapoint["t"]
+      dataset[:cpu_usage_rate_average] << datapoint["d"][0]
+      dataset[:mem_usage_absolute_average] << datapoint["d"][1]
+      dataset[:net_usage_rate_average] << (datapoint["d"][2] + datapoint["d"][3]) / 1.kilobyte
+      dataset[:disk_usage_rate_average] << (datapoint["d"][4] + datapoint["d"][5]) / 1.kilobyte
+    end
+
+    dataset
+  end
+end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_collector_worker.rb
@@ -1,0 +1,9 @@
+class ManageIQ::Providers::IbmCloud::VPC::CloudManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
+  require_nested :Runner
+
+  self.default_queue_name = "ibm_cloud_vpc"
+
+  def friendly_name
+    @friendly_name ||= "C&U Metrics Collector for IBM Cloud VPC"
+  end
+end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_collector_worker/runner.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmCloud::VPC::CloudManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
+end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
@@ -45,23 +45,72 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
             :name      => 'endpoints-subform',
             :title     => _("Endpoint"),
             :fields    => [
-              {
-                :component              => 'validate-provider-credentials',
-                :name                   => 'authentications.default.valid',
-                :skipSubmit             => true,
-                :isRequired             => true,
-                :validationDependencies => %w[type zone_id provider_region],
-                :fields                 => [
-                  {
-                    :component  => "password-field",
-                    :name       => "authentications.default.auth_key",
-                    :label      => _("IBM Cloud API Key"),
-                    :type       => "password",
-                    :isRequired => true,
-                    :validate   => [{:type => "required"}]
-                  },
-                ],
-              },
+              :component => 'tabs',
+              :name      => 'tabs',
+              :fields    => [
+                {
+                  :component => 'tab-item',
+                  :id        => 'default-tab',
+                  :name      => 'default-tab',
+                  :title     => _('Default'),
+                  :fields    => [
+                    {
+                      :component              => 'validate-provider-credentials',
+                      :name                   => 'authentications.default.valid',
+                      :skipSubmit             => true,
+                      :isRequired             => true,
+                      :validationDependencies => %w[type zone_id provider_region],
+                      :fields                 => [
+                        {
+                          :component  => "password-field",
+                          :name       => "authentications.default.auth_key",
+                          :label      => _("IBM Cloud API Key"),
+                          :type       => "password",
+                          :isRequired => true,
+                          :validate   => [{:type => "required"}]
+                        },
+                      ],
+                    }
+                  ]
+                },
+                {
+                  :component => 'tab-item',
+                  :id        => 'metrics-tab',
+                  :name      => 'metrics-tab',
+                  :title     => _('Metrics'),
+                  :fields    => [
+                    {
+                      :component    => 'protocol-selector',
+                      :id           => 'metrics_selection',
+                      :name         => 'metrics_selection',
+                      :skipSubmit   => true,
+                      :initialValue => 'none',
+                      :label        => _('Type'),
+                      :options      => [
+                        {
+                          :label => _('Disabled'),
+                          :value => 'none',
+                        },
+                        {
+                          :label => _('Enabled'),
+                          :value => 'enable_metrics',
+                        },
+                      ],
+                    },
+                    {
+                      :component  => 'password-field',
+                      :id         => 'endpoints.metrics.options.monitoring_instance_id',
+                      :name       => 'endpoints.metrics.options.monitoring_instance_id',
+                      :label      => _('IBM Cloud Monitoring Instance GUID'),
+                      :isRequired => true,
+                      :condition  => {
+                        :when => "metrics_selection",
+                        :is   => 'enable_metrics',
+                      },
+                    },
+                  ]
+                }
+              ]
             ],
           },
         ],

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -73,6 +73,8 @@
       :event_catcher_ibm_cloud_iks:
         :poll: 15.seconds
     :queue_worker_base:
+      :ems_metrics_collector_worker:
+        :ems_metrics_collector_worker_vpc: {}
       :ems_refresh_worker:
         :ems_refresh_worker_ibm_cloud_power_virtual_servers: {}
         :ems_refresh_worker_ibm_cloud_vpc: {}

--- a/manageiq-providers-ibm_cloud.gemspec
+++ b/manageiq-providers-ibm_cloud.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ibm_cloud_databases", "~> 0.1"
   spec.add_dependency "ibm_cloud_global_tagging", "~> 0.1"
   spec.add_dependency "ibm_vpc", "~> 0.1"
+  spec.add_dependency "rest-client", "~> 2.1"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov"

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_capture_spec.rb
@@ -1,0 +1,20 @@
+describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::MetricsCapture do
+  let(:ems) do
+    FactoryBot.create(:ems_ibm_cloud_vpc, :provider_region => "ca-tor").tap do |ems|
+      ems.endpoints << FactoryBot.create(:endpoint, :role => "metrics", :options => {"monitoring_instance_id" => "238fa410-548f-4d71-af83-8d8bcd91a122"})
+    end
+  end
+  let(:vm) { FactoryBot.create(:vm_ibm_cloud_vpc, :ext_management_system => ems, :ems_ref => "02r7_822df12d-b78c-4348-85c5-c74b9d31c32f") }
+
+  describe "#perf_collect_metrics" do
+    it "collects metrics" do
+      VCR.use_cassette(described_class.name.underscore) do
+        vm.perf_capture_realtime
+      end
+
+      vm.reload
+
+      expect(vm.metrics.count).to eq(6)
+    end
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_capture.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_capture.yml
@@ -1,0 +1,122 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.cloud.ibm.com/identity/token
+    body:
+      encoding: UTF-8
+      string: grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=OofdoH2oph9nB6RJDN1dnM5RBdc97-tzSE_1A6DQG3JB&response_type=cloud_iam
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept:
+      - application/json
+      Connection:
+      - close
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+      Transaction-Id:
+      - aWFtaWQtNi4xMS0xMjMzNC02YzNkY2JkLTc2NmJiZGZiODgtcHpsZ3Q-408140f2c0f24a1f9e9ae7e159ac9471
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json
+      Content-Language:
+      - en-US
+      Content-Length:
+      - '1553'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Mon, 06 Dec 2021 19:22:50 GMT
+      Connection:
+      - close
+      Set-Cookie:
+      - sessioncookie="a5409b2a80fda932"; Path=/; Secure; HttpOnly
+      Akamai-Grn:
+      - 0.640fd017.1638818570.2098386d
+      X-Proxy-Upstream-Service-Time:
+      - '102'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"eyJraWQiOiIyMDIxMTExNzA4MjAiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC02NjQwMDIyWU5RIiwiaWQiOiJJQk1pZC02NjQwMDIyWU5RIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiOTQ1ZjU4NGEtMjJlYS00N2ZjLWJmYjktNmRhMTIzODcyNzJmIiwiaWRlbnRpZmllciI6IjY2NDAwMjJZTlEiLCJnaXZlbl9uYW1lIjoiTmFzYXIiLCJmYW1pbHlfbmFtZSI6IktoYW4iLCJuYW1lIjoiTmFzYXIgS2hhbiIsImVtYWlsIjoiTmFzYXIuS2hhbkBpYm0uY29tIiwic3ViIjoiTmFzYXIuS2hhbkBpYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiTmFzYXIuS2hhbkBpYm0uY29tIiwiaWFtX2lkIjoiSUJNaWQtNjY0MDAyMllOUSIsIm5hbWUiOiJOYXNhciBLaGFuIiwiZ2l2ZW5fbmFtZSI6Ik5hc2FyIiwiZmFtaWx5X25hbWUiOiJLaGFuIiwiZW1haWwiOiJOYXNhci5LaGFuQGlibS5jb20ifSwiYWNjb3VudCI6eyJib3VuZGFyeSI6Imdsb2JhbCIsInZhbGlkIjp0cnVlLCJic3MiOiJjNTZjOWEyNjhkMjNlMWIzMzlhYzE0Nzc0MzU4MTMzYyIsImltc191c2VyX2lkIjoiOTEyMjA0NiIsImZyb3plbiI6dHJ1ZSwiaW1zIjoiMTE2MDQ0NyJ9LCJpYXQiOjE2Mzg4MTg1NjcsImV4cCI6MTYzODgyMjE2NywiaXNzIjoiaHR0cHM6Ly9pYW0uY2xvdWQuaWJtLmNvbS9pZGVudGl0eSIsImdyYW50X3R5cGUiOiJ1cm46aWJtOnBhcmFtczpvYXV0aDpncmFudC10eXBlOmFwaWtleSIsInNjb3BlIjoiaWJtIG9wZW5pZCIsImNsaWVudF9pZCI6ImRlZmF1bHQiLCJhY3IiOjEsImFtciI6WyJwd2QiXX0.p2D-3BpgbBwqk77EoxW7tbFN6TgcTdrqh3rQrt5RX8JBNiRqCP9Kygdwyg_lhUJa1QdEVhrqPseyIfGZOol9Hq65EJ-kBpzOtNgP4YUK4PxNTMySUCme94HbeTtWY-I6FVdhvCJ8ZcVa5jA4gFMrx0PVygqerwPjTyf2Ox-5jgB3gIoYsY7PEoEcKRN0-dNuEUZbKjargcI9Dgjzl_nWzs6LmEUcyNPxAznFMBpAQI0NLNQJmsn_v8nQk7scYxYbA6FImmSzwiByN_Oa42yR6kCNfEvTkLOc2bWYH1Y7Nt8WqDyL_z-DrQA-fk1lNYdRg4UouZbbEfwEC1BWJP5hWQ","refresh_token":"not_supported","ims_user_id":9122046,"token_type":"Bearer","expires_in":3600,"expiration":1638822167,"scope":"ibm
+        openid"}'
+    http_version:
+  recorded_at: Mon, 06 Dec 2021 19:22:50 GMT
+- request:
+    method: post
+    uri: https://ca-tor.monitoring.cloud.ibm.com/api/data
+    body:
+      encoding: UTF-8
+      string: '{"last":170,"sampling":60,"filter":"ibm_resource_name = ''test123''","metrics":[{"id":"ibm_is_instance_cpu_usage_percentage","aggregations":{"time":"avg"}},{"id":"ibm_is_instance_memory_usage_percentage","aggregations":{"time":"avg"}},{"id":"ibm_is_instance_network_in_bytes","aggregations":{"time":"avg"}},{"id":"ibm_is_instance_network_out_bytes","aggregations":{"time":"avg"}},{"id":"ibm_is_instance_volume_read_bytes","aggregations":{"time":"avg"}},{"id":"ibm_is_instance_volume_write_bytes","aggregations":{"time":"avg"}}],"dataSourceType":"host"}'
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (darwin20 x86_64) ruby/2.7.3p183
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJraWQiOiIyMDIxMTExNzA4MjAiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC02NjQwMDIyWU5RIiwiaWQiOiJJQk1pZC02NjQwMDIyWU5RIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiOTQ1ZjU4NGEtMjJlYS00N2ZjLWJmYjktNmRhMTIzODcyNzJmIiwiaWRlbnRpZmllciI6IjY2NDAwMjJZTlEiLCJnaXZlbl9uYW1lIjoiTmFzYXIiLCJmYW1pbHlfbmFtZSI6IktoYW4iLCJuYW1lIjoiTmFzYXIgS2hhbiIsImVtYWlsIjoiTmFzYXIuS2hhbkBpYm0uY29tIiwic3ViIjoiTmFzYXIuS2hhbkBpYm0uY29tIiwiYXV0aG4iOnsic3ViIjoiTmFzYXIuS2hhbkBpYm0uY29tIiwiaWFtX2lkIjoiSUJNaWQtNjY0MDAyMllOUSIsIm5hbWUiOiJOYXNhciBLaGFuIiwiZ2l2ZW5fbmFtZSI6Ik5hc2FyIiwiZmFtaWx5X25hbWUiOiJLaGFuIiwiZW1haWwiOiJOYXNhci5LaGFuQGlibS5jb20ifSwiYWNjb3VudCI6eyJib3VuZGFyeSI6Imdsb2JhbCIsInZhbGlkIjp0cnVlLCJic3MiOiJjNTZjOWEyNjhkMjNlMWIzMzlhYzE0Nzc0MzU4MTMzYyIsImltc191c2VyX2lkIjoiOTEyMjA0NiIsImZyb3plbiI6dHJ1ZSwiaW1zIjoiMTE2MDQ0NyJ9LCJpYXQiOjE2Mzg4MTg1NjcsImV4cCI6MTYzODgyMjE2NywiaXNzIjoiaHR0cHM6Ly9pYW0uY2xvdWQuaWJtLmNvbS9pZGVudGl0eSIsImdyYW50X3R5cGUiOiJ1cm46aWJtOnBhcmFtczpvYXV0aDpncmFudC10eXBlOmFwaWtleSIsInNjb3BlIjoiaWJtIG9wZW5pZCIsImNsaWVudF9pZCI6ImRlZmF1bHQiLCJhY3IiOjEsImFtciI6WyJwd2QiXX0.p2D-3BpgbBwqk77EoxW7tbFN6TgcTdrqh3rQrt5RX8JBNiRqCP9Kygdwyg_lhUJa1QdEVhrqPseyIfGZOol9Hq65EJ-kBpzOtNgP4YUK4PxNTMySUCme94HbeTtWY-I6FVdhvCJ8ZcVa5jA4gFMrx0PVygqerwPjTyf2Ox-5jgB3gIoYsY7PEoEcKRN0-dNuEUZbKjargcI9Dgjzl_nWzs6LmEUcyNPxAznFMBpAQI0NLNQJmsn_v8nQk7scYxYbA6FImmSzwiByN_Oa42yR6kCNfEvTkLOc2bWYH1Y7Nt8WqDyL_z-DrQA-fk1lNYdRg4UouZbbEfwEC1BWJP5hWQ
+      Ibminstanceid:
+      - 238fa410-548f-4d71-af83-8d8bcd91a122
+      Content-Length:
+      - '550'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 06 Dec 2021 19:22:51 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - INGRESSCOOKIE=1638818572.224.18264.703813; Expires=Tue, 07-Dec-21 19:22:51
+        GMT; Max-Age=86400; Path=/api; Secure; HttpOnly
+      Vary:
+      - Accept-Encoding, User-Agent
+      - Access-Control-Request-Headers
+      - Access-Control-Request-Method
+      - Origin
+      X-Sysdig-Req:
+      - mp47e:c0
+      X-Draios-Api-Version:
+      - 5.1.0.10711
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":[{"t":1638818460,"d":[0,1.718254,6734946,6292204,4.9565013333334E7,546062336]},{"t":1638818520,"d":[0.054104,1.717754,6735898,6293098,4.9565013333334E7,5.46088277333334E8]}],"start":1638818400,"end":1638818520}'
+    http_version:
+  recorded_at: Mon, 06 Dec 2021 19:22:51 GMT
+recorded_with: VCR 5.1.0

--- a/systemd/manageiq-providers-ibm_cloud_vpc_cloud_manager_metrics_collector.target
+++ b/systemd/manageiq-providers-ibm_cloud_vpc_cloud_manager_metrics_collector.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=manageiq.target

--- a/systemd/manageiq-providers-ibm_cloud_vpc_cloud_manager_metrics_collector@.service
+++ b/systemd/manageiq-providers-ibm_cloud_vpc_cloud_manager_metrics_collector@.service
@@ -1,0 +1,13 @@
+[Unit]
+PartOf=manageiq-providers-ibm_cloud_vpc_cloud_manager_metrics_collector.target
+[Install]
+WantedBy=manageiq-providers-ibm_cloud_vpc_cloud_manager_metrics_collector.target
+[Service]
+WorkingDirectory=/var/www/miq/vmdb
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::IbmCloud::VPC::CloudManager::MetricsCollectorWorker --heartbeat --guid=%i
+User=manageiq
+Restart=no
+Type=notify
+Slice=manageiq-providers-ibm_cloud_vpc_cloud_manager_metrics_collector.slice


### PR DESCRIPTION
- added the ability to capture metrics for the IBM Cloud VPC provider
<img width="1138" alt="Screen Shot 2021-11-30 at 6 11 54 PM" src="https://user-images.githubusercontent.com/48186199/144257080-7ecc4c54-0df8-4fdc-9ace-0109c65c7155.png">

Documentation PR:
- https://github.com/ManageIQ/manageiq-documentation/pull/1620

Depends on:
- https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/263

@miq-bot add_label enhancement
@miq-bot assign @agrare 