### PR TITLE
Fixed security_groups select bug

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision/payload.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision/payload.rb
@@ -22,7 +22,7 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::Provision::Payload
       :primary_network_interface => {
         :name            => 'eth0',
         :subnet          => {:id => get_option(:cloud_subnet)},
-        :security_groups => [{:id => get_option(:security_groups)}]
+        :security_groups => security_groups.map { |sg| {:id => sg.ems_ref} }
       },
       :volume_attachments        => cloud_volumes,
       :boot_volume_attachment    => {

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow/network.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow/network.rb
@@ -40,7 +40,7 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::ProvisionWorkflow::Netw
 
   # Fetch a list of security groups.
   # @param _options [void]
-  # @return [Hash<String, String>] Hash with ems_ref as key and name as value.
+  # @return [Hash<Integer, String>] Hash with id as key and name as value.
   def security_group_to_security_group(_options = {})
     cloud_network = field(:cloud_network)
     return {} if cloud_network.nil?
@@ -48,7 +48,7 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::ProvisionWorkflow::Netw
     ar_security_group = ar_ems.security_groups.select do |security_group|
       security_group.cloud_network.ems_ref == cloud_network
     end
-    string_dropdown(ar_security_group)
+    index_dropdown(ar_security_group)
   rescue => e
     logger(__method__).ui_exception(e)
   end

--- a/content/miq_dialogs/miq_provision_vpc_dialogs.yaml
+++ b/content/miq_dialogs/miq_provision_vpc_dialogs.yaml
@@ -108,9 +108,9 @@
           :description: Interface Security Group
           :values_from:
             :method: security_group_to_security_group
-          :required: true
+          :required: false
           :display: :edit
-          :data_type: :string
+          :data_type: :array_integer
       :display: :show
 
     :hardware:


### PR DESCRIPTION
Fixes an issue in the image provision form that does not allow for any security groups to be selected.

Before:
<img width="603" alt="Screen Shot 2022-03-21 at 2 18 54 PM" src="https://user-images.githubusercontent.com/32444791/159339339-6553b665-d287-4906-ab09-29ff3f761dbf.png">

After:
<img width="1145" alt="Screen Shot 2022-03-21 at 2 15 24 PM" src="https://user-images.githubusercontent.com/32444791/159338121-ee1d04c2-ad66-46d8-926a-9a191040c015.png">

