### PR TITLE
Add IBM Cloud Activity Tracker service key field for VPC

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
@@ -109,6 +109,43 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
                       },
                     },
                   ]
+                },
+                {
+                  :component => 'tab-item',
+                  :id        => 'events-tab',
+                  :name      => 'events-tab',
+                  :title     => _('Events'),
+                  :fields    => [
+                    {
+                      :component    => 'protocol-selector',
+                      :id           => 'events_selection',
+                      :name         => 'events_selection',
+                      :skipSubmit   => true,
+                      :initialValue => 'none',
+                      :label        => _('Type'),
+                      :options      => [
+                        {
+                          :label => _('Disabled'),
+                          :value => 'none',
+                        },
+                        {
+                          :label => _('Enabled'),
+                          :value => 'enable_events',
+                        },
+                      ],
+                    },
+                    {
+                      :component  => 'password-field',
+                      :id         => 'authentications.events.auth_key',
+                      :name       => 'authentications.events.auth_key',
+                      :label      => _('IBM Cloud Activity Tracker Instance Service Key'),
+                      :isRequired => true,
+                      :condition  => {
+                        :when => "events_selection",
+                        :is   => 'enable_events',
+                      },
+                    },
+                  ]
                 }
               ]
             ],


### PR DESCRIPTION
Previously the only way to provision a service key was to manually create an auth record, hence I have added a field for the key in the provider creation form.

Info: https://cloud.ibm.com/docs/activity-tracker?topic=activity-tracker-service_keys

@miq-bot add_label enhancement
@miq-bot assign @agrare 