### PR TITLE
Hooking up Create Snapshot action to backend logic

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
+  include_concern 'Operations'
+
   supports :terminate
   supports :reboot_guest do
     unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
@@ -7,6 +9,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
     unsupported_reason_add(:reset, _("The VM is not powered on")) unless current_state == "on"
   end
   supports :snapshots
+  supports :snapshot_create
 
   supports_not :suspend
 
@@ -36,6 +39,36 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
     with_provider_connection(:service => 'PCloudPVMInstancesApi') do |api|
       api.pcloud_pvminstances_delete(cloud_instance_id, ems_ref)
     end
+  end
+
+  def params_for_create_snapshot
+    {
+      :fields => [
+        {
+          :component  => 'text-field',
+          :name       => 'name',
+          :id         => 'name',
+          :label      => _('Name'),
+          :isRequired => true,
+          :validate   => [
+            {
+              :type => 'required',
+            },
+            {
+              :type    => 'pattern',
+              :pattern => '^[a-zA-Z][a-zA-Z0-9_-]*$',
+              :message => _('Must contain only alphanumeric, hyphen, and underscore characters'),
+            }
+          ],
+        },
+        {
+          :component => 'textarea',
+          :name      => 'description',
+          :id        => 'description',
+          :label     => _('Description'),
+        },
+      ],
+    }
   end
 
   def self.calculate_power_state(raw_power_state)

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm/operations.rb
@@ -1,0 +1,18 @@
+module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm::Operations
+  extend ActiveSupport::Concern
+
+  def raw_create_snapshot(name, desc = nil, _memory = nil)
+    with_provider_connection(:service => 'PCloudPVMInstancesApi') do |api|
+      req = IbmCloudPower::SnapshotCreate.new(
+        {
+          :name        => name,
+          :description => desc,
+        }
+      )
+      api.pcloud_pvminstances_snapshots_post(cloud_instance_id, ems_ref, req)
+    end
+  rescue => err
+    create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "create")
+    raise MiqException::MiqVmSnapshotError, err.to_s
+  end
+end


### PR DESCRIPTION
Hooking up "Create a new snapshot for this instance" (on a VM in PowerVS) menu action to the backend logic. 

Also being added a little "name" validation logic that's drawn from API response;
![image](https://user-images.githubusercontent.com/1767126/151263522-67201e1b-1e9f-4c7a-a806-bc7eeafb9319.png)


Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>