### PR TITLE
Add implicit :number_of_vms = 1 to dialog

### DIFF
--- a/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_clone_to_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_clone_to_template.yaml
@@ -45,6 +45,11 @@
           :data_type: :string
           :min_length: 1
           :max_length: 100
+        :number_of_vms:
+          :required: true
+          :display: :hide
+          :default: 1
+          :data_type: :integer
       :display: :show
 
     :hardware:


### PR DESCRIPTION
There is logic in Automate that adds a suffix to VM names if more than
one is being provisioned ([ref](https://github.com/ManageIQ/manageiq-content/blob/master/content/automate/ManageIQ/Cloud/VM/Provisioning/Naming.class/__methods__/vmname.rb#L63)). The ':number_of_vms' is required to be set.
In this case, provisioning a template from an existing VM, the number of
VMs should always be 1. This can be set with a hidden field in the
dialog.

Related to:
- ManageIQ/manageiq-content#718