### PR TITLE
Raise exception on volume deletion error

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
@@ -135,6 +135,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
     end
   rescue => e
     _log.error("volume=[#{name}], error: #{e}")
+    raise MiqException::MiqVolumeDeleteError, e.to_s, e.backtrace
   end
 
   def raw_attach_volume(vm_ems_ref, _device = nil)


### PR DESCRIPTION
Consistent with other operations here and in other providers, raise a
MiqException::MiqVolumeDeleteError exception when there is an error
deleting a volume.