### PR TITLE
[VPC] Add authentication validation for events

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -65,6 +65,10 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::Cl
     storage_manager
   end
 
+  def authentications_to_validate
+    authentication_for_providers.collect(&:authentication_type)
+  end
+
   def self.hostname_required?
     false
   end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher.rb
@@ -1,3 +1,9 @@
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
   require_nested :Runner
+
+  def self.all_valid_ems_in_zone
+    super.select do |ems|
+      ems.authentication_key("events").present?
+    end
+  end
 end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
@@ -19,11 +19,25 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
   end
 
   # Same as calling connect.
-  # @param _auth_type [nil] Not used
+  # @param auth_type [nil]
   # @param options [Hash] Connection options.
-  # @return [ManageIQ::Providers::IbmCloud::CloudTools::Vpc]
-  def verify_credentials(_auth_type = nil, options = {})
+  # @return [ManageIQ::Providers::IbmCloud::CloudTools::Vpc] or [Boolean]
+  def verify_credentials(auth_type = nil, options = {})
+    case auth_type&.to_sym
+    when :events
+      verify_events_credentials(options)
+    else
+      verify_default_credentials(options)
+    end
+  end
+
+  def verify_default_credentials(options = {})
     connect(options).authenticator
+  end
+
+  def verify_events_credentials(options = {})
+    service_key = authentication_key("events")
+    connect(options).resource.controller.collection(:list_resource_keys).any? { |key| key.dig(:credentials, :service_key) == service_key }
   end
 
   module ClassMethods


### PR DESCRIPTION
- added auth check in event catcher and validation of events API service key credentials


Auth validation:
```
[----] I, [2022-03-23T15:00:14.548900 #42007:52f8]  INFO -- evm: MIQ(MiqAeEngine.deliver) Delivering {:event_type=>"ems_auth_valid", "MiqEvent::miq_event"=>937, :miq_event_id=>937, "EventStream::event_stream"=>937, :event_stream_id=>937} for object [ManageIQ::Providers::IbmCloud::VPC::CloudManager.154] with state [] to Automate
[----] I, [2022-03-23T15:00:14.643737 #42007:52f8]  INFO -- evm: MIQ(MiqEvent#process_evm_event) Event Raised [ems_auth_valid]
[----] I, [2022-03-23T15:00:14.650975 #42007:52f8]  INFO -- evm: MIQ(MiqEvent#process_evm_event) Alert for Event [ems_auth_valid]
[----] I, [2022-03-23T15:00:14.651039 #42007:52f8]  INFO -- evm: MIQ(MiqAlert.evaluate_alerts) [ems_auth_valid] Target: ManageIQ::Providers::IbmCloud::VPC::CloudManager Name: [na], Id: [154]
[----] I, [2022-03-23T15:00:14.653466 #42007:52f8]  INFO -- evm: MIQ(MiqQueue#delivered) Message id: [44521], State: [ok], Delivered in [0.107928] seconds
```

Targeted refresh triggered via events afterwards:
```
[----] I, [2022-03-23T15:04:21.705848 #42007:52f8]  INFO -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh) Refreshing all targets...
[----] I, [2022-03-23T15:04:21.705899 #42007:52f8]  INFO -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh) EMS: [na], id: [154] Refreshing targets for EMS...
[----] I, [2022-03-23T15:04:21.705945 #42007:52f8]  INFO -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh) EMS: [na], id: [154]   InventoryRefresh::TargetCollection [Collection of 1 targets] id [Collection of targets with id: [{:ems_ref=>nil}]]
[----] I, [2022-03-23T15:04:21.783921 #42007:52f8]  INFO -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh_targets_for_ems) EMS: [na], id: [154] Refreshing target InventoryRefresh::TargetCollection [Collection of 1 targets] id [Collection of targets with id: [{:ems_ref=>nil}]]...
[----] I, [2022-03-23T15:04:21.793887 #42007:52f8]  INFO -- evm: EMS: [na], id: [154] Saving EMS Inventory...
[----] I, [2022-03-23T15:04:21.858086 #42007:52f8]  INFO -- evm: EMS: [na], id: [154] Saving EMS Inventory...Complete
[----] I, [2022-03-23T15:04:21.858210 #42007:52f8]  INFO -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh_targets_for_ems) EMS: [na], id: [154] Refreshing target InventoryRefresh::TargetCollection [Collection of 1 targets] id [Collection of targets with id: [{:ems_ref=>nil}]]...Complete
[----] I, [2022-03-23T15:04:21.858269 #42007:52f8]  INFO -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh) EMS: [na], id: [154] Refreshing targets for EMS...Complete - Timings {:collect_inventory_for_targets=>0.07789492607116699, :parse_targeted_inventory=>0.0003268718719482422, :save_inventory=>0.07385396957397461, :publish_inventory=>1.6927719116210938e-05, :ems_refresh=>0.15224814414978027}
[----] I, [2022-03-23T15:04:21.883544 #42007:52f8]  INFO -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh) Refreshing all targets...Complete
[----] I, [2022-03-23T15:04:21.883721 #42007:52f8]  INFO -- evm: MIQ(MiqQueue#delivered) Message id: [44556], State: [ok], Delivered in [0.182403] seconds
```

@miq-bot assign @agrare 
@miq-bot add_label enhancement