### PR TITLE
Replace 'RestClient' rescues

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -16,10 +16,10 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
       else
         make_request_clone(clone_options)
       end
-    rescue RestClient::ExceptionWithResponse => e
+    rescue IbmCloudPower::ApiError => e
       raise MiqException::MiqProvisionError, e.response.to_s
     end
-  rescue RestClient::ExceptionWithResponse => e
+  rescue IbmCloudPower::ApiError => e
     raise MiqException::MiqProvisionError, e.response.to_s
   end
 


### PR DESCRIPTION
The current IBM Cloud Power SDK gem IbmCloudPower doesn't use
RestClient. These lines were committed back when we were using the
combined ibm-cloud-sdk, which did use RestClient.