### PR TITLE
Subclass Snapshot under PowerVirtualServers

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -8,9 +8,10 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
   require_nested :PlacementGroup
   require_nested :Provision
   require_nested :ProvisionWorkflow
+  require_nested :SAPProfile
+  require_nested :Snapshot
   require_nested :Template
   require_nested :Vm
-  require_nested :SAPProfile
 
   include ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/snapshot.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/snapshot.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Snapshot < ::Snapshot
+end

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -171,6 +171,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
 
       if vm.snapshots.count == 1
         expect(vm.snapshots.first).to have_attributes(
+          :type              => 'ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Snapshot',
           :name              => 'test-snapshot-1',
           :vm_or_template_id => vm.id
         )


### PR DESCRIPTION
Add a snapshot subclass under IbmCloud::PowerVirtualServers

Depends:
- [x] https://github.com/ManageIQ/manageiq-schema/pull/666