### PR TITLE
Adding support for clone-to-template on an instance

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision.rb
@@ -2,4 +2,12 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
   include_concern 'Cloning'
   include_concern 'StateMachine'
   include_concern 'OptionsHelper'
+
+  def destination_type
+    case request_type
+    when 'template', 'clone_to_vm' then "Vm"
+    when 'clone_to_template'       then "Template"
+    else                                ""
+    end
+  end
 end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
@@ -1,6 +1,11 @@
 module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provision::StateMachine
   def create_destination
-    signal :prepare_volumes_and_networks
+    case request_type
+    when 'clone_to_template'
+      signal :determine_placement
+    else
+      signal :prepare_volumes_and_networks
+    end
   end
 
   def prepare_volumes_and_networks
@@ -28,5 +33,19 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     end
 
     signal :prepare_provision
+  end
+
+  def determine_placement
+    options[:destination] = 'image-catalog'
+    signal :start_clone_task
+  end
+
+  def start_clone_task
+    update_and_notify_parent(:message => "Starting Clone of #{clone_direction}")
+
+    clone_options = prepare_for_clone_task
+    log_clone_options(clone_options)
+    phase_context[:clone_task_mor] = start_clone(clone_options)
+    signal :poll_clone_complete
   end
 end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -189,6 +189,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
     ems
   end
 
-  def dialog_name_from_automate(_message = 'get_dialog_name')
+  def dialog_name_from_automate(message = 'get_dialog_name')
+    super(message, {'platform' => 'ibm_powervs'})
   end
 end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
@@ -11,6 +11,14 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template
     end
   end
 
+  def image?
+    true
+  end
+
+  def snapshot?
+    false
+  end
+
   def provider_object(_connection = nil)
     ext_management_system.connect
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -18,6 +18,13 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
 
   supports_not :suspend
 
+  supports :publish do
+    reason   = _("Publish not supported because VM is blank")    if blank?
+    reason ||= _("Publish not supported because VM is orphaned") if orphaned?
+    reason ||= _("Publish not supported because VM is archived") if archived?
+    unsupported_reason_add(:publish, reason) if reason
+  end
+
   def cloud_instance_id
     ext_management_system.uid_ems
   end

--- a/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_clone_to_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_clone_to_template.yaml
@@ -1,0 +1,94 @@
+---
+:name: miq_provision_ibm_powervs_dialogs_clone_to_template
+:description: IBM PowerVS Instance Provisioning Dialog
+:dialog_type: MiqProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields: {}
+      :display: :hide
+
+    :customize:
+      :description: Customization
+      :fields: {}
+      :display: :hide
+
+    :environment:
+      :description: Environment
+      :fields: {}
+      :display: :hide
+
+    :schedule:
+      :description: Schedule
+      :fields: {}
+      :display: :hide
+
+    :purpose:
+      :description: Purpose
+      :fields: {}
+      :display: :hide
+
+    :service:
+      :description: General
+      :fields:
+        :vm_name:
+          :description: Template Name
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /^[a-zA-Z0-9\-_]+$/
+          :required_regex_fail_details: Only letters (no accents), numbers, underscores and dashes are allowed.
+          :required: true
+          :display: :edit
+          :data_type: :string
+          :min_length: 1
+          :max_length: 100
+        :number_of_vms:
+          :values_from:
+            :options:
+              :max: 1
+            :method: :allowed_number_of_vms
+          :description: Count
+          :required: false
+          :display: :hide
+          :default: 1
+          :data_type: :integer
+      :display: :show
+
+    :hardware:
+      :description: Storage
+      :fields:
+        :storage_type:
+          :values:
+            image-catalog: "Image Catalog"
+            cloud-storage: "Cloud Storage"
+            both: "Both"
+          :description: Destination for the deployable image
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+      :display: :hide
+
+    :network:
+      :description: Network
+      :fields: {}
+      :display: :hide
+
+    :volume:
+      :description: Volume
+      :fields: {}
+      :display: :hide
+
+  :dialog_order:
+  - :service
+  - :hardware
+  - :customize   # unused
+  - :volumes     # unused
+  - :network     # unused
+  - :purpose     # unused
+  - :requester   # unused
+  - :environment # unused
+  - :schedule    # unused

