### PR TITLE
IKS Metrics Capture

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/container_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager.rb
@@ -7,6 +7,8 @@ class ManageIQ::Providers::IbmCloud::ContainerManager < ManageIQ::Providers::Kub
   require_nested :ContainerTemplate
   require_nested :EventCatcher
   require_nested :EventParser
+  require_nested :MetricsCapture
+  require_nested :MetricsCollectorWorker
   require_nested :Refresher
   require_nested :RefreshWorker
   require_nested :ServiceInstance
@@ -14,6 +16,16 @@ class ManageIQ::Providers::IbmCloud::ContainerManager < ManageIQ::Providers::Kub
   require_nested :ServiceParametersSet
 
   supports :create
+
+  METRICS_ROLES = %w[prometheus].freeze
+
+  supports :metrics do
+    unsupported_reason_add(:metrics, _("No metrics endpoint has been added")) unless metrics_endpoint_exists?
+  end
+
+  def metrics_endpoint_exists?
+    endpoints.where(:role => METRICS_ROLES).exists?
+  end
 
   def self.ems_type
     @ems_type ||= "iks".freeze
@@ -42,9 +54,10 @@ class ManageIQ::Providers::IbmCloud::ContainerManager < ManageIQ::Providers::Kub
   end
 
   def self.verify_credentials(args)
-    default_endpoint = args.dig("endpoints", "default")
-    hostname, port, security_protocol, certificate_authority = default_endpoint&.values_at(
-      "hostname", "port", "security_protocol", "certificate_authority"
+    endpoint_name = args.dig("endpoints").keys.first
+    endpoint = args.dig("endpoints", endpoint_name)
+    hostname, port, security_protocol, certificate_authority, endpoint_options = endpoint&.values_at(
+      "hostname", "port", "security_protocol", "certificate_authority", "options"
     )
 
     api_key = ManageIQ::Password.try_decrypt(args.dig("authentications", "bearer", "auth_key"))
@@ -63,8 +76,16 @@ class ManageIQ::Providers::IbmCloud::ContainerManager < ManageIQ::Providers::Kub
         :cert_store => cert_store
       }
     }
+    options[:instance_id] = endpoint_options["monitoring_instance_id"] unless endpoint_options.nil?
 
-    !!raw_connect(hostname, port, options)
+    case endpoint_name
+    when 'default'
+      !!raw_connect(hostname, port, options)
+    when 'prometheus'
+      !!prometheus_connect(hostname, port, options)
+    else
+      raise MiqException::MiqInvalidCredentialsError, _("Unsupported endpoint")
+    end
   end
 
   def self.get_token(api_key)
@@ -84,6 +105,30 @@ class ManageIQ::Providers::IbmCloud::ContainerManager < ManageIQ::Providers::Kub
     _log.error("IAM authentication failed: #{err.code} #{error_message}")
   end
 
