### PR TITLE
[NAJDORF] Fix start_clone IbmCloudPower::ApiError rescue

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -67,11 +67,11 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
           response&.first&.pvm_instance_id
         end
       end
-    rescue IbmCloudPower::ApiError => e
-      raise MiqException::MiqProvisionError, e.response.to_s
     end
-  rescue IbmCloudPower::ApiError => e
-    raise MiqException::MiqProvisionError, e.response.to_s
+  rescue IbmCloudPower::ApiError => err
+    error_message = JSON.parse(err.response_body)["description"] || err.message
+    _log.error("VM start_clone error: #{error_message}")
+    raise MiqException::MiqProvisionError, error_message
   end
 
   def do_clone_task_check(clone_task_ref)


### PR DESCRIPTION
Fix start_clone IbmCloudPower::ApiError rescue

(cherry picked from commit a9872dcf6f3b8db0edbf333c24aac2df3f7d3cbc)

Najdorf direct pr for https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/404