### PR TITLE
Add delete cloud databases support for VPC

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/cloud_database.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/cloud_database.rb
@@ -1,2 +1,12 @@
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager::CloudDatabase < ::CloudDatabase
+  supports :delete
+
+  def raw_delete_cloud_database
+    with_provider_connection do |connection|
+      connection.resource.controller.request(:delete_resource_instance, :id => ems_ref)
+    end
+  rescue => err
+    _log.error("cloud database=[#{name}], error: #{err}")
+    raise
+  end
 end

--- a/spec/factories/cloud_database.rb
+++ b/spec/factories/cloud_database.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :cloud_database_ibm_cloud_vpc,
+          :class => "ManageIQ::Providers::IbmCloud::VPC::CloudManager::CloudDatabase"
+end

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/cloud_database.spec
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/cloud_database.spec
@@ -1,0 +1,29 @@
+describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::CloudDatabase do
+  let(:ems) do
+    FactoryBot.create(:ems_ibm_cloud_vpc, :provider_region => "us-east")
+  end
+
+  let(:cloud_database) do
+    FactoryBot.create(:cloud_database_ibm_cloud_vpc, :ext_management_system => ems)
+  end
+
+  describe 'cloud database actions' do
+    let(:connection) do
+      double("ManageIQ::Providers::IbmCloud::CloudTools")
+    end
+
+    let(:resource_controller) do
+      double("ManageIQ::Providers::IbmCloud::CloudTools::ResourceController::Controller")
+    end
+
+    before { allow(ems).to receive(:with_provider_connection).and_yield(connection) }
+
+    context '#delete_cloud_database' do
+      it 'deletes the cloud database' do
+        allow(connection).to receive_message_chain(:resource, :controller).and_return(resource_controller)
+        expect(resource_controller).to receive(:request).with(:delete_resource_instance, :id => cloud_database.ems_ref)
+        cloud_database.delete_cloud_database
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Tested using rails console, it doesn't seem like lifecycle operations for cloud databases are supported in the UI/API yet

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/21810
- [x] https://github.com/ManageIQ/manageiq/pull/21811

Ref:
- https://cloud.ibm.com/apidocs/resource-controller/resource-controller#delete-resource-instance

@miq-bot add_label enhancement
@miq-bot assign @agrare 