### PR TITLE
Improve IAM auth error message

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/manager_mixin.rb
@@ -157,7 +157,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
       rescue IbmCloudIam::ApiError => err
         error_message = JSON.parse(err.response_body)["message"]
         _log.error("IAM authentication failed: #{err.code} #{error_message}")
-        raise MiqException::MiqInvalidCredentialsError, error_message
+        raise MiqException::MiqInvalidCredentialsError, "IAM authentication failed"
       end
 
       require "ibm_cloud_resource_controller"


### PR DESCRIPTION
The "message" included in the the IbmCloudIam response is typically
blank. Returning an "IAM authentication failed" message will be more
helpful to a user trying to input a valid API key in the provider
regisration form.