### PR TITLE
Wiring delete a snapshot & all snapshots to backend

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -10,6 +10,8 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
   end
   supports :snapshots
   supports :snapshot_create
+  supports :remove_snapshot
+  supports :remove_all_snapshots
 
   supports_not :suspend
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm/operations.rb
@@ -15,4 +15,28 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm::Ope
     create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "create")
     raise MiqException::MiqVmSnapshotError, err.to_s
   end
+
+  def raw_remove_snapshot(snapshot_id)
+    with_provider_connection(:service => 'PCloudSnapshotsApi') do |api|
+      snapshot = Snapshot.find(snapshot_id)
+      api.pcloud_cloudinstances_snapshots_delete(cloud_instance_id, snapshot.uid_ems)
+    end
+  rescue => err
+    create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "delete")
+    raise MiqException::MiqVmSnapshotError, err.to_s
+  end
+
+  def raw_remove_all_snapshots
+    with_provider_connection(:service => 'PCloudSnapshotsApi') do |api|
+      snapshots.each do |snapshot|
+        api.pcloud_cloudinstances_snapshots_delete(cloud_instance_id, snapshot.uid_ems)
+      rescue => err
+        create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "delete")
+        raise MiqException::MiqVmSnapshotError, err.to_s
+      end
+    end
+  rescue => err
+    create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "delete")
+    raise MiqException::MiqVmSnapshotError, err.to_s
+  end
 end


### PR DESCRIPTION
Hooking up delete a selected snapshot and all snapshots of a VM in PowerVS to the backend. Since there is no "delete all" API on PowerVS, this implementation queries and loops through all known snapshots of the VM with the "delete single snapshot" API. When there is an error, it'd post the error, and keep going for every snapshot in the list.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>