### PR TITLE
Use consistent child manager description

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
@@ -37,7 +37,7 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager < ManageIQ::Providers::
   end
 
   def self.description
-    @description ||= "IBM Cloud Servers Storage".freeze
+    @description ||= "IBM Cloud VPC Storage".freeze
   end
 
   def self.hostname_required?


### PR DESCRIPTION
I've been playing around in reporting and noticed this description was inconsistent.
