### PR TITLE
Affinity setting to drive fields on New Volume form

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
@@ -37,19 +37,6 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
           :validate   => [{:type => 'required'}, {:type => 'min-number-value', :value => 0, :message => _('Size must be greater than or equal to 0')}],
         },
         {
-          :component    => 'select',
-          :name         => 'volume_type',
-          :id           => 'volume_type',
-          :label        => _('Cloud Volume Type'),
-          :includeEmpty => true,
-          :options      => ems.cloud_volume_types.map do |cvt|
-            {
-              :label => cvt.description,
-              :value => cvt.name,
-            }
-          end,
-        },
-        {
           :component => 'switch',
           :name      => 'multi_attachment',
           :id        => 'multi_attachment',
@@ -83,19 +70,34 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
           :name         => 'affinity_volume_id',
           :id           => 'affinity_volume_id',
           :label        => _('Affinity Volume'),
-          :isRequired   => true,
           :validate     => [{:type => 'required'}],
-          :includeEmpty => true,
           :condition    => {
-            :not => {
-              :when => 'affinity_policy',
-              :is   => 'Off',
-            },
+            :when    => 'affinity_policy',
+            :pattern => 'affinity$',
           },
+          :includeEmpty => true,
           :options      => ems.cloud_volumes.map do |cv|
             {
               :value => cv.name,
               :label => cv.name,
+            }
+          end,
+        },
+        {
+          :component    => 'select',
+          :name         => 'volume_type',
+          :id           => 'volume_type',
+          :label        => _('Cloud Volume Type'),
+          :validate     => [{:type => 'required'}],
+          :condition    => {
+            :when    => 'affinity_policy',
+            :pattern => '^Off$',
+          },
+          :includeEmpty => true,
+          :options      => ems.cloud_volume_types.map do |cvt|
+            {
+              :label => cvt.description,
+              :value => cvt.name,
             }
           end,
         },


### PR DESCRIPTION
Given the backend API for creating a new volume on PowerVS, the UI form could be made more aligned with the required params that'd be eventually passed onto those calls. Namely, when Affinity Policy is "off," you can pass in the Type (eg. tier1 or 3). And when Affinity Policy is set to affinity or anti-affinity, the Type is totally ignored, and you need to pass in either volume or VM for the new volume to have affinity with or against.

Thus, the Type and Affinity dropdowns should react (ie. show/hide), depending on what is selected for Affinity Policy. This proposed change basically accomplish that, ~with a little warning on UI (below);~

>~Warning: Received `%s` for a non-boolean attribute `%s`. If you want to write it to the DOM, pass a string instead: %s="%s" or %s={value.toString()}. If you used to conditionally omit it with %s={condition && value}, pass %s={condition ? value : undefined} instead.%s,false,visible,visible,false,visible,visible,visible, in select (created by Select) in div (created by Select) in div (created by Select) in div (created by Select) in Select (created by ClearedSelect) in ClearedSelect (created by Select) in Select (created by Select) in Select (created by SelectWithOnChange) in SelectWithOnChange (created by SingleField) in FormFieldHideWrapper (created by SingleField) in Unknown in Unknown (created by ConditionTriggerWrapper) in ConditionTriggerWrapper (created by ConditionTriggerDetector) in ConditionTriggerDetector (created by ForwardRef(Field)) in ForwardRef(Field) (created by ConditionTriggerDetector) in ConditionTriggerDetector (created by FormConditionWrapper) in FormConditionWrapper (created by SingleField) in SingleField (created by ReactFinalForm) in form (created by Form) in Form (created by Form) in Form (created by FormTemplate) in FormTemplate (created by WrappedFormTemplate) in WrappedFormTemplate in Unknown (created by ReactFinalForm) in ReactFinalForm (created by FormRenderer) in FormRenderer (created by MiqFormRenderer) in MiqFormRenderer (created by Connect(MiqFormRenderer)) in Connect(MiqFormRenderer) (created by CloudVolumeForm) in CloudVolumeForm in Provider~

Never mind the above warning. Kavya helped me identify the lines that were causing this, and this is no longer seen with the latest force-push.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>