### PR TITLE
Update PowerVS VM provision dialog name/description

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
   end
 
   def self.default_dialog_file
-    'miq_provision_ibm_dialogs_template'
+    'miq_provision_ibm_powervs_vm_dialog'
   end
 
   def get_timezones(_options = {})

--- a/content/miq_dialogs/miq_provision_ibm_powervs_vm_dialog.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_powervs_vm_dialog.yaml
@@ -1,6 +1,6 @@
 ---
-:name: miq_provision_ibm_dialogs_template
-:description: Sample VM Provisioning Dialog
+:name: miq_provision_ibm_powervs_vm_dialog
+:description: IBM PowerVS VM Provisioning Dialog
 :dialog_type: MiqProvisionWorkflow
 :content:
   :buttons:


### PR DESCRIPTION
This VM provisioning dialog can be viewed through the Automation >
Embedded Automate > Customization > Provisioning Dialogs. The new
description is consistent with IBM Power HMC dialogs.

Screenshot of the Automate view I'm referencing:
![image](https://user-images.githubusercontent.com/1637291/150975676-c5e63da5-d266-46f6-ab9e-728991de0fe4.png)
