### PR TITLE
Use supports instead of availability for Template#delete_image

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
@@ -120,10 +120,6 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template
     ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::ImageImportWorkflow.create_job({}, extra_vars, workflow_opts, [host], credentials, :poll_interval => 5.seconds, :timeout => wrkfl_timeout)
   end
 
-  def validate_delete_image
-    validate_unsupported(_("Delete Cloud Template Operation"))
-  end
-
   private_class_method def self.set_import_auth(dst_provider_id, key, iv, encr_cos_creds)
     powervs = ExtManagementSystem.find(dst_provider_id)
     powervs.create_import_auth(key, iv, encr_cos_creds)

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
@@ -7,7 +7,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm do
   let(:power_state_on)        { "ACTIVE" }
   let(:power_state_suspended) { "SHUTOFF" }
 
-  context "is_available?" do
+  context "#supports?" do
     context "with :start" do
       let(:state) { :start }
       include_examples "Vm operation is available when not powered on"

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
@@ -11,7 +11,7 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm, :vcr do
     FactoryBot.create(:vm_ibm_cloud_vpc, :ext_management_system => ems)
   end
 
-  context "is_available?" do
+  context "#supports?" do
     let(:power_state_on)        { "running" }
     let(:power_state_suspended) { "stopped" }
 


### PR DESCRIPTION
part of https://github.com/ManageIQ/manageiq/issues/21179

templates default to not supporting deleting an image, so no need to override.
