### PR TITLE
PowerVS: Attach newly created volumes during VM provision

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -82,7 +82,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
 
     attached_volumes = options[:cloud_volumes] || []
     attached_volumes.concat(phase_context[:new_volumes]).compact!
-    specs['volume_ids'] = attached_volumes unless attached_volumes.empty?
+    specs['volume_ids'] = attached_volumes.uniq unless attached_volumes.empty?
 
     attached_networks = case get_option(:vlan)
                         when 'None'

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
@@ -15,9 +15,10 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     if new_volumes.any?
       source.with_provider_connection(:service => "PCloudVolumesApi") do |api|
         new_volumes.each do |new_volume|
-          api.pcloud_cloudinstances_volumes_post(
+          new_volume = api.pcloud_cloudinstances_volumes_post(
             cloud_instance_id, IbmCloudPower::CreateDataVolume.new(new_volume)
           )
+          phase_context[:new_volumes] << new_volume.volume_id
         end
       end
     end


### PR DESCRIPTION
When a user requests new volumes as part of a VM provision, the volumes
need to be created _and_ attached.
