### PR TITLE
Remove VM resize support for SAP

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -42,6 +42,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
   supports :resize do
     unsupported_reason_add(:resize, _('The VM is not powered off')) unless current_state == "off"
     unsupported_reason_add(:resize, _('The VM is not connected to a provider')) unless ext_management_system
+    unsupported_reason_add(:resize, _('SAP VM resize not supported')) if flavor.kind_of?(ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SAPProfile)
   end
 
   def cloud_instance_id


### PR DESCRIPTION
Removing resize support for VM's with SAP Profile as the SAP resize options are different than regular PowerVS vm resize options.
Eventually we would want to create a special SAP form/special SAP options and support SAP resize.
Depends on #432