--- a/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_template.yaml
@@ -1,0 +1,84 @@
+---
+:name: miq_provision_ibm_powervs_dialogs_template
+:description: IBM PowerVS Instance Template Dialog
+:dialog_type: MiqProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields: {}
+      :display: :hide
+
+    :customize:
+      :description: Customization
+      :fields: {}
+      :display: :hide
+
+    :environment:
+      :description: Environment
+      :fields: {}
+      :display: :hide
+
+    :schedule:
+      :description: Schedule
+      :fields: {}
+      :display: :hide
+
+    :purpose:
+      :description: Purpose
+      :fields: {}
+      :display: :hide
+
+    :service:
+      :description: General
+      :fields:
+        :vm_name:
+          :description: Template Name
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /^[a-zA-Z0-9\-_]+$/
+          :required_regex_fail_details: Only letters (no accents), numbers, underscores and dashes are allowed.
+          :required: true
+          :display: :edit
+          :data_type: :string
+          :min_length: 1
+          :max_length: 100
+      :display: :show
+
+    :hardware:
+      :description: Storage
+      :fields:
+        :storage_type:
+          :values:
+            image-catalog: "Image Catalog"
+            cloud-storage: "Cloud Storage"
+            both: "Both"
+          :description: Destination for the deployable image
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+      :display: :hide
+
+    :network:
+      :description: Network
+      :fields: {}
+      :display: :hide
+
+    :volume:
+      :description: Volume
+      :fields: {}
+      :display: :hide
+
+  :dialog_order:
+  - :service
+  - :hardware
+  - :customize   # unused
+  - :volumes     # unused
+  - :network     # unused
+  - :purpose     # unused
+  - :requester   # unused
+  - :environment # unused
+  - :schedule    # unused

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow_spec.rb
@@ -3,115 +3,136 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provi
 
   let(:admin) { FactoryBot.create(:user_with_group) }
   let(:ems) { FactoryBot.create(:ems_ibm_cloud_power_virtual_servers_cloud) }
-  let(:template) do
-    FactoryBot.create(
-      :template_ibm_cloud_power_virtual_servers,
-      :name                  => "template",
-      :ext_management_system => ems
-    )
-  end
-  let(:workflow) do
-    stub_dialog
-    allow(User).to receive_messages(:server_timezone => "UTC")
-    described_class.new({:src_vm_id => template.id}, admin.userid)
+
+  context "clone" do
+    let(:template) do
+      FactoryBot.create(
+        :template_ibm_cloud_power_virtual_servers,
+        :name                  => "template",
+        :ext_management_system => ems
+      )
+    end
+    let(:workflow) do
+      stub_dialog
+      allow(User).to receive_messages(:server_timezone => "UTC")
+      described_class.new({:src_vm_id => template.id}, admin.userid)
+    end
+
+    it "#parse_new_volumes_fields" do
+      values = {
+        :storage_type => [0, "tier1"],
+        :name         => nil,
+        :size         => nil,
+        :shareable    => false
+      }
+      expect(workflow.parse_new_volumes_fields(values))
+        .to match_array([])
+      values = {
+        :storage_type => [1, "tier1"],
+        :name         => nil,
+        :size         => nil,
+        :shareable    => false,
+        :name_1       => "disk_one",
+        :size_1       => "1",
+        :shareable_1  => "null",
+        :name_2       => "disk_two",
+        :size_2       => "2",
+        :name_3       => "disk_three",
+        :size_3       => "3",
+        :shareable_3  => nil,
+        :name_4       => "disk_four",
+        :size_4       => "4",
+        :shareable_4  => true
+      }
+      expect(workflow.parse_new_volumes_fields(values))
+        .to match_array(
+          [
+            {
+              :name      => "disk_one",
+              :size      => 1,
+              :disk_type => "tier1",
+              :shareable => false
+            },
+            {
+              :name      => "disk_two",
+              :size      => 2,
+              :disk_type => "tier1",
+              :shareable => false
+            },
+            {
+              :name      => "disk_three",
+              :size      => 3,
+              :disk_type => "tier1",
+              :shareable => false
+            },
+            {
+              :name      => "disk_four",
+              :size      => 4,
+              :disk_type => "tier1",
+              :shareable => true
+            }
+          ]
+        )
+      values = {
+        :storage_type => [2, "tier1"],
+        :name         => nil,
+        :size         => nil,
+        :shareable    => false,
+        :name_1       => "disk_one",
+        :shareable_1  => "null",
+        :size_2       => "2",
+        :name_3       => "disk_three",
+        :size_3       => "3",
+        :name_4       => "disk_four",
+        :size_4       => "",
+        :shareable_4  => true
+      }
+      expect(workflow.parse_new_volumes_fields(values))
+        .to match_array(
+          [
+            {
+              :name      => "disk_one",
+              :disk_type => "tier1",
+              :size      => 0,
+              :shareable => false
+            },
+            {
+              :size      => 2,
+              :disk_type => "tier1",
+              :shareable => false
+            },
+            {
+              :name      => "disk_three",
+              :size      => 3,
+              :disk_type => "tier1",
+              :shareable => false
+            },
+            {
+              :name      => "disk_four",
+              :size      => 0,
+              :disk_type => "tier1",
+              :shareable => true
+            }
+          ]
+        )
+    end
   end
 
