### PR TITLE
Add spec to show network_manager.refresh failure

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
@@ -28,6 +28,8 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager < ManageIQ::Providers::
            :hostname,
            :default_endpoint,
            :endpoints,
+           :refresh,
+           :refresh_ems,
            :to        => :parent_manager,
            :allow_nil => true
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
@@ -17,6 +17,8 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager < ManageIQ::Providers::
            :hostname,
            :default_endpoint,
            :endpoints,
+           :refresh,
+           :refresh_ems,
            :to        => :parent_manager,
            :allow_nil => true
 

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -37,6 +37,29 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
         assert_specific_vpn_gateway
       end
     end
+
+    it "network_manager full refresh" do
+      2.times do
+        with_vcr { ems.network_manager.refresh }
+
+        ems.reload
+
+        assert_specific_flavor
+        assert_specific_availability_zone
+        assert_specific_security_group
+        assert_specific_cloud_volume
+        assert_specific_cloud_volume_type
+        assert_specific_cloud_subnet
+        assert_specific_floating_ip
+        assert_specific_network_acl_rule
+        assert_specific_load_balancer
+        assert_specific_load_balancer_pool
+        assert_specific_cloud_database
+        assert_specific_cloud_database_flavor
+        assert_specific_vm
+        assert_specific_vpn_gateway
+      end
+    end
   end
 
   context "targeted refresh" do

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb
@@ -38,9 +38,30 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher do
       end
     end
 
-    it "network_manager full refresh" do
+    it "child managers delegate refresh to the parent manager" do
       2.times do
         with_vcr { ems.network_manager.refresh }
+
+        ems.reload
+
+        assert_specific_flavor
+        assert_specific_availability_zone
+        assert_specific_security_group
+        assert_specific_cloud_volume
+        assert_specific_cloud_volume_type
+        assert_specific_cloud_subnet
+        assert_specific_floating_ip
+        assert_specific_network_acl_rule
+        assert_specific_load_balancer
+        assert_specific_load_balancer_pool
+        assert_specific_cloud_database
+        assert_specific_cloud_database_flavor
+        assert_specific_vm
+        assert_specific_vpn_gateway
+      end
+
+      2.times do
+        with_vcr { ems.storage_manager.refresh }
 
         ems.reload
 


### PR DESCRIPTION
VPC (and most of the other providers) refresh all child managers together.  Until all are converted over we have to play some games like this: https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/inventory/persister.rb#L88-L90 to get an inventory collection's manager.

If all inventory is refreshed together is is more straightforward to simply delegate refresh to the parent manager.

Will review other providers but if we like this pattern think it can apply to all that do combined refresh.

Fixes https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/384