### PR TITLE
Fix missing System Profile dropdown VPC Provision

### DIFF
--- a/content/miq_dialogs/miq_provision_ibm_vpc_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_vpc_dialogs_template.yaml
@@ -47,13 +47,6 @@
           :display: :edit
           :data_type: :integer
           :notes_display: :hide
-        :instance_type:
-          :description: System Profile
-          :values_from:
-            :method: :allowed_instance_types
-          :required: true
-          :display: :edit
-          :data_type: :integer
         :vm_name:
           :description: Instance Name
           :required_method: :validate_vm_name
@@ -128,6 +121,13 @@
     :hardware:
       :description: Profile
       :fields:
+        :instance_type:
+          :description: System Profile
+          :values_from:
+            :method: :allowed_instance_types
+          :required: true
+          :display: :edit
+          :data_type: :integer
         :storage_type:
           :description: Boot Volume Profile
           :values_from:

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow_spec.rb
@@ -39,6 +39,10 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::ProvisionWorkflow do
       expect(workflow.security_group_to_security_group).to eq({})
     end
 
+    it "#allowed_instance_types" do
+      expect(workflow.allowed_instance_types).to eq({})
+    end
+
     it "#storage_type_to_profile" do
       expect(workflow.storage_type_to_profile).to eq({})
     end
@@ -62,6 +66,14 @@ describe ManageIQ::Providers::IbmCloud::VPC::CloudManager::ProvisionWorkflow do
 
       it "returns the key_pairs" do
         expect(workflow.guest_access_key_pairs_to_keys).to eq(kp.ems_ref => kp.name)
+      end
+    end
+
+    describe "#allowed_instance_types" do
+      let!(:flavor) { FactoryBot.create(:flavor, :ems_ref => "bx2d-2x8", :name => "bx2d-2x8", :ext_management_system => ems) }
+
+      it "returns the instance_types" do
+        expect(workflow.allowed_instance_types).to eq(flavor.id => flavor.name)
       end
     end
 


### PR DESCRIPTION
The VPC Provision Form has to show the "instance_type" selection under the Hardware/Properties tab not the General tab.

I believe this was "working" before with the system type dropdown under "General" because there are other providers (vmware, rhv) which use `:provosion_type` for something else (e.g. ISO vs PXE).  This meant that the UI knew to show a dropdown under `general/provision_type` even if it was for something completely different.

When I renamed this to `instance_type` in https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/457 to be in line with all other cloud providers, I didn't know that the UI wouldn't render it without it being under the `hardware` section.

Before:
![image](https://github.com/ManageIQ/manageiq-providers-ibm_cloud/assets/12851112/c0c5a364-28db-43ac-b42f-b93b24ee1181)

After:
![image](https://github.com/ManageIQ/manageiq-providers-ibm_cloud/assets/12851112/5e402206-cb94-4578-ac7e-0a63b6aefe42)

With this fix in place I can provision a VPC VM successfully
![image](https://github.com/ManageIQ/manageiq-providers-ibm_cloud/assets/12851112/e46ce21f-2dba-455b-8d95-9de12125e08d)
