### PR TITLE
Add ActiveSupport inflection rule for PowerVS

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,6 @@
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.singular(/PowerVirtualServers$/, 'PowerVirtualServers')
+  inflect.plural(/PowerVirtualServers$/, 'PowerVirtualServers')
+  inflect.singular(/power_virtual_servers$/, 'power_virtual_servers')
+  inflect.plural(/power_virtual_servers$/, 'power_virtual_servers')
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,0 +1,3 @@
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.singular(/PowerVirtualServers$/, 'PowerVirtualServers')
+end

--- a/spec/initializers/as_inflections_spec.rb
+++ b/spec/initializers/as_inflections_spec.rb
@@ -1,0 +1,10 @@
+describe String, "inflections" do
+  [
+    "PowerVirtualServers",
+    "power_virtual_servers"
+  ].each do |name|
+    example("#pluralize")   { expect(name.pluralize).to eq(name) }
+    example("#singularize") { expect(name.singularize).to eq(name) }
+    example("#classify")    { expect(name.classify).to eq("PowerVirtualServers") }
+  end
+end


### PR DESCRIPTION
Thanks to @Fryguy for telling me about inflections:
https://github.com/ManageIQ/manageiq/pull/21697#issuecomment-1036702555

The IBM Power IaaS is officially named "IBM Power Systems Virtual
Servers". We've morphed this product name into our class name as
"PowerVirtualServers", which breaks the rails convention of using
singular class names.

To fix this, we can add an inflection rule defining the singular of
"PowerVirtualServers" to be itself, "PowerVirtualServers". With this now
singular and classify methods work:

```ruby
irb(main):001:0> 'IbmCloud::PowerVirtualServers'.singularize
=> "IbmCloud::PowerVirtualServers"
irb(main):002:0> 'IbmCloud::PowerVirtualServers'.classify
=> "IbmCloud::PowerVirtualServers"
```