-  it "#parse_new_volumes_fields" do
-    values = {
-      :storage_type => [0, "tier1"],
-      :name         => nil,
-      :size         => nil,
-      :shareable    => false
-    }
-    expect(workflow.parse_new_volumes_fields(values))
-      .to match_array([])
-    values = {
-      :storage_type => [1, "tier1"],
-      :name         => nil,
-      :size         => nil,
-      :shareable    => false,
-      :name_1       => "disk_one",
-      :size_1       => "1",
-      :shareable_1  => "null",
-      :name_2       => "disk_two",
-      :size_2       => "2",
-      :name_3       => "disk_three",
-      :size_3       => "3",
-      :shareable_3  => nil,
-      :name_4       => "disk_four",
-      :size_4       => "4",
-      :shareable_4  => true
-    }
-    expect(workflow.parse_new_volumes_fields(values))
-      .to match_array(
-        [
-          {
-            :name      => "disk_one",
-            :size      => 1,
-            :disk_type => "tier1",
-            :shareable => false
-          },
-          {
-            :name      => "disk_two",
-            :size      => 2,
-            :disk_type => "tier1",
-            :shareable => false
-          },
-          {
-            :name      => "disk_three",
-            :size      => 3,
-            :disk_type => "tier1",
-            :shareable => false
-          },
-          {
-            :name      => "disk_four",
-            :size      => 4,
-            :disk_type => "tier1",
-            :shareable => true
-          }
-        ]
-      )
-    values = {
-      :storage_type => [2, "tier1"],
-      :name         => nil,
-      :size         => nil,
-      :shareable    => false,
-      :name_1       => "disk_one",
-      :shareable_1  => "null",
-      :size_2       => "2",
-      :name_3       => "disk_three",
-      :size_3       => "3",
-      :name_4       => "disk_four",
-      :size_4       => "",
-      :shareable_4  => true
-    }
-    expect(workflow.parse_new_volumes_fields(values))
-      .to match_array(
-        [
-          {
-            :name      => "disk_one",
-            :disk_type => "tier1",
-            :size      => 0,
-            :shareable => false
-          },
-          {
-            :size      => 2,
-            :disk_type => "tier1",
-            :shareable => false
-          },
-          {
-            :name      => "disk_three",
-            :size      => 3,
-            :disk_type => "tier1",
-            :shareable => false
-          },
-          {
-            :name      => "disk_four",
-            :size      => 0,
-            :disk_type => "tier1",
-            :shareable => true
-          }
-        ]
-      )
+  context "clone_to_template" do
+    let(:vm) { FactoryBot.create(:vm_ibm_cloud_power_virtual_servers, :ext_management_system => ems) }
+
+    it 'supports publish' do
+      expect(vm.supports?(:publish)).to be_truthy
+    end
+
+    it 'no publish if orphaned' do
+      vm.update(:ems_id => nil)
+      expect(vm.supports?(:publish)).to be_falsey
+    end
+
+    it 'no publish if archived' do
+      vm.update(:ems_id => nil, :storage_id => nil)
+      expect(vm.supports?(:publish)).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
Adding logic/code path to support `clone_to_template` provisioning operation. Happy path mostly works at this point.

To start, you'd be in the details page of a PowerVS instance, then go to Lifecycle > Publish to a Template. The following page opens;
![image](https://user-images.githubusercontent.com/1767126/166609912-e418a50f-1be2-4b31-8a44-ef553fbc82ed.png)

Just give it a unique name and Submit. The page would switch to Services > Requests, and the status updates for the image-capture operation would come in as Notifications like below;
<img width="766" alt="image" src="https://user-images.githubusercontent.com/1767126/169592761-d993e40f-3224-46b9-b4dc-ceafb8a01915.png">

To control which provider/instance should get this menu action shown, it needs the below PR to disable `:publish` feature in the base class and have yours enable it;
https://github.com/ManageIQ/manageiq/pull/21872

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>