### PR TITLE
Override quota calculation methods

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
@@ -59,6 +59,15 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template
     _log.error("image=[#{name}], error: #{e}")
   end
 
+  def number_of_cpus_for_request(request, _flavor_id = nil)
+    flavor_obj = Flavor.find_by(:ems_id => ems_id, :name => request.options[:sys_type][1])
+    if flavor_obj.kind_of?(ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SAPProfile)
+      flavor_obj.try(:cpus)
+    else
+      request.get_option(:entitled_processors).to_f.ceil
+    end
+  end
+
   def self.raw_import_image(ext_management_system, options = {})
     session_id = SecureRandom.uuid
     wrkfl_timeout = options['timeout'].to_i.hours

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
@@ -59,6 +59,15 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template
     _log.error("image=[#{name}], error: #{e}")
   end
 
+  def memory_for_request(request, _flavor_id = nil)
+    flavor_obj = Flavor.find_by(:ems_id => ems_id, :name => request.options[:sys_type][1])
+    if flavor_obj.kind_of?(ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SAPProfile)
+      flavor_obj.try(:memory)
+    else
+      request.get_option(:vm_memory).to_i * 1.gigabytes
+    end
+  end
+
   def number_of_cpus_for_request(request, _flavor_id = nil)
     flavor_obj = Flavor.find_by(:ems_id => ems_id, :name => request.options[:sys_type][1])
     if flavor_obj.kind_of?(ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SAPProfile)


### PR DESCRIPTION
Depends on:
https://github.com/ManageIQ/manageiq/pull/22680

PowerVS uses the more typical Flavor style of cpu allocation for SAP
profiles. For non SAP profiles, the Flavor only set the host type and
the user is allowed to request any number of cpus using the
entitled_processors form option.
