### PR TITLE
Fix powervs vm provision ipv4 field

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -28,10 +28,6 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
       specs['sys_type']      = get_option_last(:sys_type)
     end
 
-    # TODO: support multiple values
-    ip_addr = get_option_last(:ip_addr)
-    specs['networks'][0]['ipAddress'] = ip_addr unless !ip_addr || ip_addr.strip.blank?
-
     user_script_text = options[:user_script_text]
     user_script_text64 = Base64.encode64(user_script_text) unless user_script_text.nil?
     specs['user_data'] = user_script_text64 unless user_script_text64.nil?
@@ -48,6 +44,10 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
                         end
     attached_networks.concat(phase_context[:new_networks]).compact!
     specs['networks'] = attached_networks
+
+    # TODO: support multiple values
+    ip_addr = get_option_last(:ip_addr)
+    specs['networks'][0]['ipAddress'] = ip_addr unless !ip_addr || ip_addr.strip.blank?
 
     specs
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -47,7 +47,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
 
     # TODO: support multiple values
     ip_addr = get_option_last(:ip_addr)
-    specs['networks'][0]['ipAddress'] = ip_addr unless !ip_addr || ip_addr.strip.blank?
+    specs['networks'][0]['ipAddress'] = ip_addr if ip_addr.present?
 
     specs
   end

--- a/content/miq_dialogs/miq_provision_ibm_powervs_vm_dialog.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_powervs_vm_dialog.yaml
@@ -16,7 +16,7 @@
       :description: Customization
       :fields:
         :ip_addr:
-          :description: Specify an IPv4 address
+          :description: Specify an IPv4 address (applies to first attached network)
           :required_method: :validate_ip_address
           :required: false
           :display: :edit

--- a/content/miq_dialogs/miq_provision_ibm_powervs_vm_dialog.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_powervs_vm_dialog.yaml
@@ -18,7 +18,7 @@
         :ip_addr:
           :description: Specify an IPv4 address
           :required_method: :validate_ip_address
-          :required: true
+          :required: false
           :display: :edit
           :data_type: :string
           :min_length: 8


### PR DESCRIPTION
I believe this has been broken since 815d06d when I changed the order of assigning `specs['networks']` and `specs['networks'][0]['ipAddress']`.

Also, the field to set the ipv4 address for a network is _not_ required.