### PR TITLE
Fix task reference in VM provision state machine

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -8,13 +8,13 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
   end
 
   def start_clone(clone_options)
-      if request_type == 'clone_to_template'
-        make_request_clone_to_template(clone_options)
-      elsif sap_image?
-        make_request_clone_sap_vm(clone_options)
-      else
-        make_request_clone(clone_options)
-      end
+    if request_type == 'clone_to_template'
+      make_request_clone_to_template(clone_options)
+    elsif sap_image?
+      make_request_clone_sap_vm(clone_options)
+    else
+      make_request_clone(clone_options)
+    end
   rescue IbmCloudPower::ApiError => err
     error_message = JSON.parse(err.response_body)["description"] || err.message
     _log.error("VM start_clone error: #{error_message}")

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -22,7 +22,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
   end
 
   def do_clone_task_check(clone_task_ref)
-    request_type == 'clone_to_template' ? check_task_clone_to_template : check_task_clone(clone_task_ref)
+    request_type == 'clone_to_template' ? check_task_clone_to_template(clone_task_ref) : check_task_clone(clone_task_ref)
   end
 
   def customize_destination
@@ -118,9 +118,9 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     end
   end
 
-  def check_task_clone_to_template
+  def check_task_clone_to_template(clone_task_ref)
     source.with_provider_connection(:service => "PCloudTasksApi") do |api|
-      task = api.pcloud_tasks_get(phase_context[:clone_task_mor])
+      task = api.pcloud_tasks_get(clone_task_ref)
       stop = (task.status != 'capturing')
       phase_context[:cloud_api_completion_time] = Time.zone.now.utc if stop
       return stop, task.status_detail

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -138,6 +138,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
         status = 'The server is being provisioned.'
       when 'ACTIVE'
         stop = (instance.processors.to_f > 0) && (instance.memory.to_f > 0)
+        phase_context[:cloud_api_completion_time] = Time.zone.now.utc if stop
         status = "The server has been provisioned.; #{stop ? 'Server description available.' : 'Waiting for server description.'}"
       when 'ERROR'
         raise MiqException::MiqProvisionError, _("An error occurred while provisioning the instance.")

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
@@ -42,10 +42,10 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
 
   def start_clone_task
     update_and_notify_parent(:message => "Starting Clone of #{clone_direction}")
-
     clone_options = prepare_for_clone_task
     log_clone_options(clone_options)
-    phase_context[:clone_task_mor] = start_clone(clone_options)
+    phase_context[:clone_task_ref] = start_clone(clone_options)
+    phase_context.delete(:clone_options)
     signal :poll_clone_complete
   end
 end


### PR DESCRIPTION
When calling 'check_task_clone' to check the status of a newly
provisioned VM, the VM ID can be accessed through
'phase_context[:clone_task_mor]'. I observed that 'clone_task_ref' is
nil. This was working in the past - not sure if it has been broken for a
while, was broken by the most recent change, 0732f69, or if something
changed in one of the core repos.


Found this after noticing that a PowerVS VM provision request resulted in an error even though the PowerVS service showed the VM had been successfully created. EVM logs showed:
```
[----] E, [2022-06-13T16:24:01.106516 #266244:aaa0] ERROR -- evm: MIQ(ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provision#provision_error) [[ArgumentError]: Missing the required parameter 'pvm_instance_id' when calling            PCloudPVMInstancesApi.pcloud_pvminstances_get] encountered during phase [poll_clone_complete]                                                                                                                                                         
[----] E, [2022-06-13T16:24:01.106648 #266244:aaa0] ERROR -- evm: /home/jwcarman/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/ibm_cloud_power-1.1.1/lib/ibm_cloud_power/api/p_cloud_pvm_instances_api.rb:404:in `pcloud_pvminstances_get_with_http_info'
```