### PR TITLE
Handle VPC flavor with nil :disks value

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
@@ -182,7 +182,7 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Provider
   def flavors
     collector.flavors.each do |flavor|
       memory = flavor&.dig(:memory, :value)
-      disk = flavor[:disks].first&.dig(:size, :value) || 0
+      disk = flavor[:disks]&.first&.dig(:size, :value) || 0
       persister.flavors.build(
         :ems_ref         => flavor[:name],
         :name            => flavor[:name],


### PR DESCRIPTION
I noticed VPC refresh failing (us-south region) due to:
```
[----] I, [2023-10-27T17:51:52.340185 #563743:a258]  INFO -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh) Refreshing all targets...
[----] I, [2023-10-27T17:51:52.340287 #563743:a258]  INFO -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh) EMS: [vpc-dallas], id: [3] Refreshing targets for EMS...
[----] I, [2023-10-27T17:51:52.340344 #563743:a258]  INFO -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh) EMS: [vpc-dallas], id: [3]   ManageIQ::Providers::IbmCloud::VPC::CloudManager [vpc-dallas] id [3]
[----] I, [2023-10-27T17:51:55.832719 #563743:a258]  INFO -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh_targets_for_ems) EMS: [vpc-dallas], id: [3] Refreshing target ManageIQ::Providers::IbmCloud::VPC::CloudManager [vpc-dallas] id [3]...
[----] E, [2023-10-27T17:52:12.377043 #563743:a258] ERROR -- evm: MIQ(ManageIQ::Providers::IbmCloud::VPC::CloudManager::Refresher#refresh) EMS: [vpc-dallas], id: [3] Refresh failed
[----] E, [2023-10-27T17:52:12.379667 #563743:a258] ERROR -- evm: [NoMethodError]: undefined method `first' for nil:NilClass  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2023-10-27T17:52:12.380055 #563743:a258] ERROR -- evm: /home/jwcarman/src/github.com/ManageIQ/manageiq-providers-ibm_cloud/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb:185:in `block in flavors'
/home/jwcarman/src/github.com/ManageIQ/manageiq-providers-ibm_cloud/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb:183:in `each'
/home/jwcarman/src/github.com/ManageIQ/manageiq-providers-ibm_cloud/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb:183:in `flavors'
/home/jwcarman/src/github.com/ManageIQ/manageiq-providers-ibm_cloud/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb:19:in `parse'
...
```

I'm not sure if this Flavor is new or something (why wasn't it failing before?), but it does indeed have a `null` disks value:
```
$ ibmcloud is instance-profile bx2-2x8 --json | head
{
    "bandwidth": {
        "type": "fixed",
        "value": 4000
    },
    "disks": null,
    "family": "balanced",
    "href": "https://us-south.iaas.cloud.ibm.com/v1/instance/profiles/bx2-2x8",
    "memory": {
        "type": "fixed",
```