### PR TITLE
Add custom schema fields to IBM Cloud attach cloud volume form

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager/cloud_volume.rb
@@ -69,6 +69,19 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager::CloudVolume < ::CloudV
     }
   end
 
+  def params_for_attach
+    {
+      :fields => [
+        {
+          :component => 'text-field',
+          :name      => 'device_mountpoint',
+          :id        => 'device_mountpoint',
+          :label     => _('Device Mountpoint')
+        }
+      ]
+    }
+  end
+
   def self.raw_create_volume(ext_management_system, options)
     options = options.with_indifferent_access
     volume = {


### PR DESCRIPTION
Companion PR to https://github.com/ManageIQ/manageiq-ui-classic/pull/8254

Part of the process for upgrading [_attach.html.haml](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/vm_common/_attach.html.haml#L33) and [_detach.html.haml](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/vm_common/_detach.html.haml#L25) to react as per https://github.com/ManageIQ/manageiq-ui-classic/issues/7603.