### PR TITLE
Fix AWS S3 VCR errors getting bucket location

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/object_storage.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/object_storage.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::ObjectStorage < Manag
     (connection.list_buckets[:buckets] || []).each do |bucket|
       connection.get_bucket_location(:bucket => bucket[:name]).location_constraint
       buckets << bucket
-    rescue
+    rescue Aws::S3::Errors::NoSuchBucket
       _log.warn("bucket '#{bucket[:name]}' is not from our region '#{manager.provider_region}', skipping")
     end
 

--- a/spec/vcr_cassettes/manageiq/providers/ibm_cloud/object_storage/storage_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_cloud/object_storage/storage_manager/refresher.yml
@@ -54,7 +54,7 @@ http_interactions:
   recorded_at: Mon, 03 May 2021 13:24:22 GMT
 - request:
     method: get
-    uri: https://s3.us-east.cloud-object-storage.appdomain.cloud/bucket-for-export?location
+    uri: https://bucket-for-export.s3.us-east.cloud-object-storage.appdomain.cloud/?location
     body:
       encoding: UTF-8
       string: ''
@@ -106,7 +106,7 @@ http_interactions:
   recorded_at: Mon, 03 May 2021 13:24:24 GMT
 - request:
     method: get
-    uri: https://s3.us-east.cloud-object-storage.appdomain.cloud/roks-c03jjjed0ft0tc1kd2cg-6e58?location
+    uri: https://roks-c03jjjed0ft0tc1kd2cg-6e58.s3.us-east.cloud-object-storage.appdomain.cloud/?location
     body:
       encoding: UTF-8
       string: ''
@@ -158,7 +158,7 @@ http_interactions:
   recorded_at: Mon, 03 May 2021 13:24:25 GMT
 - request:
     method: get
-    uri: https://s3.us-east.cloud-object-storage.appdomain.cloud/roks-c1mriasd0s1lkcr2a6ig-1f5b?location
+    uri: https://roks-c1mriasd0s1lkcr2a6ig-1f5b.s3.us-east.cloud-object-storage.appdomain.cloud/?location
     body:
       encoding: UTF-8
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
   recorded_at: Mon, 03 May 2021 13:24:26 GMT
 - request:
     method: get
-    uri: https://s3.us-east.cloud-object-storage.appdomain.cloud/test-bucket-isgandar?location
+    uri: https://test-bucket-isgandar.s3.us-east.cloud-object-storage.appdomain.cloud/?location
     body:
       encoding: UTF-8
       string: ''


### PR DESCRIPTION
Newer versions of the aws-s3 gem change how they call for the bucket location constraing and the overly broad `rescue` to skip the bucket was hiding the VCR unknown http interaction exception, leaving only the unused http interactions at the end of the run.

This fixes the request URI for the bucket calls and adds a more specific `Aws::S3::Errors::NoSuchBucket` exception check for skipping buckets not in our region.