### PR TITLE
Fix pcloud_events_getsince API call

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/event_catcher/stream.rb
@@ -22,7 +22,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::EventCat
       pcloud_events_api = ems.connect(:service => "PCloudEventsApi")
 
       retry_connection = true
-      events = pcloud_events_api.pcloud_events_getsince(@ems.uid_ems, from_time).events
+      events = pcloud_events_api.pcloud_events_getsince(@ems.uid_ems, {:from_time=>from_time}).events
 
       from_time = Time.now.utc.to_i
 


### PR DESCRIPTION
The ibm_cloud_power gem update from v2.0 to v2.1 (3d31bfc) included a breaking change to the PowerVS events API call.

The ibm_cloud_power gem source can be found at
https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby

Snippet of the breaking change:
```diff
$ git diff 13c4154..fa63573 -- gems/ibm_cloud_power/lib/ibm_cloud_power/api/p_cloud_events_api.rb diff --git a/gems/ibm_cloud_power/lib/ibm_cloud_power/api/p_cloud_events_api.rb b/gems/ibm_cloud_power/lib/ibm_cloud_power/api/p_cloud_events_api.rb index 8eedabf..0560326 100644
--- a/gems/ibm_cloud_power/lib/ibm_cloud_power/api/p_cloud_events_api.rb +++ b/gems/ibm_cloud_power/lib/ibm_cloud_power/api/p_cloud_events_api.rb @@ -6,7 +6,7 @@
 The version of the OpenAPI document: 1.0.0
 Contact: kylej@us.ibm.com
 Generated by: https://openapi-generator.tech
-OpenAPI Generator version: 6.0.1
+OpenAPI Generator version: 6.2.1

 =end

@@ -90,25 +90,27 @@ module IbmCloudPower
     end

     # Get events from this cloud instance since a specific timestamp
-    # You must append the '?time=' query parameter to the cURL URL to get a list of events.
     # @param cloud_instance_id [String] Cloud Instance ID of a PCloud Instance
-    # @param time [String] (deprecated - use from_time) A time in either ISO 8601 or unix epoch format
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :time (deprecated - use from_time) A time in either ISO 8601 or unix epoch format
+    # @option opts [String] :from_time A from query time in either ISO 8601 or unix epoch format
+    # @option opts [String] :to_time A to query time in either ISO 8601 or unix epoch format
     # @option opts [String] :accept_language The language requested for the return document
     # @return [Events]
-    def pcloud_events_getsince(cloud_instance_id, time, opts = {})
-      data, _status_code, _headers = pcloud_events_getsince_with_http_info(cloud_instance_id, time, opts)
+    def pcloud_events_getsince(cloud_instance_id, opts = {})
+      data, _status_code, _headers = pcloud_events_getsince_with_http_info(cloud_instance_id, opts)
       data
     end
```