### PR TITLE
Fix typo, we use logger from stdlib, not logging gem

### DIFF
--- a/lib/manageiq/providers/ibm_cloud/cloud_tool.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tool.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'logging'
+require 'logger'
 require_relative 'cloud_tools'
 
 module ManageIQ

--- a/lib/manageiq/providers/ibm_cloud/cloud_tools.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'logging'
 require 'ibm_vpc'
 
 require_relative 'cloud_tools/sdk'


### PR DESCRIPTION
Note, ManageIQ uses the Logging gem from dependencies but we're not using that here and this gem doesn't specify Logging as a dependency so I guess that's why you can sometimes get the following error I noticed in a CI test run:

```
  Coverage report generated for RSpec to /home/runner/work/manageiq-cross_repo-tests/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-providers-ibm_cloud@0ddccb36f4dad739c9990d76e207b4815153d90e/coverage. 23490 / 57482 LOC (40.86%) covered.
  ** override_gem("manageiq-gems-pending", :path=>"/home/runner/work/manageiq-cross_repo-tests/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-gems-pending@daf76728d0bc2b291d08c8d7fb9d6551cd1c335d") at /home/runner/work/manageiq-cross_repo-tests/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-providers-ibm_cloud@0ddccb36f4dad739c9990d76e207b4815153d90e/spec/manageiq/bundler.d/overrides.rb:1
  ** override_gem("manageiq-smartstate", :path=>"/home/runner/work/manageiq-cross_repo-tests/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-smartstate@d94d7a702ebc285439413935ef222d848baa355c") at /home/runner/work/manageiq-cross_repo-tests/manageiq-cross_repo-tests/repos/ManageIQ/manageiq-providers-ibm_cloud@0ddccb36f4dad739c9990d76e207b4815153d90e/spec/manageiq/bundler.d/overrides.rb:2
  ** Using session_store: ActionDispatch::Session::MemoryStore
  ** ManageIQ master, codename: Quinteros

  An error occurred while loading ./spec/models/manageiq/providers/ibm_cloud/vpc/cloud_tools_spec.rb. - Did you mean?
                      rspec ./spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager_spec.rb
                      rspec ./spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm_spec.rb
                      rspec ./spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresher_spec.rb

  Failure/Error: require 'logging'

  LoadError:
    cannot load such file -- logging
  # ./lib/manageiq/providers/ibm_cloud/cloud_tools.rb:3:in `<top (required)>'
  # ./spec/models/manageiq/providers/ibm_cloud/vpc/cloud_tools_spec.rb:3:in `<top (required)>'
```