### PR TITLE
console_url to return hardcoded string for IBM Cloud

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -48,8 +48,13 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
 
   supports :catalog
   supports :create
+  supports :native_console
   supports :provisioning
   supports_not :volume_availability_zones
+
+  def console_url
+    "https://cloud.ibm.com"
+  end
 
   def image_name
     "ibm_power_vs"


### PR DESCRIPTION
Requires:
- [ ] https://github.com/ManageIQ/manageiq/pull/21778

Required by:
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/8149

it will supply the cloud provider native console URL.