### PR TITLE
Improve PowerVS "Native Console" URL

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -54,7 +54,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
   supports_not :volume_availability_zones
 
   def console_url
-    "https://cloud.ibm.com"
+    "https://cloud.ibm.com/services/power-iaas/#{CGI.escape(pcloud_crn.values.join(":"))}"
   end
 
   def image_name

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -56,6 +56,11 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
     parse_crn(connection.default_headers["Crn"])[:location]
   end
 
+  def pcloud_crn(connection = nil)
+    connection ||= connect
+    parse_crn(connection.default_headers["Crn"])
+  end
+
   private
 
   def parse_crn(crn)


### PR DESCRIPTION
The IBM Cloud console URL for a specific PowerVS service instance can be
constructed using its CRN. This is much more convenient than dropping
the user into the default cloud.ibm.com interface where they'll have to
find and select the service instance they're looking for.

I verified this URL works with or without an existing cloud.ibm.com session (in the without case, the user will have go through the standard auth check before arriving at the PowerVS service web console).