### PR TITLE
Adding HTML5 Console support for cloud instance with noVNC

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -25,6 +25,14 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
     unsupported_reason_add(:publish, reason) if reason
   end
 
+  supports :html5_console do
+    reason   = _("VM Console not supported because VM is not powered on") unless current_state == "on"
+    reason ||= _("VM Console not supported because VM is orphaned")       if orphaned?
+    reason ||= _("VM Console not supported because VM is archived")       if archived?
+    unsupported_reason_add(:html5_console, reason) if reason
+  end
+  supports :launch_html5_console
+
   def cloud_instance_id
     ext_management_system.uid_ems
   end
@@ -90,6 +98,10 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
     else
       "off"
     end
+  end
+
+  def console_supported?(type)
+    return true if type.upcase == 'VNC'
   end
 
   private

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
@@ -4,10 +4,10 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm do
   end
   let(:vm) { FactoryBot.create(:vm_ibm_cloud_power_virtual_servers, :ext_management_system => ems) }
 
-  context "is_available?" do
-    let(:power_state_on)        { "ACTIVE" }
-    let(:power_state_suspended) { "SHUTOFF" }
+  let(:power_state_on)        { "ACTIVE" }
+  let(:power_state_suspended) { "SHUTOFF" }
 
+  context "is_available?" do
     context "with :start" do
       let(:state) { :start }
       include_examples "Vm operation is available when not powered on"
@@ -36,6 +36,28 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm do
     context "with :reset" do
       let(:state) { :reset }
       include_examples "Vm operation is available when powered on"
+    end
+  end
+
+  context "supports VM console access?" do
+    it 'supports console access if powered on' do
+      vm.update(:raw_power_state => power_state_on)
+      expect(vm.supports?(:html5_console)).to be_truthy
+    end
+
+    it 'no console access if powered off' do
+      vm.update(:raw_power_state => power_state_suspended)
+      expect(vm.supports?(:html5_console)).to be_falsey
+    end
+
+    it 'no console access if orphaned' do
+      vm.update(:ems_id => nil)
+      expect(vm.supports?(:html5_console)).to be_falsey
+    end
+
+    it 'no console access if archived' do
+      vm.update(:ems_id => nil, :storage_id => nil)
+      expect(vm.supports?(:html5_console)).to be_falsey
     end
   end
 end


### PR DESCRIPTION
This adds Access > VM Console menu action which would launch the "noVNC" console window/tab upon click. Not supported if VM is not powered on, is archived, or orphaned, for which specs are added.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>