### PR TITLE
Hooking up Snapshot restore action to backend

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -10,6 +10,9 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
   end
   supports :snapshots
   supports :snapshot_create
+  supports :revert_to_snapshot do
+    unsupported_reason_add(:revert_to_snapshot, _("Cannot revert to snapshot while VM is running")) unless current_state == "off"
+  end
   supports :remove_snapshot
   supports :remove_all_snapshots
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm/operations.rb
@@ -16,6 +16,17 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm::Ope
     raise MiqException::MiqVmSnapshotError, err.to_s
   end
 
+  def raw_revert_to_snapshot(snapshot_id)
+    with_provider_connection(:service => 'PCloudPVMInstancesApi') do |api|
+      snapshot = Snapshot.find(snapshot_id)
+      req = IbmCloudPower::SnapshotRestore.new({:force => false}) # would not force restore, if VM is not shut down
+      api.pcloud_pvminstances_snapshots_restore_post(cloud_instance_id, ems_ref, snapshot.uid_ems, req)
+    end
+  rescue => err
+    create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "restore")
+    raise MiqException::MiqVmSnapshotError, err.to_s
+  end
+
   def raw_remove_snapshot(snapshot_id)
     with_provider_connection(:service => 'PCloudSnapshotsApi') do |api|
       snapshot = Snapshot.find(snapshot_id)


### PR DESCRIPTION
With the proposed change in place, I can restore the VM to the selected snapshot, if the VM is shut down in advance. The restore operation would fail, if the VM is up (because I chose not to "force" it), and the returned error message from PowerVS is a bit cryptic. Thus, decided to check the `power_state` proactively and `raise` an error with a better message which the user would find in the Notification panel. It basically works, but I get the same notification 2 or 3 times. Is there a better way that'd generate only one such notification?

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>