### PR TITLE
Saving volume type name as description as well for UI

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
@@ -290,9 +290,10 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
     # get only the active storage
     collector.storage_types.storage_types_capacity.each do |v|
       persister.cloud_volume_types.build(
-        :type    => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudVolumeType",
-        :ems_ref => v.storage_type,
-        :name    => v.storage_type
+        :type        => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudVolumeType",
+        :ems_ref     => v.storage_type,
+        :name        => v.storage_type,
+        :description => v.storage_type
       )
     end
   end

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -46,6 +46,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
         assert_specific_cloud_subnet
         assert_specific_network_port
         assert_specific_cloud_volume
+        assert_volume_type_attribs
       end
     end
 
@@ -237,6 +238,14 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
         :status      => volume_data['volume_status'],
         :volume_type => volume_data['pi_volume_type']
       )
+    end
+
+    def assert_volume_type_attribs
+      voltypes = ems.storage_manager.cloud_volume_types
+      voltypes.each do |vtype|
+        expect(vtype[:name].length).to be > 0
+        expect(vtype[:description].length).to be > 0
+      end
     end
 
     def full_refresh(ems)


### PR DESCRIPTION
While testing for Najdorf release, I noticed the "Cloud Volume Types" dropdown for a Storage Manager in PowerVS shows blank choices. The number of choices is correct, but you can't tell what. This is because UI is showing `description` values from the `cloud_volume_types` table, while the inventory code doesn't populate them. 

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>