### PR TITLE
Fixing create/update databases logic

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/cloud_database.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/cloud_database.rb
@@ -7,10 +7,12 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::CloudDatabase < ::CloudD
     {
       :fields => [
         {
-          :component => 'text-field',
-          :id        => 'name',
-          :name      => 'name',
-          :label     => _('Cloud Database'),
+          :component  => 'text-field',
+          :id         => 'name',
+          :name       => 'name',
+          :isRequired => true,
+          :validate   => [{:type => 'required'}],
+          :label      => _('Cloud Database Name'),
         },
         {
           :component    => 'select',
@@ -31,7 +33,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::CloudDatabase < ::CloudD
           :component    => 'select',
           :name         => 'database',
           :id           => 'database',
-          :label        => _('Cloud Database'),
+          :label        => _('Cloud Database Type'),
           :includeEmpty => true,
           :isRequired   => true,
           :validate     => [{:type => 'required'}],
@@ -61,12 +63,12 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::CloudDatabase < ::CloudD
 
   def self.raw_create_cloud_database(ext_management_system, options)
     ext_management_system.with_provider_connection do |connection|
-      resource_group = ext_management_system.resource_groups.find_by!(:name => options[:resource_group_name])
+      resource_group = ext_management_system.resource_groups.find_by!(:name => options["resource_group_name"])
       connection.resource.controller.request(:create_resource_instance,
-                                             :name             => options[:name],
+                                             :name             => options["name"],
                                              :target           => ext_management_system.provider_region,
                                              :resource_group   => resource_group.ems_ref,
-                                             :resource_plan_id => "databases-for-#{options[:database]}-standard")
+                                             :resource_plan_id => "databases-for-#{options["database"]}-standard")
     end
   rescue => err
     _log.error("cloud database=[#{name}], error: #{err}")
@@ -84,7 +86,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::CloudDatabase < ::CloudD
 
   def raw_update_cloud_database(options)
     with_provider_connection do |connection|
-      connection.resource.controller.request(:update_resource_instance, :id => ems_ref, :name => options[:name])
+      connection.resource.controller.request(:update_resource_instance, :id => ems_ref, :name => options["name"])
     end
   rescue => err
     _log.error("cloud database=[#{name}], error: #{err}")

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/cloud_database_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/cloud_database_spec.rb
@@ -29,9 +29,9 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::CloudDatabase do
                                                               :target           => ems.provider_region,
                                                               :resource_group   => resource_group.ems_ref,
                                                               :resource_plan_id => "databases-for-postgresql-standard")
-        cloud_database.class.raw_create_cloud_database(ems, {:name                => "test-db",
-                                                             :resource_group_name => resource_group.name,
-                                                             :database            => "postgresql"})
+        cloud_database.class.raw_create_cloud_database(ems, {"name"                => "test-db",
+                                                             "resource_group_name" => resource_group.name,
+                                                             "database"            => "postgresql"})
       end
     end
 
@@ -45,7 +45,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::CloudDatabase do
     context '#update_cloud_database' do
       it 'updates the cloud database' do
         expect(resource_controller).to receive(:request).with(:update_resource_instance, :id => cloud_database.ems_ref, :name => "test-db-new")
-        cloud_database.update_cloud_database({:name => "test-db-new"})
+        cloud_database.update_cloud_database({"name" => "test-db-new"})
       end
     end
   end


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/8339

Converted all of the options[:key] to options["key"]. 

@miq-bot add-reviewer @nasark
@miq-bot add-reviewer @agrare
@miq-bot assign @agrare 