### PR TITLE
Rename placement_type to the standard instance_type

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision/payload.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision/payload.rb
@@ -15,7 +15,7 @@ module ManageIQ::Providers::IbmCloud::VPC::CloudManager::Provision::Payload
     payload = {
       :name                      => get_option(:vm_target_name),
       :keys                      => [{:id => get_option(:guest_access_key_pair)}],
-      :profile                   => {:name => get_option_last(:provision_type)},
+      :profile                   => {:name => get_option_last(:instance_type)},
       :image                     => {:id => vm_image[:ems_ref]},
       :zone                      => {:name => get_option_last(:placement_availability_zone)},
       :vpc                       => {:id => get_option(:cloud_network)},

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow/general.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow/general.rb
@@ -2,13 +2,13 @@
 
 # Contains the elements used to populate and validate general fields.
 module ManageIQ::Providers::IbmCloud::VPC::CloudManager::ProvisionWorkflow::General
-  # Fetch system profiles from inventory.
+  # Fetch flavors from inventory.
   # @param _options [void]
   # @return [Hash] Hash with ems_ref as key and name as value.
-  def provision_type_to_profile(_options = {})
+  def allowed_instance_types(_options = {})
     return {} if ar_ems.nil?
 
-    @provision_type_to_profile ||= index_dropdown(ar_ems.flavors)
+    @allowed_instance_types ||= index_dropdown(ar_ems.flavors)
   rescue => e
     logger(__method__).ui_exception(e)
   end

--- a/content/miq_dialogs/miq_provision_ibm_vpc_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_vpc_dialogs_template.yaml
@@ -47,10 +47,10 @@
           :display: :edit
           :data_type: :integer
           :notes_display: :hide
-        :provision_type:
+        :instance_type:
           :description: System Profile
           :values_from:
-            :method: :provision_type_to_profile
+            :method: :allowed_instance_types
           :required: true
           :display: :edit
           :data_type: :integer


### PR DESCRIPTION
There is core code which depends on having an `:instance_type` option
for Cloud-type provision requests.

This should be merged with the schema change: https://github.com/ManageIQ/manageiq-schema/pull/692