+  def self.prometheus_connect(hostname, port, options)
+    require 'prometheus/api_client'
+
+    uri = raw_api_endpoint(hostname, port, "/prometheus").to_s
+    headers = {
+      :Authorization => "Bearer #{IBMCloudSdkCore::IAMTokenManager.new(:apikey => options[:api_key]).access_token}",
+      :IBMInstanceID => options[:instance_id]
+    }
+    ssl_options = options[:ssl_options] || {:verify_ssl => OpenSSL::SSL::VERIFY_NONE}
+
+    prometheus_options = {
+      :http_proxy_uri => options[:http_proxy] || VMDB::Util.http_proxy_uri.to_s,
+      :verify_ssl     => ssl_options[:verify_ssl],
+      :ssl_cert_store => ssl_options[:ca_file],
+    }
+
+    Prometheus::ApiClient.client(:url => uri, :headers => headers, :options => prometheus_options)&.query(:query => "ALL")&.kind_of?(Hash)
+  end
+
+  def verify_prometheus_credentials
+    client = ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCapture::PrometheusClient.new(self)
+    client.prometheus_try_connect
+  end
+
   def self.params_for_create
     {
       :fields => [
@@ -93,78 +138,220 @@ class ManageIQ::Providers::IbmCloud::ContainerManager < ManageIQ::Providers::Kub
           :id        => 'endpoints-subform',
           :title     => _("Endpoints"),
           :fields    => [
-            {
-              :component              => 'validate-provider-credentials',
-              :id                     => 'authentications.bearer.valid',
-              :name                   => 'authentications.bearer.valid',
-              :skipSubmit             => true,
-              :isRequired             => true,
-              :validationDependencies => %w[type zone_id provider_region realm uid_ems],
-              :fields                 => [
-                {
-                  :component    => "select",
-                  :id           => "endpoints.default.security_protocol",
-                  :name         => "endpoints.default.security_protocol",
-                  :label        => _("Security Protocol"),
-                  :isRequired   => true,
-                  :validate     => [{:type => "required"}],
-                  :initialValue => 'ssl-with-validation',
-                  :options      => [
-                    {
-                      :label => _("SSL"),
-                      :value => "ssl-with-validation"
-                    },
-                    {
-                      :label => _("SSL trusting custom CA"),
-                      :value => "ssl-with-validation-custom-ca"
-                    },
-                    {
-                      :label => _("SSL without validation"),
-                      :value => "ssl-without-validation",
-                    },
-                  ]
-                },
-                {
-                  :component  => "text-field",
-                  :id         => "endpoints.default.hostname",
-                  :name       => "endpoints.default.hostname",
-                  :label      => _("Hostname (or IPv4 or IPv6 address)"),
-                  :isRequired => true,
-                  :validate   => [{:type => "required"}],
-                },
-                {
-                  :component  => "text-field",
-                  :id         => "endpoints.default.port",
-                  :name       => "endpoints.default.port",
-                  :label      => _("API Port"),
-                  :type       => "number",
-                  :isRequired => true,
-                  :validate   => [{:type => "required"}],
-                },
-                {
-                  :component  => "textarea",
-                  :id         => "endpoints.default.certificate_authority",
-                  :name       => "endpoints.default.certificate_authority",
-                  :label      => _("Trusted CA Certificates"),
-                  :rows       => 10,
-                  :isRequired => true,
-                  :validate   => [{:type => "required"}],
-                  :condition  => {
-                    :when => 'endpoints.default.security_protocol',
-                    :is   => 'ssl-with-validation-custom-ca',
+            :component => 'tabs',
+            :name      => 'tabs',
+            :fields    => [
+              {
+                :component => 'tab-item',
+                :id        => 'default-tab',
+                :name      => 'default-tab',
+                :title     => _('Default'),
+                :fields    => [
+                  {
+                    :component              => 'validate-provider-credentials',
+                    :id                     => 'authentications.bearer.valid',
+                    :name                   => 'authentications.bearer.valid',
+                    :skipSubmit             => true,
+                    :isRequired             => true,
+                    :validationDependencies => %w[type zone_id provider_region realm uid_ems],
+                    :fields                 => [
+                      {
+                        :component    => "select",
+                        :id           => "endpoints.default.security_protocol",
+                        :name         => "endpoints.default.security_protocol",
+                        :label        => _("Security Protocol"),
+                        :isRequired   => true,
+                        :validate     => [{:type => "required"}],
+                        :initialValue => 'ssl-with-validation',
+                        :options      => [
+                          {
+                            :label => _("SSL"),
+                            :value => "ssl-with-validation"
+                          },
+                          {
+                            :label => _("SSL trusting custom CA"),
+                            :value => "ssl-with-validation-custom-ca"
+                          },
+                          {
+                            :label => _("SSL without validation"),
+                            :value => "ssl-without-validation",
+                          },
+                        ]
+                      },
+                      {
+                        :component  => "text-field",
+                        :id         => "endpoints.default.hostname",
+                        :name       => "endpoints.default.hostname",
+                        :label      => _("Hostname (or IPv4 or IPv6 address)"),
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}],
+                      },
+                      {
+                        :component  => "text-field",
+                        :id         => "endpoints.default.port",
+                        :name       => "endpoints.default.port",
+                        :label      => _("API Port"),
+                        :type       => "number",
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}],
+                      },
+                      {
+                        :component  => "textarea",
+                        :id         => "endpoints.default.certificate_authority",
+                        :name       => "endpoints.default.certificate_authority",
+                        :label      => _("Trusted CA Certificates"),
+                        :rows       => 10,
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}],
+                        :condition  => {
+                          :when => 'endpoints.default.security_protocol',
+                          :is   => 'ssl-with-validation-custom-ca',
+                        },
+                      },
+                      {
+                        :component  => "password-field",
+                        :id         => "authentications.bearer.auth_key",
+                        :name       => "authentications.bearer.auth_key",
+                        :label      => _("IBM Cloud API Key"),
+                        :type       => "password",
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}]
+                      }
+                    ],
                   },
-                },
-                {
-                  :component  => "password-field",
-                  :id         => "authentications.bearer.auth_key",
-                  :name       => "authentications.bearer.auth_key",
-                  :label      => _("IBM Cloud API Key"),
-                  :type       => "password",
-                  :isRequired => true,
-                  :validate   => [{:type => "required"}]
-                }
-              ],
-            },
+                ],
+              },
+              {
+                :component => 'tab-item',
+                :id        => 'metrics-tab',
+                :name      => 'metrics-tab',
+                :title     => _('Metrics'),
+                :fields    => [
+                  {
+                    :component    => 'protocol-selector',
+                    :id           => 'metrics_selection',
+                    :name         => 'metrics_selection',
+                    :skipSubmit   => true,
+                    :initialValue => 'none',
+                    :label        => _('Type'),
+                    :options      => [
+                      {
+                        :label => _('Disabled'),
+                        :value => 'none',
+                      },
+                      {
+                        :label => _('Prometheus'),
+                        :value => 'prometheus',
+                        :pivot => 'endpoints.prometheus.hostname',
+                      },
+                    ],
+                  },
+                  {
+                    :component              => 'validate-provider-credentials',
+                    :id                     => "authentications.prometheus.valid",
+                    :name                   => "authentications.prometheus.valid",
+                    :skipSubmit             => true,
+                    :isRequired             => true,
+                    :validationDependencies => ['type', "metrics_selection", "authentications.bearer.auth_key"],
+                    :condition              => {
+                      :when => "metrics_selection",
+                      :is   => 'prometheus',
+                    },
+                    :fields                 => [
+                      {
+                        :component    => "select",
+                        :id           => "endpoints.prometheus.security_protocol",
+                        :name         => "endpoints.prometheus.security_protocol",
+                        :label        => _("Security Protocol"),
+                        :isRequired   => true,
+                        :initialValue => 'ssl-with-validation',
+                        :validate     => [{:type => "required"}],
+                        :options      => [
+                          {
+                            :label => _("SSL"),
+                            :value => "ssl-with-validation"
+                          },
+                          {
+                            :label => _("SSL trusting custom CA"),
+                            :value => "ssl-with-validation-custom-ca"
+                          },
+                          {
+                            :label => _("SSL without validation"),
+                            :value => "ssl-without-validation"
+                          },
+                        ]
+                      },
+                      {
+                        :component  => "text-field",
+                        :id         => "endpoints.prometheus.hostname",
+                        :name       => "endpoints.prometheus.hostname",
+                        :label      => _("Hostname (or IPv4 or IPv6 address)"),
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}],
+                        :inputAddon => {
+                          :after => {
+                            :fields => [
+                              {
+                                :component => 'input-addon-button-group',
+                                :id        => 'detect-prometheus-group',
+                                :name      => 'detect-prometheus-group',
+                                :fields    => [
+                                  {
+                                    :component    => 'detect-button',
+                                    :id           => 'detect-prometheus-button',
+                                    :name         => 'detect-prometheus-button',
+                                    :label        => _('Detect'),
+                                    :dependencies => [
+                                      'endpoints.default.hostname',
+                                      'endpoints.default.port',
+                                      'endpoints.default.security_protocol',
+                                      'endpoints.default.certificate_authority',
+                                      'authentications.bearer.auth_key',
+                                    ],
+                                    :target       => 'endpoints.prometheus',
+                                  },
+                                ],
+                              }
+                            ],
+                          },
+                        },
+                      },
+                      {
+                        :component    => "text-field",
+                        :id           => "endpoints.prometheus.port",
+                        :name         => "endpoints.prometheus.port",
+                        :label        => _("API Port"),
+                        :type         => "number",
+                        :initialValue => 443,
+                        :isRequired   => true,
+                        :validate     => [{:type => "required"}],
+                      },
+                      {
+                        :component  => "textarea",
+                        :id         => "endpoints.prometheus.certificate_authority",
+                        :name       => "endpoints.prometheus.certificate_authority",
+                        :label      => _("Trusted CA Certificates"),
+                        :rows       => 10,
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}],
+                        :condition  => {
+                          :when => 'endpoints.prometheus.security_protocol',
+                          :is   => 'ssl-with-validation-custom-ca',
+                        },
+                      },
+                      {
+                        :component  => 'password-field',
+                        :id         => 'endpoints.prometheus.options.monitoring_instance_id',
+                        :name       => 'endpoints.prometheus.options.monitoring_instance_id',
+                        :label      => _('IBM Cloud Monitoring Instance GUID'),
+                        :isRequired => true,
+                        :validate   => [{:type => "required"}],
+                      },
+                    ]
+                  },
+                ]
+              },
+            ]
           ]
         },
         {

--- a/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_capture.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCapture < ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
+  require_nested :PrometheusCaptureContext
+
+  def prometheus_capture_context(target, start_time, end_time)
+    ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCapture::PrometheusCaptureContext.new(target, start_time, end_time, INTERVAL)
+  end
+end

--- a/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_capture/prometheus_capture_context.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_capture/prometheus_capture_context.rb
@@ -1,0 +1,105 @@
+class ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCapture::PrometheusCaptureContext < ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::PrometheusCaptureContext
+  def initialize(target, start_time, end_time, interval)
+    @target = target
+    @starts = start_time.to_i.in_milliseconds
+    @ends = end_time.to_i.in_milliseconds if end_time
+    @interval = interval.to_i
+    @tenant = target.try(:container_project).try(:name) || '_system'
+    @ext_management_system = @target.ext_management_system
+    @ts_values = Hash.new { |h, k| h[k] = {} }
+    @metrics = []
+
+    @node_hardware = if @target.respond_to?(:hardware)
+                       @target.hardware
+                     else
+                       @target.try(:container_node).try(:hardware)
+                     end
+
+    @node_cores = @node_hardware.try(:cpu_total_cores)
+    @node_memory = @node_hardware.try(:memory_mb)
+
+    validate_target
+  end
+
+  def collect_node_metrics
+    # set node labels
+    labels = labels_to_s(:kube_node_name => @target.name)
+
+    @metrics = %w(cpu_usage_rate_average mem_usage_absolute_average net_usage_rate_average)
+    collect_metrics_for_labels(labels)
+  end
+
+  def collect_container_metrics
+    # set container labels
+    labels = labels_to_s(
+      :container_name      => @target.name,
+      :kube_pod_name       => @target.container_group.name,
+      :kube_namespace_name => @target.container_project.name,
+    )
+
+    @metrics = %w(cpu_usage_rate_average mem_usage_absolute_average)
+    collect_metrics_for_labels(labels)
+  end
+
+  def collect_group_metrics
+    # set pod labels
+
+    labels = labels_to_s(
+      :kube_pod_name       => @target.name,
+      :kube_namespace_name => @target.container_project.name,
+    )
+
+    @metrics = %w(cpu_usage_rate_average mem_usage_absolute_average net_usage_rate_average)
+    collect_metrics_for_labels(labels)
+  end
+
+  def collect_metrics_for_labels(labels)
+    # promQL field is in pct of cpu cores
+    # miq field is in pct of node cpu
+    cpu_resid = "sum(sysdig_container_cpu_cores_used_percent{#{labels}})"
+    fetch_counters_data(cpu_resid, 'cpu_usage_rate_average')
+
+    # promQL field is in bytes, @node_memory is in mb
+    # miq field is in pct of node memory
+    mem_resid = "sum(sysdig_container_memory_used_bytes{#{labels}})"
+    fetch_counters_data(mem_resid, 'mem_usage_absolute_average', @node_memory * 1e6 / 100.0)
+
+    # promQL field is in bytes
+    # miq field is on kb ( / 1000 )
+    if @metrics.include?('net_usage_rate_average')
+      net_resid = "sum(rate(sysdig_container_net_in_bytes{#{labels}}[#{AVG_OVER}])) + " \
+                  "sum(rate(sysdig_container_net_out_bytes{#{labels}}[#{AVG_OVER}]))"
+      fetch_counters_data(net_resid, 'net_usage_rate_average', 1000.0)
+    end
+
+    @ts_values
+  end
+
+  def fetch_counters_data(resource, metric_title, conversion_factor = 1)
+    start_sec = (@starts / 1_000) - @interval
+    end_sec = @ends ? (@ends / 1_000).to_i : Time.now.utc.to_i
+
+    sort_and_normalize(
+      prometheus_client.query_range(
+        :query => resource,
+        :start => start_sec.to_i,
+        :end   => end_sec,
+        :step  => "#{@interval}s"
+      ),
+      metric_title,
+      conversion_factor
+    )
+  rescue NoMetricsFoundError
+    raise
+  rescue StandardError => e
+    raise CollectionFailure, "#{e.class.name}: #{e.message}"
+  end
+
+  def labels_to_s(labels)
+    labels.compact.sort.map { |k, v| "#{k}=\"#{v}\"" }.join(',')
+  end
+
+  def prometheus_client
+    @prometheus_client ||= ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCapture::PrometheusClient.new(@ext_management_system).prometheus_client
+  end
+end

--- a/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_capture/prometheus_client.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_capture/prometheus_client.rb
@@ -1,0 +1,33 @@
+class ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCapture::PrometheusClient < ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::PrometheusClient
+
+  def prometheus_client
+    @prometheus_uri ||= prometheus_uri
+    @prometheus_headers ||= prometheus_headers
+    @prometheus_options ||= prometheus_options
+
+    prometheus_client_new(@prometheus_uri, @prometheus_headers, @prometheus_options)
+  end
+
+  def prometheus_client_new(uri, headers, options)
+    Prometheus::ApiClient.client(
+      :url     => uri.to_s,
+      :options => options,
+      :headers => headers
+    )
+  end
+
+  def prometheus_uri
+    URI::HTTPS.build(
+      :host => prometheus_endpoint.hostname,
+      :port => prometheus_endpoint.port,
+      :path => "/prometheus"
+    )
+  end
+
+  def prometheus_headers
+    {
+      :Authorization => "Bearer #{IBMCloudSdkCore::IAMTokenManager.new(:apikey => @ext_management_system.authentication_key("prometheus")).access_token}",
+      :IBMInstanceID => prometheus_endpoint.options["monitoring_instance_id"]
+    }
+  end
+end

--- a/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_collector_worker.rb
@@ -1,0 +1,21 @@
+class ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
+  require_nested :Runner
+
+  self.default_queue_name = "iks"
+
+  def friendly_name
+    @friendly_name ||= "C&U Metrics Collector for IKS"
+  end
+
+  def self.emses_in_zone
+    super.select do |ems|
+      ems.supports_metrics?.tap do |supported|
+        _log.info("Skipping [#{ems.name}] since it has no metrics endpoint") unless supported
+      end
+    end
+  end
+
+  def self.settings_name
+    :ems_metrics_collector_worker_ibm_cloud_iks
+  end
+end

--- a/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_collector_worker/runner.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -83,9 +83,12 @@
         :poll: 15.seconds
       :event_catcher_ibm_cloud_iks:
         :poll: 15.seconds
+      :event_catcher_prometheus:
+        :poll: 20.seconds
     :queue_worker_base:
       :ems_metrics_collector_worker:
         :ems_metrics_collector_worker_vpc: {}
+        :ems_metrics_collector_worker_ibm_cloud_iks: {}
       :ems_refresh_worker:
         :ems_refresh_worker_ibm_cloud_power_virtual_servers: {}
         :ems_refresh_worker_ibm_cloud_vpc: {}

--- a/manageiq-providers-ibm_cloud.gemspec
+++ b/manageiq-providers-ibm_cloud.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ibm_cloud_databases", "~> 0.1"
   spec.add_dependency "ibm_cloud_global_tagging", "~> 0.1"
   spec.add_dependency "ibm_vpc", "~> 0.1"
+  spec.add_dependency "prometheus-api-client", "~> 0.6"
   spec.add_dependency "rest-client", "~> 2.1"
 
   spec.add_development_dependency "manageiq-style"

--- a/systemd/manageiq-providers-ibm_cloud_container_manager_metrics_collector.target
+++ b/systemd/manageiq-providers-ibm_cloud_container_manager_metrics_collector.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=manageiq.target

--- a/systemd/manageiq-providers-ibm_cloud_container_manager_metrics_collector@.service
+++ b/systemd/manageiq-providers-ibm_cloud_container_manager_metrics_collector@.service
@@ -1,0 +1,13 @@
+[Unit]
+PartOf=manageiq-providers-ibm_cloud_container_manager_metrics_collector.target
+[Install]
+WantedBy=manageiq-providers-ibm_cloud_container_manager_metrics_collector.target
+[Service]
+WorkingDirectory=/var/www/miq/vmdb
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCollectorWorker --heartbeat --guid=%i
+User=manageiq
+Restart=no
+Type=notify
+Slice=manageiq-providers-ibm_cloud_container_manager_metrics_collector.slice


### PR DESCRIPTION
- added the ability to capture metrics for the IKS container provider
- IBM Cloud Monitoring service uses Sysdig PromQL queries (https://docs.sysdig.com/en/docs/sysdig-monitor/metrics-dictionary/metrics-and-label-mapping/mapping-classic-metrics-with-promql-metrics/)

<img width="1523" alt="Screen Shot 2022-01-20 at 5 16 55 PM" src="https://user-images.githubusercontent.com/48186199/150431009-ac9b5de3-529f-4bae-bbd9-9adebc84be9b.png">

Documentation PR:
- https://github.com/ManageIQ/manageiq-documentation/pull/1635

Note:
- There is a bug at the moment related to dashboards in the UI, see https://github.com/ManageIQ/manageiq-ui-classic/issues/8068

Reference:
- https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/314

@miq-bot add_label enhancement
@miq-bot assign @agrare 