### PR TITLE
Fix clone_to_template provision preparation

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -82,7 +82,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
 
     attached_volumes = options[:cloud_volumes] || []
     attached_volumes.concat(phase_context[:new_volumes]).compact!
-    specs['volume_ids'] = attached_volumes.uniq unless attached_volumes.empty?
+    specs['volume_ids'] = attached_volumes unless attached_volumes.empty?
 
     attached_networks = case get_option(:vlan)
                         when 'None'

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
@@ -2,7 +2,8 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
   def create_destination
     case request_type
     when 'clone_to_template'
-      signal :determine_placement
+      options[:destination] = 'image-catalog'
+      signal :prepare_provision
     else
       signal :prepare_volumes_and_networks
     end
@@ -34,19 +35,5 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     end
 
     signal :prepare_provision
-  end
-
-  def determine_placement
-    options[:destination] = 'image-catalog'
-    signal :start_clone_task
-  end
-
-  def start_clone_task
-    update_and_notify_parent(:message => "Starting Clone of #{clone_direction}")
-    clone_options = prepare_for_clone_task
-    log_clone_options(clone_options)
-    phase_context[:clone_task_ref] = start_clone(clone_options)
-    phase_context.delete(:clone_options)
-    signal :poll_clone_complete
   end
 end


### PR DESCRIPTION
The switch statement in create_destination caused clone_to_template to
skip the prepare_provision phase. Because of this, clone_options was set
in a start_clone_task override. This works perfectly for
clone_to_template, but when provisioning a vm *from* a template the
clone_options parsing gets calls twice - from prepare_provision and the
start_clone_task override.

The start_clone_task override can be dropped entirely if we simply call
prepare_provision for the clone_to_template case.
