### PR TITLE
Changed Feature Name from native to management_console

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -50,7 +50,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageI
 
   supports :catalog
   supports :create
-  supports :native_console
+  supports :management_console
   supports :provisioning
   supports_not :volume_availability_zones
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -33,10 +33,10 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
   end
   supports :launch_html5_console
 
-  supports :native_console do
+  supports :management_console do
     reason ||= _("VM Console not supported because VM is orphaned") if orphaned?
     reason ||= _("VM Console not supported because VM is archived") if archived?
-    unsupported_reason_add(:native_console, reason) if reason
+    unsupported_reason_add(:management_console, reason) if reason
   end
 
   supports :resize do

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
@@ -69,22 +69,22 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm do
   context "supports management console access?" do
     it 'supports console access if powered on' do
       vm.update(:raw_power_state => power_state_on)
-      expect(vm.supports?(:native_console)).to be_truthy
+      expect(vm.supports?(:management_console)).to be_truthy
     end
 
     it 'no console access if powered off' do
       vm.update(:raw_power_state => power_state_suspended)
-      expect(vm.supports?(:native_console)).to be_truthy
+      expect(vm.supports?(:management_console)).to be_truthy
     end
 
     it 'no console access if orphaned' do
       vm.update(:ems_id => nil)
-      expect(vm.supports?(:native_console)).to be_falsey
+      expect(vm.supports?(:management_console)).to be_falsey
     end
 
     it 'no console access if archived' do
       vm.update(:ems_id => nil, :storage_id => nil)
-      expect(vm.supports?(:native_console)).to be_falsey
+      expect(vm.supports?(:management_console)).to be_falsey
     end
   end
 end


### PR DESCRIPTION
Related: https://github.com/ManageIQ/manageiq/pull/22474

Changes the feature name for the IBM providers from native_console to management_console since native_console is already used by the RHV provider.