### PR TITLE
Remove 'migratable' param from PVS VM provision

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -64,7 +64,6 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     else
       specs['server_name']   = get_option(:vm_target_name)
       specs['memory']        = get_option_last(:vm_memory).to_i
-      specs['migratable']    = get_option_last(:migratable) == 1
       specs['processors']    = get_option_last(:entitled_processors).to_f
       specs['proc_type']     = get_option_last(:instance_type)
       specs['pin_policy']    = get_option_last(:pin_policy)

--- a/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_template.yaml
@@ -51,15 +51,6 @@
           :display: :edit
           :default: 1
           :data_type: :integer
-        :migratable:
-          :values:
-            false: 0
-            true: 1
-          :description: Migratable
-          :required: false
-          :display: :edit
-          :default: true
-          :data_type: :boolean
         :user_script:
           :description: Upload
           :required: false

--- a/lib/tasks_private/power_virtual_servers.rake
+++ b/lib/tasks_private/power_virtual_servers.rake
@@ -106,7 +106,6 @@ namespace :vcr do
           "processors"    => 0.25,
           "memory"        => 2,
           "key_pair_name" => "test-ssh-key-no-comment",
-          "migratable"    => true,
           "pin_policy"    => "none",
           "networks"      => [
             IbmCloudPower::PVMInstanceAddNetwork.new(
@@ -123,7 +122,6 @@ namespace :vcr do
           "processors"      => 0.25,
           "memory"          => 2,
           "key_pair_name"   => "test-ssh-key-with-comment",
-          "migratable"      => false,
           "pin_policy"      => "soft",
           "placement_group" => "test-placement-group-affinity",
           "networks"        => [
@@ -141,7 +139,6 @@ namespace :vcr do
           "processors"      => 1,
           "memory"          => 4,
           "key_pair_name"   => "test-ssh-key-with-comment-line-breaks",
-          "migratable"      => true,
           "pin_policy"      => "hard",
           "networks"        => [
             IbmCloudPower::PVMInstanceAddNetwork.new(
@@ -158,7 +155,6 @@ namespace :vcr do
           "processors"            => 0.50,
           "memory"                => 2,
           "key_pair_name"         => "test-ssh-key-no-comment",
-          "migratable"            => true,
           "pin_policy"            => "none",
           "shared_processor_pool" => "test_pool",
           "networks"              => [
@@ -176,7 +172,6 @@ namespace :vcr do
           "processors"      => 0.75,
           "memory"          => 4,
           "key_pair_name"   => "test-ssh-key-no-comment",
-          "migratable"      => true,
           "pin_policy"      => "none",
           "networks"        => [
             IbmCloudPower::PVMInstanceAddNetwork.new(
@@ -196,7 +191,6 @@ namespace :vcr do
           "processors"      => 1.25,
           "memory"          => 6,
           "key_pair_name"   => "test-ssh-key-no-comment",
-          "migratable"      => true,
           "pin_policy"      => "none",
           "placement_group" => "test-placement-group-anti-affinity",
           "networks"        => [


### PR DESCRIPTION
The PowerVS 'migratable' parameter has been deprecated and replaced by 'pinPolicy'. Pin policy is already included in the VM provisioning dialog.