### PR TITLE
Rename VPC provision dialog to standard format

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow.rb
@@ -12,12 +12,6 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::ProvisionWorkflow < ::Mi
 
   # Class methods. Do not move to sub module.
   class << self
-    # Specify the name of the provision dialog to pull from the database.
-    # @return [String] The :name field in the provision dialog.
-    def default_dialog_file
-      'miq_provision_vpc_dialogs'
-    end
-
     # Sets the model to use for Provisioning.
     # @return [ManageIQ::Providers::IbmCloud::VPC::CloudManager]
     def provider_model

--- a/content/miq_dialogs/miq_provision_ibm_vpc_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_vpc_dialogs_template.yaml
@@ -1,5 +1,5 @@
 ---
-:name: miq_provision_vpc_dialogs
+:name: miq_provision_ibm_vpc_dialogs_template
 :description: VPC VM Provisioning Dialog
 :dialog_type: MiqProvisionWorkflow
 :content:


### PR DESCRIPTION
Rename the VPC provision template dialog to a standard format so that the dialog name returned by automate matches