### PR TITLE
Remove defaults from PowerVS vm provsion form

### DIFF
--- a/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_template.yaml
@@ -146,7 +146,6 @@
           :description: Processor
           :required: true
           :display: :edit
-          :default: 0
           :data_type: :integer
         :sys_type:
           :values_from:
@@ -154,7 +153,6 @@
           :description: Machine Type
           :required: true
           :display: :edit
-          :default: 0
           :data_type: :integer
         :storage_type:
           :values_from:
@@ -162,7 +160,6 @@
           :description: Storage Type
           :required: true
           :display: :edit
-          :default: 0
           :data_type: :integer
         :vm_memory:
           :description: Memory (GB)


### PR DESCRIPTION
These defaults aren't honored when creating catalog items.

The default values, though, are merely the first values returned by the PowerVS API. Often this doesn't end up being the most common selection (for example, an e980 is usualy the default machine type but s922 would be more commonly selected). Different PowerVS datacenters may have different options based on availability and capacity, so there's not really a nice global default.

Removing the default values prevents users from assuming the default values are in any way suggestive of a typical provision.