### PR TITLE
Fix IBM Cloud Activity Tracker gem

### DIFF
--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/activity_tracker.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/activity_tracker.rb
@@ -13,6 +13,8 @@ module ManageIQ
 
           # Return a new Activty Tracker SDK instance.
           def sdk_client
+            require 'ibm_cloud_activity_tracker'
+
             @sdk_params[:authenticator] = @cloudtools.authenticator
             @sdk_client ||= IbmCloudActivityTracker::ActivityTrackerApiV1.new(@sdk_params)
           end

--- a/manageiq-providers-ibm_cloud.gemspec
+++ b/manageiq-providers-ibm_cloud.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ibm_cloud_power", "~> 1.1", ">= 1.1.1"
   spec.add_dependency "ibm_cloud_resource_controller", "~> 2.0"
   spec.add_dependency "ibm-cloud-sdk", "~> 0.1"
-  spec.add_dependency "ibm_cloud_activity_tracker", "~> 0.1"
+  spec.add_dependency "ibm_cloud_activity_tracker", "~> 0.1", ">= 0.1.1"
   spec.add_dependency "ibm_cloud_databases", "~> 0.1"
   spec.add_dependency "ibm_cloud_global_tagging", "~> 0.1"
   spec.add_dependency "ibm_vpc", "~> 0.1"


### PR DESCRIPTION
There was an issue with the `ibm_cloud_activity_tracker` gem not being initialized which is now resolved.

@miq-bot assign @agrare 
@miq-bot add_label bug