### PR TITLE
Replace persister.cloud_volumes.find with .lazy_find

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
@@ -81,7 +81,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
           :device_name     => volume.name,
           :device_type     => volume.disk_type,
           :controller_type => "ibm",
-          :backing         => persister.cloud_volumes.find(vol_id),
+          :backing         => persister.cloud_volumes.lazy_find(vol_id),
           :location        => vol_id,
           :size            => volume.size&.gigabytes
         )


### PR DESCRIPTION
The `#find` method on an inventory_collection introduces an ordering dependency and should be replaced with a `#lazy_find`