### PR TITLE
VPC: Fix child NetworkManager and StorageManager refresh

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
@@ -56,7 +56,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC < ManageIQ::Provi
   end
 
   def add_cloud_database_flavors(extra_properties = {})
-    add_collection(cloud, :cloud_database_flavors, extra_properties) do |builder|
+    add_cloud_collection(:cloud_database_flavors, extra_properties) do |builder|
       builder.add_properties(:strategy => :local_db_find_references) if targeted?
     end
   end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc/network_manager.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC::NetworkManager < ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC
+  def storage_manager
+    manager.parent_manager.storage_manager
+  end
 end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc/storage_manager.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC::StorageManager < ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC
+  def network_manager
+    manager.parent_manager.network_manager
+  end
 end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
@@ -1,11 +1,12 @@
 class ManageIQ::Providers::IbmCloud::VPC::NetworkManager < ManageIQ::Providers::NetworkManager
   require_nested :CloudNetwork
+  require_nested :CloudSubnet
   require_nested :FloatingIp
   require_nested :LoadBalancer
+  require_nested :LoadBalancerHealthCheck
   require_nested :LoadBalancerListener
   require_nested :LoadBalancerPool
   require_nested :LoadBalancerPoolMember
-  require_nested :LoadBalancerHealthCheck
   require_nested :NetworkPort
   require_nested :NetworkRouter
   require_nested :SecurityGroup

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
@@ -30,6 +30,7 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager < ManageIQ::Providers::
            :hostname,
            :default_endpoint,
            :endpoints,
+           :provider_region,
            :refresh,
            :refresh_ems,
            :to        => :parent_manager,

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
@@ -9,6 +9,7 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager < ManageIQ::Providers::
   require_nested :LoadBalancerPoolMember
   require_nested :NetworkPort
   require_nested :NetworkRouter
+  require_nested :Refresher
   require_nested :SecurityGroup
 
   include ManageIQ::Providers::IbmCloud::VPC::ManagerMixin

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/refresher.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/refresher.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager < ManageIQ::Providers::
   include ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
   include ManageIQ::Providers::StorageManager::BlockMixin
 
+  require_nested :CloudVolume
   require_nested :CloudVolumeType
 
   delegate :authentication_check,

--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager < ManageIQ::Providers::
 
   require_nested :CloudVolume
   require_nested :CloudVolumeType
+  require_nested :Refresher
 
   delegate :authentication_check,
            :authentication_status,

--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
@@ -19,6 +19,7 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager < ManageIQ::Providers::
            :hostname,
            :default_endpoint,
            :endpoints,
+           :provider_region,
            :refresh,
            :refresh_ems,
            :to        => :parent_manager,

--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager/refresher.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager/refresher.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmCloud::VPC::StorageManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+end


### PR DESCRIPTION
- Add missing nested classes
- Add network and storage manager persister methods
- Add cloud_database_flavors as a _cloud_ collection
- Subclass Refresher for network and storage manager
- Delegate 'provider_region' to cloud manager
