### PR TITLE
[VPC] Persist user to EmsEvent

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_parser.rb
@@ -3,6 +3,7 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventParser
     event_hash = {
       :event_type => event["action"],
       :source     => "IBMCloud-VPC",
+      :username   => event.dig("initiator", "name"),
       :ems_id     => ems_id,
       :ems_ref    => event["_id"],
       :timestamp  => event["eventTime"],


### PR DESCRIPTION
- the user is persisted via the `username` column

i.e.
```
 #<EmsEvent:0x00007fd2a97ba0b0
  id: 102,
  event_type: "is.instance.instance.create",
  message: nil,
  timestamp: Thu, 02 Jun 2022 20:24:58 UTC +00:00,
  .
  .
  .
  source: "IBMCloud-VPC",
  chain_id: nil,
  ems_id: 17,
  is_task: nil,
  full_data: "[FILTERED]",
  created_on: Thu, 02 Jun 2022 20:25:47 UTC +00:00,
  username: "Nasar.Khan@ibm.com",
  ems_cluster_id: nil,
  ems_cluster_name: nil,
  .
  .
  .>
```

@miq-bot add_label enhancement
@miq-bot assign @agrare 