### PR TITLE
Add targeted refresh specs to PowerVS / Fix targeted VM refresh bug

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers/target_collection.rb
@@ -65,6 +65,18 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers::
     []
   end
 
+  def snapshots
+    begin
+      @snapshots ||= snapshots_api.pcloud_cloudinstances_snapshots_getall(cloud_instance_id).snapshots.select do |snapshot|
+        references(:vms).include?(snapshot.pvm_instance_id)
+      end
+    rescue IbmCloudPower::ApiError => err
+      error_message = JSON.parse(err.response_body)["description"]
+      _log.debug("Error retrieving snapshots: #{error_message}")
+      nil
+    end.compact
+  end
+
   private
 
   def parse_targets!

--- a/lib/tasks_private/power_virtual_servers.rake
+++ b/lib/tasks_private/power_virtual_servers.rake
@@ -115,7 +115,7 @@ namespace :vcr do
         ),
         IbmCloudPower::PVMInstanceCreate.new(
           "server_name"     => "test-instance-ibmi-s922-capped-tier1",
-          "image_id"        => "IBMi-75-00-2984-1",
+          "image_id"        => "IBMi-75-02-2984-1",
           "sys_type"        => "s922",
           "proc_type"       => "capped",
           "storage_type"    => "tier1",

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -87,7 +87,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
       expect(CloudNetwork.count).to eq(4)
       expect(CloudSubnet.count).to eq(4)
       expect(CloudSubnetNetworkPort.count).to eq(8)
-      expect(Flavor.count).to eq(56)
+      expect(Flavor.count).to eq(58)
       expect(MiqTemplate.count).to eq(6)
       expect(ManageIQ::Providers::CloudManager::AuthKeyPair.count).to be > 1
       expect(NetworkPort.count).to eq(8)

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -1,4 +1,5 @@
 describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refresher do
+  include Spec::Support::EmsRefreshHelper
   it ".ems_type" do
     expect(described_class.ems_type).to eq(:ibm_cloud_power_virtual_servers)
   end
@@ -64,6 +65,20 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
         full_refresh(ems.network_manager)
         assert_table_counts
         assert_specific_flavor
+      end
+    end
+
+    context "targeted refresh of VM" do
+      before { with_vcr { ems.refresh } }
+
+      context "vm target", :target_vm => true do
+        let(:target) { ems.vms.find_by(:name => "test-instance-ibmi-s922-capped-tier1") }
+
+        it "doesn't impact other inventory" do
+          assert_inventory_not_changed do
+            with_vcr("vm_target") { EmsRefresh.refresh(target) }
+          end
+        end
       end
     end
 

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -111,7 +111,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
 
     def assert_cloud_manager
       expect(ems).to have_attributes(
-        :provider_region => "us-east01"
+        :provider_region => "mon01"
       )
     end
 

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -104,7 +104,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
       expect(ems.network_manager.network_ports.count).to eq(8)
       expect(ems.operating_systems.count).to eq(12)
       expect(ems.placement_groups.count).to eq(2)
-      expect(ems.storage_manager.cloud_volume_types.count).to eq(2)
+      expect(ems.storage_manager.cloud_volume_types.count).to eq(4)
       expect(ems.storage_manager.cloud_volumes.count).to eq(10)
       expect(ems.vms.count).to eq(6)
     end

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -86,7 +86,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
       expect(CloudVolume.count).to eq(10)
       expect(CloudNetwork.count).to eq(4)
       expect(CloudSubnet.count).to eq(4)
-      expect(CloudSubnetNetworkPort.count).to eq(12)
+      expect(CloudSubnetNetworkPort.count).to eq(8)
       expect(Flavor.count).to eq(56)
       expect(MiqTemplate.count).to eq(6)
       expect(ManageIQ::Providers::CloudManager::AuthKeyPair.count).to be > 1

--- a/spec/vcr_cassettes/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher.yml
@@ -23,11 +23,11 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Transaction-Id:
-      - amd6bWw-757e022abd7d4c3fbcdd268b3c2fb3f6
+      - d3Y2MnA-8a0f73483ffc482e85fc4ad3d0eddd95
       X-Request-Id:
-      - 59d07170-c3f4-4a11-a8a4-0445d921fe80
+      - 9b4c989f-0a8e-4939-89a9-b4946f2a2cde
       X-Correlation-Id:
-      - amd6bWw-757e022abd7d4c3fbcdd268b3c2fb3f6
+      - d3Y2MnA-8a0f73483ffc482e85fc4ad3d0eddd95
       Cache-Control:
       - no-cache, no-store, must-revalidate
       Expires:
@@ -39,38 +39,37 @@ http_interactions:
       Content-Language:
       - en-US
       Content-Length:
-      - '1605'
+      - '1532'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 31 Jan 2023 16:51:10 GMT
+      - Thu, 18 Jan 2024 19:27:07 GMT
       Connection:
       - keep-alive
       Akamai-Grn:
-      - 0.d617dd17.1675183870.55dfb693
+      - 0.4df47568.1705606027.b675149a
       X-Proxy-Upstream-Service-Time:
-      - '111'
+      - '159'
     body:
       encoding: ASCII-8BIT
-      string: '{"access_token":"eyJraWQiOiIyMDIzMDExMTA4MjkiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC01NTAwMDVLRUQxIiwiaWQiOiJJQk1pZC01NTAwMDVLRUQxIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiMDEwNTg0NzYtOGQzOS00N2ZiLWE5OWItYzIyYTBlYjI5NmZiIiwiaWRlbnRpZmllciI6IjU1MDAwNUtFRDEiLCJnaXZlbl9uYW1lIjoiSGlybyIsImZhbWlseV9uYW1lIjoiTWl5YW1vdG8iLCJuYW1lIjoiSGlybyBNaXlhbW90byIsImVtYWlsIjoibWl5YW1vdG9oQHVzLmlibS5jb20iLCJzdWIiOiJtaXlhbW90b2hAdXMuaWJtLmNvbSIsImF1dGhuIjp7InN1YiI6Im1peWFtb3RvaEB1cy5pYm0uY29tIiwiaWFtX2lkIjoiSUJNaWQtNTUwMDA1S0VEMSIsIm5hbWUiOiJIaXJvIE1peWFtb3RvIiwiZ2l2ZW5fbmFtZSI6Ikhpcm8iLCJmYW1pbHlfbmFtZSI6Ik1peWFtb3RvIiwiZW1haWwiOiJtaXlhbW90b2hAdXMuaWJtLmNvbSJ9LCJhY2NvdW50Ijp7ImJvdW5kYXJ5IjoiZ2xvYmFsIiwidmFsaWQiOnRydWUsImJzcyI6IjFmZGY1ZWZmYzNmOTQ1Njg4YzAyMWNkMGE4YjQ1YzRkIiwiaW1zX3VzZXJfaWQiOiI5Njk3Mjk0IiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxODMwMTA5In0sImlhdCI6MTY3NTE4Mzg2NywiZXhwIjoxNjc1MTg3NDY3LCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MywiYW1yIjpbInRvdHAiLCJtZmEiLCJvdHAiLCJwd2QiXX0.YQCrs5ofKoSZEmLP2fJ6xSK7zN6MDDksJDHt5raLLWKi1AZ_Nj_OoWcSOW931ZEzaVmcUhgWz7it6IGs0QYvMJunStqtqyL2_f9-Vus8ONddnS--PQ7V0jFl6H9aiIu7BjqVLg2xDYLL9GmVWxfKRLZIbip4P6NLCRFIUdAPLEjfIRgN6CqA3IKFv0DsNW12TqS2-mfuXd7yuBBTBsBNrK9pALk2Qx2C8O86Qas89u51dCAcLvrLm9VlBXqlq1rGi18TVbcGEMJ0lYQ9fobpIwdMXpR_aODb2hP0TZk2pYuscWxfQOSwiSCodGMOvHfiQIupMgRHN3vuxDqmaLb7uQ","refresh_token":"not_supported","ims_user_id":9697294,"token_type":"Bearer","expires_in":3600,"expiration":1675187467,"scope":"ibm
+      string: '{"access_token":"IAMBEARERTOKEN","refresh_token":"not_supported","ims_user_id":7771420,"token_type":"Bearer","expires_in":3600,"expiration":1705609624,"scope":"ibm
         openid"}'
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:10 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:07 GMT
 - request:
     method: get
     uri: https://resource-controller.cloud.ibm.com/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: ''
     headers:
       User-Agent:
-      - ibm_cloud_resource_controller-ruby-sdk-2.0.1 arm64-apple-darwin22 ruby-3.0.5
+      - ibm_cloud_resource_controller-ruby-sdk-2.0.2 x86_64-pc-linux-gnu ruby-3.1.4
       X-Ibmcloud-Sdk-Analytics:
       - service_name=resource_controller;service_version=V2;operation_id=get_resource_instance
       Accept:
       - application/json
       Authorization:
-      - Bearer eyJraWQiOiIyMDIzMDExMTA4MjkiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC01NTAwMDVLRUQxIiwiaWQiOiJJQk1pZC01NTAwMDVLRUQxIiwicmVhbG1pZCI6IklCTWlkIiwianRpIjoiMDEwNTg0NzYtOGQzOS00N2ZiLWE5OWItYzIyYTBlYjI5NmZiIiwiaWRlbnRpZmllciI6IjU1MDAwNUtFRDEiLCJnaXZlbl9uYW1lIjoiSGlybyIsImZhbWlseV9uYW1lIjoiTWl5YW1vdG8iLCJuYW1lIjoiSGlybyBNaXlhbW90byIsImVtYWlsIjoibWl5YW1vdG9oQHVzLmlibS5jb20iLCJzdWIiOiJtaXlhbW90b2hAdXMuaWJtLmNvbSIsImF1dGhuIjp7InN1YiI6Im1peWFtb3RvaEB1cy5pYm0uY29tIiwiaWFtX2lkIjoiSUJNaWQtNTUwMDA1S0VEMSIsIm5hbWUiOiJIaXJvIE1peWFtb3RvIiwiZ2l2ZW5fbmFtZSI6Ikhpcm8iLCJmYW1pbHlfbmFtZSI6Ik1peWFtb3RvIiwiZW1haWwiOiJtaXlhbW90b2hAdXMuaWJtLmNvbSJ9LCJhY2NvdW50Ijp7ImJvdW5kYXJ5IjoiZ2xvYmFsIiwidmFsaWQiOnRydWUsImJzcyI6IjFmZGY1ZWZmYzNmOTQ1Njg4YzAyMWNkMGE4YjQ1YzRkIiwiaW1zX3VzZXJfaWQiOiI5Njk3Mjk0IiwiZnJvemVuIjp0cnVlLCJpbXMiOiIxODMwMTA5In0sImlhdCI6MTY3NTE4Mzg2NywiZXhwIjoxNjc1MTg3NDY3LCJpc3MiOiJodHRwczovL2lhbS5jbG91ZC5pYm0uY29tL2lkZW50aXR5IiwiZ3JhbnRfdHlwZSI6InVybjppYm06cGFyYW1zOm9hdXRoOmdyYW50LXR5cGU6YXBpa2V5Iiwic2NvcGUiOiJpYm0gb3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCIsImFjciI6MywiYW1yIjpbInRvdHAiLCJtZmEiLCJvdHAiLCJwd2QiXX0.YQCrs5ofKoSZEmLP2fJ6xSK7zN6MDDksJDHt5raLLWKi1AZ_Nj_OoWcSOW931ZEzaVmcUhgWz7it6IGs0QYvMJunStqtqyL2_f9-Vus8ONddnS--PQ7V0jFl6H9aiIu7BjqVLg2xDYLL9GmVWxfKRLZIbip4P6NLCRFIUdAPLEjfIRgN6CqA3IKFv0DsNW12TqS2-mfuXd7yuBBTBsBNrK9pALk2Qx2C8O86Qas89u51dCAcLvrLm9VlBXqlq1rGi18TVbcGEMJ0lYQ9fobpIwdMXpR_aODb2hP0TZk2pYuscWxfQOSwiSCodGMOvHfiQIupMgRHN3vuxDqmaLb7uQ
+      - Bearer IAMBEARERTOKEN
       Connection:
       - close
   response:
@@ -81,17 +80,17 @@ http_interactions:
       Content-Type:
       - application/json
       Request-Id:
-      - d1a9e0af-a52c-4313-baa9-77586944051e
+      - 3c46bfcb-5acf-4fd7-848d-789288361c90
       Retry-After:
       - '0'
       Strict-Transport-Security:
       - max-age=31536000;includeSubDomains
       Transaction-Id:
-      - bss-ec0d5fd106f8b3ee
+      - bss-e9adacd3b34aa054
       X-Content-Type-Options:
       - nosniff
       X-Global-Transaction-Id:
-      - bss-ec0d5fd106f8b3ee
+      - bss-e9adacd3b34aa054
       X-Op-Completion-Time:
       - ''
       X-Ratelimit-Limit:
@@ -101,47 +100,46 @@ http_interactions:
       X-Ratelimit-Reset:
       - '0'
       X-Request-Id:
-      - d1a9e0af-a52c-4313-baa9-77586944051e
+      - 3c46bfcb-5acf-4fd7-848d-789288361c90
       X-Transaction-Id:
-      - bss-ec0d5fd106f8b3ee
+      - bss-e9adacd3b34aa054
       X-Envoy-Upstream-Service-Time:
-      - '254'
+      - '381'
       Server:
       - istio-envoy
       Content-Length:
       - '2116'
       Expires:
-      - Tue, 31 Jan 2023 16:51:10 GMT
+      - Thu, 18 Jan 2024 19:27:07 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
       Date:
-      - Tue, 31 Jan 2023 16:51:10 GMT
+      - Thu, 18 Jan 2024 19:27:07 GMT
       Connection:
       - close
     body:
-      encoding: ASCII-8BIT
-      string: '{"id":"crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","guid":"IBM_CLOUD_POWERVS_INSTANCE_ID","url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID","created_at":"2022-01-04T19:19:27.00879531Z","updated_at":"2022-05-28T10:58:12.563242645Z","deleted_at":null,"created_by":"IBMid-2700063YVN","updated_by":"IBMid-2700063YVN","deleted_by":"","scheduled_reclaim_at":null,"restored_at":null,"scheduled_reclaim_by":"","restored_by":"","name":"rdr-power.control.plane.test-hcm-us-east01-miq-specs","region_id":"us-east01","account_id":"1fdf5effc3f945688c021cd0a8b45c4d","reseller_channel_id":"","resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","resource_group_id":"2f9167fcfa9c4e2a951c5d8fa22bd01f","resource_group_crn":"crn:v1:bluemix:public:resource-controller::a/1fdf5effc3f945688c021cd0a8b45c4d::resource-group:2f9167fcfa9c4e2a951c5d8fa22bd01f","target_crn":"crn:v1:bluemix:public:globalcatalog::::deployment:f165dd34-3a40-423b-9d95-e90a23f724dd%3Aus-east0159210","allow_cleanup":false,"crn":"crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","state":"active","type":"service_instance","resource_id":"abd259f0-9990-11e8-acc8-b9f54a8f1661","dashboard_url":"https://power-iaas.cloud.ibm.com/authenticate","last_operation":{"type":"create","state":"succeeded","async":true,"description":"service
+      encoding: UTF-8
+      string: '{"id":"crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","guid":"IBM_CLOUD_POWERVS_INSTANCE_ID","url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID","created_at":"2022-01-04T19:19:27.00879531Z","updated_at":"2022-05-28T10:58:12.563242645Z","deleted_at":null,"created_by":"IBMid-2700063YVN","updated_by":"IBMid-2700063YVN","deleted_by":"","scheduled_reclaim_at":null,"restored_at":null,"scheduled_reclaim_by":"","restored_by":"","name":"rdr-power.control.plane.test-hcm-mon01-miq-specs","region_id":"mon01","account_id":"1fdf5effc3f945688c021cd0a8b45c4d","reseller_channel_id":"","resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","resource_group_id":"2f9167fcfa9c4e2a951c5d8fa22bd01f","resource_group_crn":"crn:v1:bluemix:public:resource-controller::a/1fdf5effc3f945688c021cd0a8b45c4d::resource-group:2f9167fcfa9c4e2a951c5d8fa22bd01f","target_crn":"crn:v1:bluemix:public:globalcatalog::::deployment:f165dd34-3a40-423b-9d95-e90a23f724dd%3Amon0159210","allow_cleanup":false,"crn":"crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","state":"active","type":"service_instance","resource_id":"abd259f0-9990-11e8-acc8-b9f54a8f1661","dashboard_url":"https://power-iaas.cloud.ibm.com/authenticate","last_operation":{"type":"create","state":"succeeded","async":true,"description":"service
         instance IBM_CLOUD_POWERVS_INSTANCE_ID was provisioned successfully for account
-        1fdf5effc3f945688c021cd0a8b45c4d in region us-east01","cancelable":false,"poll":false},"resource_aliases_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_aliases","resource_bindings_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_bindings","resource_keys_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_keys","plan_history":[{"resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","start_date":"2022-01-04T19:19:27.00879531Z","requestor_id":"IBMid-2700063YVN"}],"migrated":false,"controlled_by":"","locked":false}
+        1fdf5effc3f945688c021cd0a8b45c4d in region mon01","cancelable":false,"poll":false},"resource_aliases_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_aliases","resource_bindings_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_bindings","resource_keys_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_keys","plan_history":[{"resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","start_date":"2022-01-04T19:19:27.00879531Z","requestor_id":"IBMid-2700063YVN"}],"migrated":false,"controlled_by":"","locked":false}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:10 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:07 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -160,24 +158,23 @@ http_interactions:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"images":[{"creationDate":"2022-11-15T22:45:40.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/8de97d73-95c0-46e9-a509-0b10be36eded","imageID":"8de97d73-95c0-46e9-a509-0b10be36eded","lastUpdateDate":"2022-11-15T22:47:23.000Z","name":"7300-00-01","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"aix"},"state":"active","storagePool":"Tier3-Flash-1","storageType":"tier3"},{"creationDate":"2022-11-15T22:45:06.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/7da758c0-949b-4b11-a306-dc7dfc33919e","imageID":"7da758c0-949b-4b11-a306-dc7dfc33919e","lastUpdateDate":"2022-11-15T22:46:13.000Z","name":"CentOS-Stream-8","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"Tier3-Flash-1","storageType":"tier3"},{"creationDate":"2022-11-15T22:41:45.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/dadb9d07-f092-415e-bb1c-8c7ae91afadd","imageID":"dadb9d07-f092-415e-bb1c-8c7ae91afadd","lastUpdateDate":"2022-11-15T22:43:15.000Z","name":"IBMi-75-00-2984-1","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"Tier3-Flash-1","storageType":"tier3"},{"creationDate":"2022-11-15T22:42:20.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/10d7c4a5-32a7-44a9-b9e1-9a428a4da5d9","imageID":"10d7c4a5-32a7-44a9-b9e1-9a428a4da5d9","lastUpdateDate":"2022-11-15T22:44:09.000Z","name":"RHEL8-SP6","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"rhel"},"state":"active","storagePool":"Tier3-Flash-1","storageType":"tier3"},{"creationDate":"2022-11-12T11:36:56.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/a0198511-c877-4f6f-b1c3-64312fcdb92c","imageID":"a0198511-c877-4f6f-b1c3-64312fcdb92c","lastUpdateDate":"2022-11-12T11:39:15.000Z","name":"SLES15-SP4","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"sles"},"state":"active","storagePool":"Tier3-Flash-1","storageType":"tier3"},{"creationDate":"2022-01-28T22:32:39.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/032d72bf-89f2-44a9-bbc4-ab898dd93309","imageID":"032d72bf-89f2-44a9-bbc4-ab898dd93309","lastUpdateDate":"2022-01-28T22:36:51.000Z","name":"rhcos-4.8","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"import","operatingSystem":"rhel"},"state":"active","storagePool":"Tier3-Flash-2","storageType":"tier3"}]}
+      string: '{"images":[{"creationDate":"2022-11-15T22:45:40.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/8de97d73-95c0-46e9-a509-0b10be36eded","imageID":"8de97d73-95c0-46e9-a509-0b10be36eded","lastUpdateDate":"2023-06-07T01:38:14.000Z","name":"7300-00-01","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"aix"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-15T22:45:06.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/7da758c0-949b-4b11-a306-dc7dfc33919e","imageID":"7da758c0-949b-4b11-a306-dc7dfc33919e","lastUpdateDate":"2023-06-07T01:38:15.000Z","name":"CentOS-Stream-8","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2024-01-18T18:41:35.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/9eebf535-9b78-450e-bffd-e7cb4d3c9e94","imageID":"9eebf535-9b78-450e-bffd-e7cb4d3c9e94","lastUpdateDate":"2024-01-18T18:41:35.000Z","name":"IBMi-75-02-2984-1","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-15T22:42:20.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/10d7c4a5-32a7-44a9-b9e1-9a428a4da5d9","imageID":"10d7c4a5-32a7-44a9-b9e1-9a428a4da5d9","lastUpdateDate":"2023-06-07T01:38:17.000Z","name":"RHEL8-SP6","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-12T11:36:56.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/a0198511-c877-4f6f-b1c3-64312fcdb92c","imageID":"a0198511-c877-4f6f-b1c3-64312fcdb92c","lastUpdateDate":"2023-06-07T01:38:19.000Z","name":"SLES15-SP4","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"sles"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-01-28T22:32:39.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/032d72bf-89f2-44a9-bbc4-ab898dd93309","imageID":"032d72bf-89f2-44a9-bbc4-ab898dd93309","lastUpdateDate":"2023-12-14T21:46:24.000Z","name":"rhcos-4.8","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"import","operatingSystem":"rhel"},"state":"active","storagePool":"General-Flash-81","storageType":"tier3"}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:11 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:09 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/system-pools
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/system-pools
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -190,32 +187,29 @@ http_interactions:
     headers:
       Content-Type:
       - application/json
-      Content-Length:
-      - '1383'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"e980":{"capacity":{"cores":141.25,"memory":14968},"coreMemoryRatio":64,"maxAvailable":{"cores":66,"memory":13845},"maxCoresAvailable":{"cores":66,"memory":13845},"maxMemoryAvailable":{"cores":66,"memory":13845},"sharedCoreRatio":{"default":0.25,"max":1,"min":0.05},"systems":[{"cores":66,"id":1,"memory":13845}],"type":"e980"},"s922":{"capacity":{"cores":15,"memory":927},"coreMemoryRatio":64,"maxAvailable":{"cores":5.25,"memory":821},"maxCoresAvailable":{"cores":5.25,"memory":616},"maxMemoryAvailable":{"cores":5,"memory":821},"sharedCoreRatio":{"default":0.25,"max":1,"min":0.05},"systems":[{"cores":5.25,"id":8,"memory":616},{"cores":5,"id":23,"memory":536},{"cores":5,"id":13,"memory":821},{"cores":4.75,"id":5,"memory":485},{"cores":4.5,"id":15,"memory":661},{"cores":4.25,"id":11,"memory":705},{"cores":4.25,"id":17,"memory":784},{"cores":4.25,"id":4,"memory":550},{"cores":4,"id":7,"memory":646},{"cores":4,"id":18,"memory":392},{"cores":3.76,"id":16,"memory":575},{"cores":3.76,"id":6,"memory":408},{"cores":3.75,"id":12,"memory":469},{"cores":3.5,"id":20,"memory":511},{"cores":3.25,"id":9,"memory":495},{"cores":2.76,"id":19,"memory":440},{"cores":2.75,"id":14,"memory":579},{"cores":2.75,"id":21,"memory":551},{"cores":1.5,"id":10,"memory":458},{"cores":1.5,"id":25,"memory":410},{"cores":1.5,"id":24,"memory":486},{"cores":1.26,"id":22,"memory":335}],"type":"s922"}}
+      string: '{"e980":{"capacity":{"cores":88,"memory":12564,"totalCores":null,"totalMemory":null},"coreMemoryRatio":64,"maxAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"maxCoresAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"maxMemoryAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"sharedCoreRatio":{"default":0.25,"max":1,"min":0.05},"systems":[{"cores":59.5,"id":1,"memory":11779,"totalCores":null,"totalMemory":null}],"type":"e980"},"s922":{"capacity":{"cores":15,"memory":935,"totalCores":null,"totalMemory":null},"coreMemoryRatio":64,"maxAvailable":{"cores":14.25,"memory":902,"totalCores":null,"totalMemory":null},"maxCoresAvailable":{"cores":14.25,"memory":897,"totalCores":null,"totalMemory":null},"maxMemoryAvailable":{"cores":6,"memory":902,"totalCores":null,"totalMemory":null},"sharedCoreRatio":{"default":0.25,"max":1,"min":0.05},"systems":[{"cores":14.25,"id":14,"memory":897,"totalCores":null,"totalMemory":null},{"cores":12.3,"id":25,"memory":895,"totalCores":null,"totalMemory":null},{"cores":11.75,"id":18,"memory":884,"totalCores":null,"totalMemory":null},{"cores":10.25,"id":12,"memory":849,"totalCores":null,"totalMemory":null},{"cores":9.5,"id":11,"memory":874,"totalCores":null,"totalMemory":null},{"cores":9,"id":15,"memory":880,"totalCores":null,"totalMemory":null},{"cores":8.25,"id":9,"memory":681,"totalCores":null,"totalMemory":null},{"cores":7.5,"id":8,"memory":843,"totalCores":null,"totalMemory":null},{"cores":6,"id":17,"memory":902,"totalCores":null,"totalMemory":null},{"cores":5.5,"id":23,"memory":598,"totalCores":null,"totalMemory":null},{"cores":4.5,"id":5,"memory":728,"totalCores":null,"totalMemory":null},{"cores":4.5,"id":21,"memory":738,"totalCores":null,"totalMemory":null},{"cores":4,"id":13,"memory":822,"totalCores":null,"totalMemory":null},{"cores":3.5,"id":10,"memory":624,"totalCores":null,"totalMemory":null},{"cores":1.5,"id":20,"memory":855,"totalCores":null,"totalMemory":null},{"cores":0.5,"id":24,"memory":519,"totalCores":null,"totalMemory":null},{"cores":0.26,"id":19,"memory":397,"totalCores":null,"totalMemory":null},{"cores":0.26,"id":16,"memory":485,"totalCores":null,"totalMemory":null},{"cores":0.01,"id":6,"memory":556,"totalCores":null,"totalMemory":null},{"cores":0,"id":4,"memory":533,"totalCores":null,"totalMemory":null},{"cores":0,"id":22,"memory":455,"totalCores":null,"totalMemory":null},{"cores":0,"id":7,"memory":320,"totalCores":null,"totalMemory":null}],"type":"s922"}}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:13 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:09 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -236,24 +230,23 @@ http_interactions:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"capabilities":["cloud-connections","direct-link-transit-gateway","ibmi-software-licenses","linux","pinning","rhel-sap","sap","snapshots","volume-clone","vpn-connections","shared-processor-pools"],"cloudInstanceID":"c8d0ac7c30c944f0ac3288eb8bb74aaa","enabled":true,"initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"IBM_CLOUD_POWERVS_INSTANCE_ID","openstackID":"07389ca7-2266-4303-afd3-5babc1cebe20","pvmInstances":[],"region":"us-east01","tenantID":"1fdf5effc3f945688c021cd0a8b45c4d","usage":{"instances":0,"memory":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0,"storageStandard":0}}
+      string: '{"capabilities":["cloud-connections","direct-link-transit-gateway","ibmi-software-licenses","linux","pinning","rhel-sap","sap","snapshots","volume-clone","vpn-connections","shared-processor-pools"],"cloudInstanceID":"c8d0ac7c30c944f0ac3288eb8bb74aaa","enabled":true,"initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"IBM_CLOUD_POWERVS_INSTANCE_ID","openstackID":"07389ca7-2266-4303-afd3-5babc1cebe20","pvmInstances":[],"region":"mon01","tenantID":"1fdf5effc3f945688c021cd0a8b45c4d","usage":{"instances":0,"memory":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0,"storageStandard":0}}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:15 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:10 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/sap
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/sap
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -272,62 +265,23 @@ http_interactions:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"profiles":[{"certified":true,"cores":16,"memory":1600,"profileID":"bh1-16x1600","type":"balanced"},{"certified":true,"cores":20,"memory":2000,"profileID":"bh1-20x2000","type":"balanced"},{"certified":true,"cores":22,"memory":2200,"profileID":"bh1-22x2200","type":"balanced"},{"certified":true,"cores":25,"memory":2500,"profileID":"bh1-25x2500","type":"balanced"},{"certified":true,"cores":30,"memory":3000,"profileID":"bh1-30x3000","type":"balanced"},{"certified":true,"cores":35,"memory":3500,"profileID":"bh1-35x3500","type":"balanced"},{"certified":true,"cores":40,"memory":4000,"profileID":"bh1-40x4000","type":"balanced"},{"certified":true,"cores":50,"memory":5000,"profileID":"bh1-50x5000","type":"balanced"},{"certified":true,"cores":60,"memory":6000,"profileID":"bh1-60x6000","type":"balanced"},{"certified":true,"cores":70,"memory":7000,"profileID":"bh1-70x7000","type":"balanced"},{"certified":true,"cores":80,"memory":8000,"profileID":"bh1-80x8000","type":"balanced"},{"certified":true,"cores":100,"memory":10000,"profileID":"bh1-100x10000","type":"balanced"},{"certified":true,"cores":120,"memory":12000,"profileID":"bh1-120x12000","type":"balanced"},{"certified":true,"cores":140,"memory":14000,"profileID":"bh1-140x14000","type":"balanced"},{"certified":true,"cores":60,"memory":3000,"profileID":"ch1-60x3000","type":"compute"},{"certified":true,"cores":70,"memory":3500,"profileID":"ch1-70x3500","type":"compute"},{"certified":true,"cores":80,"memory":4000,"profileID":"ch1-80x4000","type":"compute"},{"certified":true,"cores":100,"memory":5000,"profileID":"ch1-100x5000","type":"compute"},{"certified":true,"cores":120,"memory":6000,"profileID":"ch1-120x6000","type":"compute"},{"certified":true,"cores":140,"memory":7000,"profileID":"ch1-140x7000","type":"compute"},{"certified":true,"cores":8,"memory":1440,"profileID":"mh1-8x1440","type":"memory"},{"certified":true,"cores":10,"memory":1800,"profileID":"mh1-10x1800","type":"memory"},{"certified":true,"cores":12,"memory":2160,"profileID":"mh1-12x2160","type":"memory"},{"certified":true,"cores":16,"memory":2880,"profileID":"mh1-16x2880","type":"memory"},{"certified":true,"cores":20,"memory":3600,"profileID":"mh1-20x3600","type":"memory"},{"certified":true,"cores":22,"memory":3960,"profileID":"mh1-22x3960","type":"memory"},{"certified":true,"cores":25,"memory":4500,"profileID":"mh1-25x4500","type":"memory"},{"certified":true,"cores":30,"memory":5400,"profileID":"mh1-30x5400","type":"memory"},{"certified":true,"cores":35,"memory":6300,"profileID":"mh1-35x6300","type":"memory"},{"certified":true,"cores":40,"memory":7200,"profileID":"mh1-40x7200","type":"memory"},{"certified":true,"cores":50,"memory":9000,"profileID":"mh1-50x9000","type":"memory"},{"certified":true,"cores":60,"memory":10800,"profileID":"mh1-60x10800","type":"memory"},{"certified":true,"cores":70,"memory":12600,"profileID":"mh1-70x12600","type":"memory"},{"certified":true,"cores":80,"memory":14400,"profileID":"mh1-80x14400","type":"memory"},{"certified":true,"cores":4,"memory":128,"profileID":"ush1-4x128","type":"small"},{"certified":true,"cores":4,"memory":256,"profileID":"ush1-4x256","type":"small"},{"certified":true,"cores":4,"memory":384,"profileID":"ush1-4x384","type":"small"},{"certified":true,"cores":4,"memory":512,"profileID":"ush1-4x512","type":"small"},{"certified":true,"cores":4,"memory":768,"profileID":"ush1-4x768","type":"small"},{"certified":true,"cores":4,"memory":960,"profileID":"umh-4x960","type":"ultra-memory"},{"certified":true,"cores":6,"memory":1440,"profileID":"umh-6x1440","type":"ultra-memory"},{"certified":true,"cores":8,"memory":1920,"profileID":"umh-8x1920","type":"ultra-memory"},{"certified":true,"cores":10,"memory":2400,"profileID":"umh-10x2400","type":"ultra-memory"},{"certified":true,"cores":12,"memory":2880,"profileID":"umh-12x2880","type":"ultra-memory"},{"certified":true,"cores":16,"memory":3840,"profileID":"umh-16x3840","type":"ultra-memory"},{"certified":true,"cores":20,"memory":4800,"profileID":"umh-20x4800","type":"ultra-memory"},{"certified":true,"cores":22,"memory":5280,"profileID":"umh-22x5280","type":"ultra-memory"},{"certified":true,"cores":25,"memory":6000,"profileID":"umh-25x6000","type":"ultra-memory"},{"certified":true,"cores":30,"memory":7200,"profileID":"umh-30x7200","type":"ultra-memory"},{"certified":true,"cores":35,"memory":8400,"profileID":"umh-35x8400","type":"ultra-memory"},{"certified":true,"cores":40,"memory":9600,"profileID":"umh-40x9600","type":"ultra-memory"},{"certified":true,"cores":50,"memory":12000,"profileID":"umh-50x12000","type":"ultra-memory"},{"certified":true,"cores":60,"memory":14400,"profileID":"umh-60x14400","type":"ultra-memory"},{"certified":false,"cores":1,"memory":128,"profileID":"np1-1x128","type":"non-production"}]}
+      string: '{"profiles":[{"certified":true,"cores":16,"memory":1600,"profileID":"bh1-16x1600","type":"balanced"},{"certified":true,"cores":20,"memory":2000,"profileID":"bh1-20x2000","type":"balanced"},{"certified":true,"cores":22,"memory":2200,"profileID":"bh1-22x2200","type":"balanced"},{"certified":true,"cores":25,"memory":2500,"profileID":"bh1-25x2500","type":"balanced"},{"certified":true,"cores":30,"memory":3000,"profileID":"bh1-30x3000","type":"balanced"},{"certified":true,"cores":35,"memory":3500,"profileID":"bh1-35x3500","type":"balanced"},{"certified":true,"cores":40,"memory":4000,"profileID":"bh1-40x4000","type":"balanced"},{"certified":true,"cores":50,"memory":5000,"profileID":"bh1-50x5000","type":"balanced"},{"certified":true,"cores":60,"memory":6000,"profileID":"bh1-60x6000","type":"balanced"},{"certified":true,"cores":70,"memory":7000,"profileID":"bh1-70x7000","type":"balanced"},{"certified":true,"cores":80,"memory":8000,"profileID":"bh1-80x8000","type":"balanced"},{"certified":true,"cores":100,"memory":10000,"profileID":"bh1-100x10000","type":"balanced"},{"certified":true,"cores":120,"memory":12000,"profileID":"bh1-120x12000","type":"balanced"},{"certified":true,"cores":140,"memory":14000,"profileID":"bh1-140x14000","type":"balanced"},{"certified":true,"cores":60,"memory":3000,"profileID":"ch1-60x3000","type":"compute"},{"certified":true,"cores":70,"memory":3500,"profileID":"ch1-70x3500","type":"compute"},{"certified":true,"cores":80,"memory":4000,"profileID":"ch1-80x4000","type":"compute"},{"certified":true,"cores":100,"memory":5000,"profileID":"ch1-100x5000","type":"compute"},{"certified":true,"cores":120,"memory":6000,"profileID":"ch1-120x6000","type":"compute"},{"certified":true,"cores":140,"memory":7000,"profileID":"ch1-140x7000","type":"compute"},{"certified":true,"cores":8,"memory":1440,"profileID":"mh1-8x1440","type":"memory"},{"certified":true,"cores":10,"memory":1800,"profileID":"mh1-10x1800","type":"memory"},{"certified":true,"cores":12,"memory":2160,"profileID":"mh1-12x2160","type":"memory"},{"certified":true,"cores":16,"memory":2880,"profileID":"mh1-16x2880","type":"memory"},{"certified":true,"cores":20,"memory":3600,"profileID":"mh1-20x3600","type":"memory"},{"certified":true,"cores":22,"memory":3960,"profileID":"mh1-22x3960","type":"memory"},{"certified":true,"cores":25,"memory":4500,"profileID":"mh1-25x4500","type":"memory"},{"certified":true,"cores":30,"memory":5400,"profileID":"mh1-30x5400","type":"memory"},{"certified":true,"cores":35,"memory":6300,"profileID":"mh1-35x6300","type":"memory"},{"certified":true,"cores":40,"memory":7200,"profileID":"mh1-40x7200","type":"memory"},{"certified":true,"cores":50,"memory":9000,"profileID":"mh1-50x9000","type":"memory"},{"certified":true,"cores":60,"memory":10800,"profileID":"mh1-60x10800","type":"memory"},{"certified":true,"cores":70,"memory":12600,"profileID":"mh1-70x12600","type":"memory"},{"certified":true,"cores":80,"memory":14400,"profileID":"mh1-80x14400","type":"memory"},{"certified":true,"cores":90,"memory":16200,"profileID":"mh1-90x16200","type":"memory"},{"certified":true,"cores":100,"memory":18000,"profileID":"mh1-100x18000","type":"memory"},{"certified":true,"cores":4,"memory":128,"profileID":"ush1-4x128","type":"small"},{"certified":true,"cores":4,"memory":256,"profileID":"ush1-4x256","type":"small"},{"certified":true,"cores":4,"memory":384,"profileID":"ush1-4x384","type":"small"},{"certified":true,"cores":4,"memory":512,"profileID":"ush1-4x512","type":"small"},{"certified":true,"cores":4,"memory":768,"profileID":"ush1-4x768","type":"small"},{"certified":true,"cores":4,"memory":960,"profileID":"umh-4x960","type":"ultra-memory"},{"certified":true,"cores":6,"memory":1440,"profileID":"umh-6x1440","type":"ultra-memory"},{"certified":true,"cores":8,"memory":1920,"profileID":"umh-8x1920","type":"ultra-memory"},{"certified":true,"cores":10,"memory":2400,"profileID":"umh-10x2400","type":"ultra-memory"},{"certified":true,"cores":12,"memory":2880,"profileID":"umh-12x2880","type":"ultra-memory"},{"certified":true,"cores":16,"memory":3840,"profileID":"umh-16x3840","type":"ultra-memory"},{"certified":true,"cores":20,"memory":4800,"profileID":"umh-20x4800","type":"ultra-memory"},{"certified":true,"cores":22,"memory":5280,"profileID":"umh-22x5280","type":"ultra-memory"},{"certified":true,"cores":25,"memory":6000,"profileID":"umh-25x6000","type":"ultra-memory"},{"certified":true,"cores":30,"memory":7200,"profileID":"umh-30x7200","type":"ultra-memory"},{"certified":true,"cores":35,"memory":8400,"profileID":"umh-35x8400","type":"ultra-memory"},{"certified":true,"cores":40,"memory":9600,"profileID":"umh-40x9600","type":"ultra-memory"},{"certified":true,"cores":50,"memory":12000,"profileID":"umh-50x12000","type":"ultra-memory"},{"certified":true,"cores":60,"memory":14400,"profileID":"umh-60x14400","type":"ultra-memory"},{"certified":false,"cores":1,"memory":128,"profileID":"np1-1x128","type":"non-production"}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:16 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:10 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/storage-capacity/storage-types
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/storage-capacity/storage-types
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '853'
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"maximumStorageAllocation":{"maxAllocationSize":299273,"storagePool":"Tier3-Flash-2","storageType":"tier3"},"storageTypesCapacity":[{"maximumStorageAllocation":{"maxAllocationSize":295188,"storagePool":"Tier1-Flash-1","storageType":"tier1"},"storagePoolsCapacity":[{"maxAllocationSize":295137,"poolName":"Tier1-Flash-2","storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":295188,"poolName":"Tier1-Flash-1","storageType":"tier1","totalCapacity":390092}],"storageType":"tier1"},{"maximumStorageAllocation":{"maxAllocationSize":299273,"storagePool":"Tier3-Flash-2","storageType":"tier3"},"storagePoolsCapacity":[{"maxAllocationSize":299273,"poolName":"Tier3-Flash-2","storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":270591,"poolName":"Tier3-Flash-1","storageType":"tier3","totalCapacity":390092}],"storageType":"tier3"}]}
-
-        '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:19 GMT
-- request:
-    method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -346,24 +300,23 @@ http_interactions:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"volumes":[{"bootVolume":false,"bootable":true,"creationDate":"2023-01-31T01:29:43.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/volumes/72995028-8f21-4a3c-83a9-620c82699c4a","lastUpdateDate":"2023-01-31T01:30:09.000Z","name":"test-instance-862a0a0f-0001d786-boot-0","pvmInstanceIDs":["862a0a0f-92b6-409c-b2d0-852bff557669"],"shareable":false,"size":100,"state":"in-use","volumeID":"72995028-8f21-4a3c-83a9-620c82699c4a","volumePool":"Tier3-Flash-2","volumeType":"Tier3-Flash-2","wwn":"60050768108002DAC800000000001D21"},{"bootVolume":false,"bootable":true,"creationDate":"2023-01-30T17:56:44.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/volumes/ac381925-fb6b-4fcc-8306-444c1ba99e2d","lastUpdateDate":"2023-01-30T17:57:11.000Z","name":"test-instance-b35fecac-0001d6ff-boot-0","pvmInstanceIDs":["b35fecac-450d-4344-a87b-a14c459de44a"],"shareable":false,"size":120,"state":"in-use","volumeID":"ac381925-fb6b-4fcc-8306-444c1ba99e2d","volumePool":"Tier3-Flash-2","volumeType":"Tier3-Flash-2","wwn":"60050768108002DAC800000000001D0F"},{"bootVolume":false,"bootable":true,"creationDate":"2023-01-30T17:54:52.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/volumes/70ecc94d-ff42-4a33-b1fd-ca4c4d76152d","lastUpdateDate":"2023-01-30T17:55:12.000Z","name":"test-instance-0c186073-0001d6fc-boot-0","pvmInstanceIDs":["0c186073-26b2-4cbb-bf4e-e64057db23b0"],"shareable":false,"size":100,"state":"in-use","volumeID":"70ecc94d-ff42-4a33-b1fd-ca4c4d76152d","volumePool":"Tier3-Flash-2","volumeType":"Tier3-Flash-2","wwn":"60050768108002DAC800000000001D0E"},{"bootVolume":false,"bootable":true,"creationDate":"2023-01-30T17:51:39.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/volumes/043cd4de-15e1-41fc-8dc4-1b6714785078","lastUpdateDate":"2023-01-30T17:51:58.000Z","name":"test-instance-22f161cb-0001d6f6-boot-0","pvmInstanceIDs":["22f161cb-024d-42ba-8081-7d72019d6b59"],"shareable":false,"size":120,"state":"in-use","volumeID":"043cd4de-15e1-41fc-8dc4-1b6714785078","volumePool":"Tier3-Flash-2","volumeType":"Tier3-Flash-2","wwn":"60050768108002DAC800000000001D0C"},{"bootVolume":false,"bootable":true,"creationDate":"2023-01-30T17:49:20.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/volumes/5cdf032a-5c6f-409f-8413-2214f14f2a69","lastUpdateDate":"2023-01-30T17:49:47.000Z","name":"test-instance-46578c3d-0001d6f3-boot-0","pvmInstanceIDs":["46578c3d-a771-4410-8c9c-33f95b470e88"],"shareable":false,"size":100,"state":"in-use","volumeID":"5cdf032a-5c6f-409f-8413-2214f14f2a69","volumePool":"Tier1-Flash-1","volumeType":"Tier1-Flash-1","wwn":"60050768108101DAC000000000022977"},{"bootVolume":false,"bootable":true,"creationDate":"2023-01-30T17:47:12.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/volumes/88c1c414-634d-47e7-81fe-041c0add78d9","lastUpdateDate":"2023-01-30T17:47:40.000Z","name":"test-instance-afd27dad-0001d6f0-boot-0","pvmInstanceIDs":["afd27dad-9513-47f1-9dba-59a37b494127"],"shareable":false,"size":25,"state":"in-use","volumeID":"88c1c414-634d-47e7-81fe-041c0add78d9","volumePool":"Tier1-Flash-1","volumeType":"Tier1-Flash-1","wwn":"60050768108101DAC000000000022976"},{"bootVolume":false,"bootable":false,"creationDate":"2023-01-30T17:46:18.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/volumes/a8d23809-094d-4d7b-a9af-fd6a5ee0ef42","lastUpdateDate":"2023-01-30T17:46:20.000Z","name":"test-volume-15GB-tier1-notsharable","pvmInstanceIDs":[],"shareable":false,"size":15,"state":"available","volumeID":"a8d23809-094d-4d7b-a9af-fd6a5ee0ef42","volumePool":"Tier1-Flash-1","volumeType":"Tier1-Flash-1","wwn":"60050768108101DAC000000000022975"},{"bootVolume":false,"bootable":false,"creationDate":"2023-01-30T17:46:14.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/volumes/7add0150-e375-42aa-9e70-2ab042d46d93","lastUpdateDate":"2023-01-30T17:46:15.000Z","name":"test-volume-3GB-tier1-notsharable","pvmInstanceIDs":[],"shareable":false,"size":3,"state":"available","volumeID":"7add0150-e375-42aa-9e70-2ab042d46d93","volumePool":"Tier1-Flash-1","volumeType":"Tier1-Flash-1","wwn":"60050768108101DAC000000000022974"},{"bootVolume":false,"bootable":false,"creationDate":"2023-01-30T17:46:08.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/volumes/e103c649-7614-4837-a779-4cf227d7a627","lastUpdateDate":"2023-01-30T17:46:09.000Z","name":"test-volume-10GB-tier3-sharable","pvmInstanceIDs":[],"shareable":true,"size":10,"state":"available","volumeID":"e103c649-7614-4837-a779-4cf227d7a627","volumePool":"Tier3-Flash-2","volumeType":"Tier3-Flash-2","wwn":"60050768108002DAC800000000001D0B"},{"bootVolume":false,"bootable":false,"creationDate":"2023-01-30T17:46:03.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/volumes/c46702c8-d935-4214-ba8d-7ef89706f42a","lastUpdateDate":"2023-01-30T17:46:04.000Z","name":"test-volume-1GB-tier3-sharable","pvmInstanceIDs":[],"shareable":true,"size":1,"state":"available","volumeID":"c46702c8-d935-4214-ba8d-7ef89706f42a","volumePool":"Tier3-Flash-2","volumeType":"Tier3-Flash-2","wwn":"60050768108002DAC800000000001D0A"}]}
+      string: '{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"any"},"storageTypesCapacity":[{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier0"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092}],"storageType":"tier0"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier1"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092}],"storageType":"tier1"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier3"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092}],"storageType":"tier3"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier5k"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092}],"storageType":"tier5k"}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:19 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:12 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -382,108 +335,33 @@ http_interactions:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"pvmInstances":[{"addresses":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/862a0a0f-92b6-409c-b2d0-852bff557669/networks/test-network-pub-vlan-dns","ip":"127.0.0.139","ipAddress":"127.0.0.139","macAddress":"fa:a9:48:05:28:20","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"creationDate":"2023-01-31T01:29:35.000Z","diskSize":100,"health":{"lastUpdate":"2023-01-31T16:51:22.848709","status":"OK"},"hostID":22,"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/862a0a0f-92b6-409c-b2d0-852bff557669","imageID":"eea8ba65-7468-4871-8442-39ee45594f45","maxmem":16,"maxproc":1,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/862a0a0f-92b6-409c-b2d0-852bff557669/networks/test-network-pub-vlan-dns","ip":"127.0.0.139","ipAddress":"127.0.0.139","macAddress":"fa:a9:48:05:28:20","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"operatingSystem":"Linux/Red
-        Hat Enterprise Linux 4.18.0-127.0.0.el8.ppc64l8.6 (Ootpa), 8.6 (Ootpa)","osType":"rhel","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.5,"pvmInstanceID":"862a0a0f-92b6-409c-b2d0-852bff557669","serverName":"test-instance-rhel-s922-shared-tier3","sharedProcessorPool":"test_pool","sharedProcessorPoolID":"6a0f7faf-1cf4-4533-9871-3426085394ff","srcs":[],"status":"ACTIVE","storagePool":"Tier3-Flash-2","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2023-01-31T01:29:35.000Z","virtualCores":{"assigned":1,"max":8,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a/networks/test-network-pub-vlan-dns","ip":"127.0.0.138","ipAddress":"127.0.0.138","macAddress":"fa:ea:24:4e:c8:21","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a/networks/test-network-vlan-jumbo","ip":"127.0.0.20","ipAddress":"127.0.0.20","macAddress":"fa:ea:24:4e:c8:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"creationDate":"2023-01-30T17:56:36.000Z","diskSize":120,"health":{"lastUpdate":"2023-01-31T16:51:22.848769","status":"WARNING"},"hostID":14,"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a","imageID":"032d72bf-89f2-44a9-bbc4-ab898dd93309","maxmem":48,"maxproc":10,"memory":6,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a/networks/test-network-pub-vlan-dns","ip":"127.0.0.138","ipAddress":"127.0.0.138","macAddress":"fa:ea:24:4e:c8:21","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a/networks/test-network-vlan-jumbo","ip":"127.0.0.20","ipAddress":"127.0.0.20","macAddress":"fa:ea:24:4e:c8:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"127.0.0.0.0.0","osType":"rhel","pinPolicy":"none","placementGroup":"cc87f5d8-af58-4644-a16b-7571e0d5d9e8","procType":"shared","processors":1.25,"pvmInstanceID":"b35fecac-450d-4344-a87b-a14c459de44a","serverName":"test-instance-rhcos-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"Tier3-Flash-2","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2023-01-30T17:56:36.000Z","virtualCores":{"assigned":2,"max":16,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0/networks/test-network-pub-vlan","ip":"127.0.0.109","ipAddress":"127.0.0.109","macAddress":"fa:20:48:80:0c:21","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0/networks/test-network-vlan","ip":"127.0.0.209","ipAddress":"127.0.0.209","macAddress":"fa:20:48:80:0c:20","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2023-01-30T17:54:44.000Z","diskSize":100,"health":{"lastUpdate":"2023-01-31T16:51:22.848802","status":"OK"},"hostID":8,"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0","imageID":"8aa5f4d8-1b6a-4416-bc64-bd01c00d071a","maxmem":32,"maxproc":6,"memory":4,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0/networks/test-network-pub-vlan","ip":"127.0.0.109","ipAddress":"127.0.0.109","macAddress":"fa:20:48:80:0c:21","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0/networks/test-network-vlan","ip":"127.0.0.209","ipAddress":"127.0.0.209","macAddress":"fa:20:48:80:0c:20","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/SLES
-        5.14.21-150400.24.11-defa15-SP4, 15-SP4","osType":"sles","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.75,"pvmInstanceID":"0c186073-26b2-4cbb-bf4e-e64057db23b0","serverName":"test-instance-sles-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"Tier3-Flash-2","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2023-01-30T17:54:44.000Z","virtualCores":{"assigned":1,"max":8,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/22f161cb-024d-42ba-8081-7d72019d6b59/networks/test-network-pub-vlan","ip":"127.0.0.110","ipAddress":"127.0.0.110","macAddress":"fa:24:f8:9a:85:20","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"creationDate":"2023-01-30T17:51:30.000Z","diskSize":120,"health":{"lastUpdate":"2023-01-31T16:51:22.848826","status":"OK"},"hostID":1,"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/22f161cb-024d-42ba-8081-7d72019d6b59","imageID":"689a1b67-cb62-43b1-804b-aa89c75c37bd","maxmem":32,"maxproc":8,"memory":4,"minmem":2,"minproc":1,"networks":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/22f161cb-024d-42ba-8081-7d72019d6b59/networks/test-network-pub-vlan","ip":"127.0.0.110","ipAddress":"127.0.0.110","macAddress":"fa:24:f8:9a:85:20","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/CentOS
-        Stream 4.18.0-373.el8.ppc64le, 8","osType":"rhel","pinPolicy":"hard","placementGroup":"none","procType":"dedicated","processors":1,"pvmInstanceID":"22f161cb-024d-42ba-8081-7d72019d6b59","serverName":"test-instance-centos-e980-dedicated-tier3","srcs":[],"status":"ACTIVE","storagePool":"Tier3-Flash-2","storagePoolAffinity":true,"storageType":"tier3","sysType":"e980","updatedDate":"2023-01-30T17:51:30.000Z","virtualCores":{"assigned":1,"max":8,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/46578c3d-a771-4410-8c9c-33f95b470e88/networks/test-network-vlan-jumbo","ip":"127.0.0.40","ipAddress":"127.0.0.40","macAddress":"fa:da:83:7e:e2:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"consoleLanguage":{"code":"037","language":"037
-        English"},"creationDate":"2023-01-30T17:49:08.000Z","diskSize":100,"health":{"lastUpdate":"2023-01-31T16:51:22.848851","status":"OK"},"hostID":8,"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/46578c3d-a771-4410-8c9c-33f95b470e88","imageID":"107ebbab-9231-4f83-951c-7859ef5393a3","maxmem":16,"maxproc":2,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/46578c3d-a771-4410-8c9c-33f95b470e88/networks/test-network-vlan-jumbo","ip":"127.0.0.40","ipAddress":"127.0.0.40","macAddress":"fa:da:83:7e:e2:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"V7R5M0
-        1990 0","osType":"ibmi","pinPolicy":"none","placementGroup":"3fad2500-22df-4f2e-a0f8-530564a7163f","procType":"capped","processors":0.25,"pvmInstanceID":"46578c3d-a771-4410-8c9c-33f95b470e88","serverName":"test-instance-ibmi-s922-capped-tier1","softwareLicenses":{"ibmiCSS":false,"ibmiDBQ":false,"ibmiPHA":false,"ibmiRDS":false},"srcs":[[{"src":"A6005008","timestamp":"2023-01-30T17:57:46Z"},{"src":"03B00061","timestamp":"2023-01-30T17:57:46Z"},{"src":"FFFF0000","timestamp":"2023-01-30T17:57:46Z"},{"src":"00000000","timestamp":"2023-01-30T17:57:46Z"},{"src":"00000000","timestamp":"2023-01-30T17:57:46Z"},{"src":"50070404","timestamp":"2023-01-30T17:57:46Z"},{"src":"00000000","timestamp":"2023-01-30T17:57:46Z"},{"src":"00000000","timestamp":"2023-01-30T17:57:46Z"},{"src":"00000000","timestamp":"2023-01-30T17:57:46Z"}]],"status":"ACTIVE","storagePool":"Tier1-Flash-1","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2023-01-30T17:49:08.000Z","virtualCores":{"assigned":1,"max":4,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/afd27dad-9513-47f1-9dba-59a37b494127/networks/test-network-vlan","ip":"127.0.0.113","ipAddress":"127.0.0.113","macAddress":"fa:b0:7c:d0:50:20","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2023-01-30T17:46:57.000Z","diskSize":25,"health":{"lastUpdate":"2023-01-31T16:51:22.848875","status":"OK"},"hostID":14,"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/afd27dad-9513-47f1-9dba-59a37b494127","imageID":"d7cb1f7c-1737-4cad-95c1-16a927e969b1","maxmem":16,"maxproc":2,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/afd27dad-9513-47f1-9dba-59a37b494127/networks/test-network-vlan","ip":"127.0.0.113","ipAddress":"127.0.0.113","macAddress":"fa:b0:7c:d0:50:20","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"AIX
-        7.3, 7300-00-01-2148","osType":"aix","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.25,"pvmInstanceID":"afd27dad-9513-47f1-9dba-59a37b494127","serverName":"test-instance-aix-s922-shared-tier1","srcs":[[{"src":"00000000","timestamp":"2023-01-30T17:50:08Z"}]],"status":"ACTIVE","storagePool":"Tier1-Flash-1","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2023-01-30T17:46:57.000Z","virtualCores":{"assigned":1,"max":5,"min":1}}]}
+      string: '{"volumes":[{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T19:02:29.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/7d6f53e6-4adf-4792-8b5f-07cc618dff78","ioThrottleRate":"360
+        iops","lastUpdateDate":"2024-01-18T19:13:21.000Z","name":"test-instance-d6a661a8-00030ebf-boot-0","pvmInstanceIDs":["d6a661a8-fed1-4a52-9d50-24fc9f9956b8"],"shareable":false,"size":120,"state":"in-use","volumeID":"7d6f53e6-4adf-4792-8b5f-07cc618dff78","volumePool":"General-Flash-81","volumeType":"Tier3-General-Flash-81","wwn":"60050768108002DAC800000000004AF4"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:49:45.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/ba26d663-1e76-4457-8732-9d9235df8019","ioThrottleRate":"300
+        iops","lastUpdateDate":"2024-01-18T19:00:43.000Z","name":"test-instance-54e1f646-00030ebe-boot-0","pvmInstanceIDs":["54e1f646-8ce4-4ee5-9355-e5d34166c4fd"],"shareable":false,"size":100,"state":"in-use","volumeID":"ba26d663-1e76-4457-8732-9d9235df8019","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C4"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:47:54.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/984498df-5554-4685-a109-821d5e39b27b","ioThrottleRate":"300
+        iops","lastUpdateDate":"2024-01-18T18:48:16.000Z","name":"test-instance-b9370d8d-00030ebb-boot-0","pvmInstanceIDs":["b9370d8d-8d73-4f0e-ad84-34f7fd52eb84"],"shareable":false,"size":100,"state":"in-use","volumeID":"984498df-5554-4685-a109-821d5e39b27b","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C3"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:45:07.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/cdfebbb2-d64e-41e1-9834-4f6b5d249489","ioThrottleRate":"360
+        iops","lastUpdateDate":"2024-01-18T18:45:34.000Z","name":"test-instance-1ea38460-00030eb6-boot-0","pvmInstanceIDs":["1ea38460-b3ff-4abd-802b-0289983be590"],"shareable":false,"size":120,"state":"in-use","volumeID":"cdfebbb2-d64e-41e1-9834-4f6b5d249489","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C2"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:43:15.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/ed84f79b-b8d1-48c3-8766-2a92ff6a879b","ioThrottleRate":"1000
+        iops","lastUpdateDate":"2024-01-18T18:43:38.000Z","name":"test-instance-e8cf72cf-00030eb4-boot-0","pvmInstanceIDs":["e8cf72cf-7685-4bfb-a386-66422f71820a"],"shareable":false,"size":100,"state":"in-use","volumeID":"ed84f79b-b8d1-48c3-8766-2a92ff6a879b","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274C1"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T17:24:51.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/2e653913-14fe-4b3a-a4f3-c7396bed0862","ioThrottleRate":"250
+        iops","lastUpdateDate":"2024-01-18T17:25:13.000Z","name":"test-instance-502106d8-00030ea7-boot-0","pvmInstanceIDs":["502106d8-d969-49df-9103-184c3ab97508"],"shareable":false,"size":25,"state":"in-use","volumeID":"2e653913-14fe-4b3a-a4f3-c7396bed0862","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274BB"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:13.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/21f2d430-44fd-4f5e-af43-66076e6e9af7","ioThrottleRate":"150
+        iops","lastUpdateDate":"2024-01-18T17:24:14.000Z","name":"test-volume-15GB-tier1-notsharable","pvmInstanceIDs":[],"shareable":false,"size":15,"state":"available","volumeID":"21f2d430-44fd-4f5e-af43-66076e6e9af7","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274BA"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:07.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/5bb66445-1de3-4817-8590-42b35f21f9d8","ioThrottleRate":"30
+        iops","lastUpdateDate":"2024-01-18T17:24:08.000Z","name":"test-volume-3GB-tier1-notsharable","pvmInstanceIDs":[],"shareable":false,"size":3,"state":"available","volumeID":"5bb66445-1de3-4817-8590-42b35f21f9d8","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274B9"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:03.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/f302fbf6-c2f7-4df2-b80c-c3c2e8055d77","ioThrottleRate":"30
+        iops","lastUpdateDate":"2024-01-18T17:24:04.000Z","name":"test-volume-10GB-tier3-sharable","pvmInstanceIDs":[],"shareable":true,"size":10,"state":"available","volumeID":"f302fbf6-c2f7-4df2-b80c-c3c2e8055d77","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274B8"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:23:57.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/46eef916-ea40-4aee-9e0c-df840da65867","ioThrottleRate":"3
+        iops","lastUpdateDate":"2024-01-18T17:23:58.000Z","name":"test-volume-1GB-tier3-sharable","pvmInstanceIDs":[],"shareable":true,"size":1,"state":"available","volumeID":"46eef916-ea40-4aee-9e0c-df840da65867","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274B7"}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:25 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:12 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/862a0a0f-92b6-409c-b2d0-852bff557669
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1819'
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"addresses":[{"externalIP":"127.0.0.11","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/862a0a0f-92b6-409c-b2d0-852bff557669/networks/91cace34-2dcf-4b2d-8195-7202e8686cb3","ip":"127.0.0.139","ipAddress":"127.0.0.139","macAddress":"fa:a9:48:05:28:20","networkID":"91cace34-2dcf-4b2d-8195-7202e8686cb3","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"creationDate":"2023-01-31T01:29:35.000Z","diskSize":100,"health":{"lastUpdate":"2023-01-31T16:51:26.984549","status":"OK"},"hostID":22,"imageID":"eea8ba65-7468-4871-8442-39ee45594f45","maxmem":16,"maxproc":1,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["91cace34-2dcf-4b2d-8195-7202e8686cb3"],"networks":[{"externalIP":"127.0.0.11","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/862a0a0f-92b6-409c-b2d0-852bff557669/networks/91cace34-2dcf-4b2d-8195-7202e8686cb3","ip":"127.0.0.139","ipAddress":"127.0.0.139","macAddress":"fa:a9:48:05:28:20","networkID":"91cace34-2dcf-4b2d-8195-7202e8686cb3","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"operatingSystem":"Linux/Red
-        Hat Enterprise Linux 4.18.0-127.0.0.el8.ppc64l8.6 (Ootpa), 8.6 (Ootpa)","osType":"rhel","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.5,"pvmInstanceID":"862a0a0f-92b6-409c-b2d0-852bff557669","serverName":"test-instance-rhel-s922-shared-tier3","sharedProcessorPool":"test_pool","sharedProcessorPoolID":"6a0f7faf-1cf4-4533-9871-3426085394ff","srcs":[],"status":"ACTIVE","storagePool":"Tier3-Flash-2","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2023-01-31T01:29:35.000Z","virtualCores":{"assigned":1,"max":8,"min":1},"volumeIDs":["72995028-8f21-4a3c-83a9-620c82699c4a"]}
-
-        '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:28 GMT
-- request:
-    method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/eea8ba65-7468-4871-8442-39ee45594f45
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '559'
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"creationDate":"2022-07-21T18:32:49.000Z","imageID":"eea8ba65-7468-4871-8442-39ee45594f45","lastUpdateDate":"2022-07-21T19:15:55.000Z","name":"RHEL8-SP6","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"rhel"},"state":"active","storagePool":"Tier3-Flash-2","storageType":"tier3","volumes":[{"bootable":true,"name":"Imported
-        image volume","size":100,"volumeID":"385a2645-42a9-4110-9073-f877fa2ad31f"}]}
-
-        '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:30 GMT
-- request:
-    method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -502,24 +380,29 @@ http_interactions:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"addresses":[{"externalIP":"127.0.0.10","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a/networks/91cace34-2dcf-4b2d-8195-7202e8686cb3","ip":"127.0.0.138","ipAddress":"127.0.0.138","macAddress":"fa:ea:24:4e:c8:21","networkID":"91cace34-2dcf-4b2d-8195-7202e8686cb3","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a/networks/563c573d-edd8-4d26-a223-cb4b4d407abd","ip":"127.0.0.20","ipAddress":"127.0.0.20","macAddress":"fa:ea:24:4e:c8:20","networkID":"563c573d-edd8-4d26-a223-cb4b4d407abd","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"creationDate":"2023-01-30T17:56:36.000Z","diskSize":120,"health":{"lastUpdate":"2023-01-31T16:51:31.851837","status":"WARNING"},"hostID":14,"imageID":"032d72bf-89f2-44a9-bbc4-ab898dd93309","maxmem":48,"maxproc":10,"memory":6,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["91cace34-2dcf-4b2d-8195-7202e8686cb3","563c573d-edd8-4d26-a223-cb4b4d407abd"],"networks":[{"externalIP":"127.0.0.10","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a/networks/91cace34-2dcf-4b2d-8195-7202e8686cb3","ip":"127.0.0.138","ipAddress":"127.0.0.138","macAddress":"fa:ea:24:4e:c8:21","networkID":"91cace34-2dcf-4b2d-8195-7202e8686cb3","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a/networks/563c573d-edd8-4d26-a223-cb4b4d407abd","ip":"127.0.0.20","ipAddress":"127.0.0.20","macAddress":"fa:ea:24:4e:c8:20","networkID":"563c573d-edd8-4d26-a223-cb4b4d407abd","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"127.0.0.0.0.0","osType":"rhel","pinPolicy":"none","placementGroup":"cc87f5d8-af58-4644-a16b-7571e0d5d9e8","procType":"shared","processors":1.25,"pvmInstanceID":"b35fecac-450d-4344-a87b-a14c459de44a","serverName":"test-instance-rhcos-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"Tier3-Flash-2","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2023-01-30T17:56:36.000Z","virtualCores":{"assigned":2,"max":16,"min":1},"volumeIDs":["ac381925-fb6b-4fcc-8306-444c1ba99e2d"]}
+      string: '{"pvmInstances":[{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/test-network-pub-vlan-dns","ip":"127.0.0.122","ipAddress":"127.0.0.122","macAddress":"fa:7f:f8:6b:9e:21","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/test-network-vlan-jumbo","ip":"127.0.0.10","ipAddress":"127.0.0.10","macAddress":"fa:7f:f8:6b:9e:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"creationDate":"2024-01-18T19:02:24.000Z","diskSize":120,"health":{"lastUpdate":"2024-01-18T19:27:12.850166","status":"WARNING"},"hostID":19,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8","imageID":"032d72bf-89f2-44a9-bbc4-ab898dd93309","maxmem":48,"maxproc":10,"memory":6,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/test-network-pub-vlan-dns","ip":"127.0.0.122","ipAddress":"127.0.0.122","macAddress":"fa:7f:f8:6b:9e:21","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/test-network-vlan-jumbo","ip":"127.0.0.10","ipAddress":"127.0.0.10","macAddress":"fa:7f:f8:6b:9e:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"127.0.0.0.0.0","osType":"rhel","pinPolicy":"none","placementGroup":"f99c2fc5-73ba-4387-9736-61dc51f53471","procType":"shared","processors":1.25,"pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8","serverName":"test-instance-rhcos-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-81","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T19:02:24.000Z","virtualCores":{"assigned":2,"max":16,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/test-network-pub-vlan","ip":"127.0.0.46","ipAddress":"127.0.0.46","macAddress":"fa:1a:90:7c:8a:21","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/test-network-vlan","ip":"127.0.0.208","ipAddress":"127.0.0.208","macAddress":"fa:1a:90:7c:8a:20","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T18:49:40.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:27:12.850195","status":"OK"},"hostID":19,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd","imageID":"38cac9ad-d422-46d7-acda-9024dd17c034","maxmem":32,"maxproc":6,"memory":4,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/test-network-pub-vlan","ip":"127.0.0.46","ipAddress":"127.0.0.46","macAddress":"fa:1a:90:7c:8a:21","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/test-network-vlan","ip":"127.0.0.208","ipAddress":"127.0.0.208","macAddress":"fa:1a:90:7c:8a:20","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/SLES
+        5.14.21-150400.24.11-defa15-SP4, 15-SP4","osType":"sles","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.75,"pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd","serverName":"test-instance-sles-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T18:49:40.000Z","virtualCores":{"assigned":1,"max":8,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84/networks/test-network-pub-vlan-dns","ip":"127.0.0.124","ipAddress":"127.0.0.124","macAddress":"fa:a0:0e:97:fe:20","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"creationDate":"2024-01-18T18:47:48.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:27:12.850216","status":"OK"},"hostID":6,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","imageID":"62ae0e80-e11b-45cd-a955-90fc08d7191c","maxmem":16,"maxproc":1,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84/networks/test-network-pub-vlan-dns","ip":"127.0.0.124","ipAddress":"127.0.0.124","macAddress":"fa:a0:0e:97:fe:20","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"operatingSystem":"Linux/Red
+        Hat Enterprise Linux 4.18.0-127.0.0.el8.ppc64l8.6 (Ootpa), 8.6 (Ootpa)","osType":"rhel","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.5,"pvmInstanceID":"b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","serverName":"test-instance-rhel-s922-shared-tier3","sharedProcessorPool":"test_pool","sharedProcessorPoolID":"85029156-8753-4d06-9a56-d13e3bd4c27d","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T18:47:48.000Z","virtualCores":{"assigned":1,"max":8,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590/networks/test-network-pub-vlan","ip":"127.0.0.45","ipAddress":"127.0.0.45","macAddress":"fa:50:f2:44:d6:20","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T18:45:03.000Z","diskSize":120,"health":{"lastUpdate":"2024-01-18T19:27:12.850236","status":"OK"},"hostID":1,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590","imageID":"69992304-1da0-4e66-a957-b95a58fb7d5c","maxmem":32,"maxproc":8,"memory":4,"minmem":2,"minproc":1,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590/networks/test-network-pub-vlan","ip":"127.0.0.45","ipAddress":"127.0.0.45","macAddress":"fa:50:f2:44:d6:20","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/CentOS
+        Stream 4.18.0-497.el8.ppc64le, 8","osType":"rhel","pinPolicy":"hard","placementGroup":"none","procType":"dedicated","processors":1,"pvmInstanceID":"1ea38460-b3ff-4abd-802b-0289983be590","serverName":"test-instance-centos-e980-dedicated-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"e980","updatedDate":"2024-01-18T18:45:03.000Z","virtualCores":{"assigned":1,"max":8,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/test-network-vlan-jumbo","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"consoleLanguage":{"code":"037","language":"037
+        English"},"creationDate":"2024-01-18T18:43:09.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:27:12.850256","status":"OK"},"hostID":7,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a","imageID":"ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2","maxmem":16,"maxproc":2,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/test-network-vlan-jumbo","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"V7R5M0
+        410 2","osType":"ibmi","pinPolicy":"none","placementGroup":"8334ba79-bd98-47af-ad25-6eb8a1c4c817","procType":"capped","processors":0.25,"pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a","serverName":"test-instance-ibmi-s922-capped-tier1","softwareLicenses":{"ibmiCSS":false,"ibmiDBQ":false,"ibmiPHA":false,"ibmiRDS":false},"srcs":[[{"src":"A6005008","timestamp":"2024-01-18T18:51:32Z"},{"src":"03B00061","timestamp":"2024-01-18T18:51:32Z"},{"src":"FFFF0000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"50070404","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"}]],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2024-01-18T18:43:09.000Z","virtualCores":{"assigned":1,"max":4,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508/networks/test-network-vlan","ip":"127.0.0.186","ipAddress":"127.0.0.186","macAddress":"fa:46:3d:6b:a1:20","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T17:24:40.000Z","diskSize":25,"health":{"lastUpdate":"2024-01-18T19:27:12.850275","status":"OK"},"hostID":4,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508","imageID":"45afea97-e991-41f4-8ef9-44d5e893ff45","maxmem":16,"maxproc":2,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508/networks/test-network-vlan","ip":"127.0.0.186","ipAddress":"127.0.0.186","macAddress":"fa:46:3d:6b:a1:20","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"AIX
+        7.3, 7300-00-01-2148","osType":"aix","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.25,"pvmInstanceID":"502106d8-d969-49df-9103-184c3ab97508","serverName":"test-instance-aix-s922-shared-tier1","srcs":[[{"src":"00000000","timestamp":"2024-01-18T17:27:40Z"}]],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2024-01-18T17:24:40.000Z","virtualCores":{"assigned":1,"max":5,"min":1}}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:34 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:15 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -538,25 +421,59 @@ http_interactions:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"addresses":[{"externalIP":"127.0.0.237","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0/networks/f9c99b4d-9dd6-4af2-b76a-5ad030a93262","ip":"127.0.0.109","ipAddress":"127.0.0.109","macAddress":"fa:20:48:80:0c:21","networkID":"f9c99b4d-9dd6-4af2-b76a-5ad030a93262","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0/networks/b656f9f4-ac42-4a3f-a85e-cf05161bd4d0","ip":"127.0.0.209","ipAddress":"127.0.0.209","macAddress":"fa:20:48:80:0c:20","networkID":"b656f9f4-ac42-4a3f-a85e-cf05161bd4d0","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2023-01-30T17:54:44.000Z","diskSize":100,"health":{"lastUpdate":"2023-01-31T16:51:35.572873","status":"OK"},"hostID":8,"imageID":"8aa5f4d8-1b6a-4416-bc64-bd01c00d071a","maxmem":32,"maxproc":6,"memory":4,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["f9c99b4d-9dd6-4af2-b76a-5ad030a93262","b656f9f4-ac42-4a3f-a85e-cf05161bd4d0"],"networks":[{"externalIP":"127.0.0.237","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0/networks/f9c99b4d-9dd6-4af2-b76a-5ad030a93262","ip":"127.0.0.109","ipAddress":"127.0.0.109","macAddress":"fa:20:48:80:0c:21","networkID":"f9c99b4d-9dd6-4af2-b76a-5ad030a93262","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0/networks/b656f9f4-ac42-4a3f-a85e-cf05161bd4d0","ip":"127.0.0.209","ipAddress":"127.0.0.209","macAddress":"fa:20:48:80:0c:20","networkID":"b656f9f4-ac42-4a3f-a85e-cf05161bd4d0","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/SLES
-        5.14.21-150400.24.11-defa15-SP4, 15-SP4","osType":"sles","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.75,"pvmInstanceID":"0c186073-26b2-4cbb-bf4e-e64057db23b0","serverName":"test-instance-sles-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"Tier3-Flash-2","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2023-01-30T17:54:44.000Z","virtualCores":{"assigned":1,"max":8,"min":1},"volumeIDs":["70ecc94d-ff42-4a33-b1fd-ca4c4d76152d"]}
+      string: '{"addresses":[{"externalIP":"127.0.0.122","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b","ip":"127.0.0.122","ipAddress":"127.0.0.122","macAddress":"fa:7f:f8:6b:9e:21","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.10","ipAddress":"127.0.0.10","macAddress":"fa:7f:f8:6b:9e:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"creationDate":"2024-01-18T19:02:24.000Z","diskSize":120,"health":{"lastUpdate":"2024-01-18T19:27:16.580231","status":"WARNING"},"hostID":19,"imageID":"032d72bf-89f2-44a9-bbc4-ab898dd93309","maxmem":48,"maxproc":10,"memory":6,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["3e0c10e1-7cca-44b4-865d-ebd369169a1b","925c13aa-9579-43a3-86e1-150131906835"],"networks":[{"externalIP":"127.0.0.122","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b","ip":"127.0.0.122","ipAddress":"127.0.0.122","macAddress":"fa:7f:f8:6b:9e:21","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.10","ipAddress":"127.0.0.10","macAddress":"fa:7f:f8:6b:9e:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"127.0.0.0.0.0","osType":"rhel","pinPolicy":"none","placementGroup":"f99c2fc5-73ba-4387-9736-61dc51f53471","procType":"shared","processors":1.25,"pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8","serverName":"test-instance-rhcos-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-81","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T19:02:24.000Z","virtualCores":{"assigned":2,"max":16,"min":1},"volumeIDs":["7d6f53e6-4adf-4792-8b5f-07cc618dff78"]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:37 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:17 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/8aa5f4d8-1b6a-4416-bc64-bd01c00d071a
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"addresses":[{"externalIP":"127.0.0.46","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5","ip":"127.0.0.46","ipAddress":"127.0.0.46","macAddress":"fa:1a:90:7c:8a:21","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/3de2f865-8726-43a3-8ee8-a385aa851adf","ip":"127.0.0.208","ipAddress":"127.0.0.208","macAddress":"fa:1a:90:7c:8a:20","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T18:49:40.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:27:18.089259","status":"OK"},"hostID":19,"imageID":"38cac9ad-d422-46d7-acda-9024dd17c034","maxmem":32,"maxproc":6,"memory":4,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["11896394-64c5-4d6d-8a2f-a9ad829348c5","3de2f865-8726-43a3-8ee8-a385aa851adf"],"networks":[{"externalIP":"127.0.0.46","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5","ip":"127.0.0.46","ipAddress":"127.0.0.46","macAddress":"fa:1a:90:7c:8a:21","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/3de2f865-8726-43a3-8ee8-a385aa851adf","ip":"127.0.0.208","ipAddress":"127.0.0.208","macAddress":"fa:1a:90:7c:8a:20","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/SLES
+        5.14.21-150400.24.11-defa15-SP4, 15-SP4","osType":"sles","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.75,"pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd","serverName":"test-instance-sles-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T18:49:40.000Z","virtualCores":{"assigned":1,"max":8,"min":1},"volumeIDs":["ba26d663-1e76-4457-8732-9d9235df8019"]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:27:18 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/38cac9ad-d422-46d7-acda-9024dd17c034
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -570,32 +487,30 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '560'
+      - '433'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"creationDate":"2022-09-13T16:56:18.000Z","imageID":"8aa5f4d8-1b6a-4416-bc64-bd01c00d071a","lastUpdateDate":"2022-09-13T18:07:59.000Z","name":"SLES15-SP4","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"sles"},"state":"active","storagePool":"Tier3-Flash-2","storageType":"tier3","volumes":[{"bootable":true,"name":"Imported
-        image volume","size":100,"volumeID":"dbcd1a8b-b6be-4ebe-a9c9-533135d6e00a"}]}
+      string: '{"creationDate":"2023-12-13T02:27:06.000Z","imageID":"38cac9ad-d422-46d7-acda-9024dd17c034","lastUpdateDate":"2023-12-13T02:41:10.000Z","name":"SLES15-SP4","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"sles"},"state":"active","storagePool":"","storageType":"","volumes":[]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:39 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:20 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/22f161cb-024d-42ba-8081-7d72019d6b59
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -609,32 +524,31 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1683'
+      - '1829'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"addresses":[{"externalIP":"127.0.0.238","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/22f161cb-024d-42ba-8081-7d72019d6b59/networks/f9c99b4d-9dd6-4af2-b76a-5ad030a93262","ip":"127.0.0.110","ipAddress":"127.0.0.110","macAddress":"fa:24:f8:9a:85:20","networkID":"f9c99b4d-9dd6-4af2-b76a-5ad030a93262","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"creationDate":"2023-01-30T17:51:30.000Z","diskSize":120,"health":{"lastUpdate":"2023-01-31T16:51:40.178248","status":"OK"},"hostID":1,"imageID":"689a1b67-cb62-43b1-804b-aa89c75c37bd","maxmem":32,"maxproc":8,"memory":4,"migratable":false,"minmem":2,"minproc":1,"networkIDs":["f9c99b4d-9dd6-4af2-b76a-5ad030a93262"],"networks":[{"externalIP":"127.0.0.238","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/22f161cb-024d-42ba-8081-7d72019d6b59/networks/f9c99b4d-9dd6-4af2-b76a-5ad030a93262","ip":"127.0.0.110","ipAddress":"127.0.0.110","macAddress":"fa:24:f8:9a:85:20","networkID":"f9c99b4d-9dd6-4af2-b76a-5ad030a93262","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/CentOS
-        Stream 4.18.0-373.el8.ppc64le, 8","osType":"rhel","pinPolicy":"hard","placementGroup":"none","procType":"dedicated","processors":1,"pvmInstanceID":"22f161cb-024d-42ba-8081-7d72019d6b59","serverName":"test-instance-centos-e980-dedicated-tier3","srcs":[],"status":"ACTIVE","storagePool":"Tier3-Flash-2","storagePoolAffinity":true,"storageType":"tier3","sysType":"e980","updatedDate":"2023-01-30T17:51:30.000Z","virtualCores":{"assigned":1,"max":8,"min":1},"volumeIDs":["043cd4de-15e1-41fc-8dc4-1b6714785078"]}
+      string: '{"addresses":[{"externalIP":"127.0.0.124","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b","ip":"127.0.0.124","ipAddress":"127.0.0.124","macAddress":"fa:a0:0e:97:fe:20","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"creationDate":"2024-01-18T18:47:48.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:27:20.611855","status":"OK"},"hostID":6,"imageID":"62ae0e80-e11b-45cd-a955-90fc08d7191c","maxmem":16,"maxproc":1,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["3e0c10e1-7cca-44b4-865d-ebd369169a1b"],"networks":[{"externalIP":"127.0.0.124","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b","ip":"127.0.0.124","ipAddress":"127.0.0.124","macAddress":"fa:a0:0e:97:fe:20","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"operatingSystem":"Linux/Red
+        Hat Enterprise Linux 4.18.0-127.0.0.el8.ppc64l8.6 (Ootpa), 8.6 (Ootpa)","osType":"rhel","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.5,"pvmInstanceID":"b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","serverName":"test-instance-rhel-s922-shared-tier3","sharedProcessorPool":"test_pool","sharedProcessorPoolID":"85029156-8753-4d06-9a56-d13e3bd4c27d","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T18:47:48.000Z","virtualCores":{"assigned":1,"max":8,"min":1},"volumeIDs":["984498df-5554-4685-a109-821d5e39b27b"]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:42 GMT
+  recorded_at: Thu, 18 Jan 2024 19:27:21 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/689a1b67-cb62-43b1-804b-aa89c75c37bd
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/62ae0e80-e11b-45cd-a955-90fc08d7191c
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -648,70 +562,30 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '541'
+      - '432'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"creationDate":"2022-03-25T19:32:19.000Z","imageID":"689a1b67-cb62-43b1-804b-aa89c75c37bd","lastUpdateDate":"2022-03-25T20:15:23.000Z","name":"CentOS-Stream-8","servers":[],"size":120,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","operatingSystem":"rhel"},"state":"active","storagePool":"Tier3-Flash-2","storageType":"tier3","volumes":[{"bootable":true,"name":"Imported
-        image volume","size":120,"volumeID":"00e2449f-bac1-4ccd-8e38-d90279beefc1"}]}
+      string: '{"creationDate":"2023-12-13T01:38:31.000Z","imageID":"62ae0e80-e11b-45cd-a955-90fc08d7191c","lastUpdateDate":"2023-12-13T02:22:36.000Z","name":"RHEL8-SP6","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":"","volumes":[]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:43 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:11 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/46578c3d-a771-4410-8c9c-33f95b470e88
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"addresses":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/46578c3d-a771-4410-8c9c-33f95b470e88/networks/563c573d-edd8-4d26-a223-cb4b4d407abd","ip":"127.0.0.40","ipAddress":"127.0.0.40","macAddress":"fa:da:83:7e:e2:20","networkID":"563c573d-edd8-4d26-a223-cb4b4d407abd","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"consoleLanguage":{"code":"037","language":"037
-        English"},"creationDate":"2023-01-30T17:49:08.000Z","diskSize":100,"health":{"lastUpdate":"2023-01-31T16:51:44.142277","status":"OK"},"hostID":8,"imageID":"107ebbab-9231-4f83-951c-7859ef5393a3","maxmem":16,"maxproc":2,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["563c573d-edd8-4d26-a223-cb4b4d407abd"],"networks":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/46578c3d-a771-4410-8c9c-33f95b470e88/networks/563c573d-edd8-4d26-a223-cb4b4d407abd","ip":"127.0.0.40","ipAddress":"127.0.0.40","macAddress":"fa:da:83:7e:e2:20","networkID":"563c573d-edd8-4d26-a223-cb4b4d407abd","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"V7R5M0
-        1990 0","osType":"ibmi","pinPolicy":"none","placementGroup":"3fad2500-22df-4f2e-a0f8-530564a7163f","procType":"capped","processors":0.25,"pvmInstanceID":"46578c3d-a771-4410-8c9c-33f95b470e88","serverName":"test-instance-ibmi-s922-capped-tier1","softwareLicenses":{"ibmiCSS":false,"ibmiDBQ":false,"ibmiPHA":false,"ibmiRDS":false},"srcs":[[{"src":"A6005008","timestamp":"2023-01-30T17:57:46Z"},{"src":"03B00061","timestamp":"2023-01-30T17:57:46Z"},{"src":"FFFF0000","timestamp":"2023-01-30T17:57:46Z"},{"src":"00000000","timestamp":"2023-01-30T17:57:46Z"},{"src":"00000000","timestamp":"2023-01-30T17:57:46Z"},{"src":"50070404","timestamp":"2023-01-30T17:57:46Z"},{"src":"00000000","timestamp":"2023-01-30T17:57:46Z"},{"src":"00000000","timestamp":"2023-01-30T17:57:46Z"},{"src":"00000000","timestamp":"2023-01-30T17:57:46Z"}]],"status":"ACTIVE","storagePool":"Tier1-Flash-1","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2023-01-30T17:49:08.000Z","virtualCores":{"assigned":1,"max":4,"min":1},"volumeIDs":["5cdf032a-5c6f-409f-8413-2214f14f2a69"]}
-
-        '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:50 GMT
-- request:
-    method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/107ebbab-9231-4f83-951c-7859ef5393a3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -725,32 +599,31 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '540'
+      - '1686'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"creationDate":"2022-07-25T17:27:09.000Z","imageID":"107ebbab-9231-4f83-951c-7859ef5393a3","lastUpdateDate":"2022-07-25T18:15:20.000Z","name":"IBMi-75-00-2984-1","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","operatingSystem":"ibmi"},"state":"active","storagePool":"Tier1-Flash-1","storageType":"tier1","volumes":[{"bootable":true,"name":"Imported
-        image volume","size":100,"volumeID":"e7729112-91cc-4f86-8d2c-32f8644423d5"}]}
+      string: '{"addresses":[{"externalIP":"127.0.0.45","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5","ip":"127.0.0.45","ipAddress":"127.0.0.45","macAddress":"fa:50:f2:44:d6:20","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T18:45:03.000Z","diskSize":120,"health":{"lastUpdate":"2024-01-18T19:28:12.186103","status":"OK"},"hostID":1,"imageID":"69992304-1da0-4e66-a957-b95a58fb7d5c","maxmem":32,"maxproc":8,"memory":4,"migratable":false,"minmem":2,"minproc":1,"networkIDs":["11896394-64c5-4d6d-8a2f-a9ad829348c5"],"networks":[{"externalIP":"127.0.0.45","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5","ip":"127.0.0.45","ipAddress":"127.0.0.45","macAddress":"fa:50:f2:44:d6:20","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/CentOS
+        Stream 4.18.0-497.el8.ppc64le, 8","osType":"rhel","pinPolicy":"hard","placementGroup":"none","procType":"dedicated","processors":1,"pvmInstanceID":"1ea38460-b3ff-4abd-802b-0289983be590","serverName":"test-instance-centos-e980-dedicated-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"e980","updatedDate":"2024-01-18T18:45:03.000Z","virtualCores":{"assigned":1,"max":8,"min":1},"volumeIDs":["cdfebbb2-d64e-41e1-9834-4f6b5d249489"]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:51 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:12 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/afd27dad-9513-47f1-9dba-59a37b494127
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/69992304-1da0-4e66-a957-b95a58fb7d5c
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -764,32 +637,67 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1625'
+      - '434'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"addresses":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/afd27dad-9513-47f1-9dba-59a37b494127/networks/b656f9f4-ac42-4a3f-a85e-cf05161bd4d0","ip":"127.0.0.113","ipAddress":"127.0.0.113","macAddress":"fa:b0:7c:d0:50:20","networkID":"b656f9f4-ac42-4a3f-a85e-cf05161bd4d0","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2023-01-30T17:46:57.000Z","diskSize":25,"health":{"lastUpdate":"2023-01-31T16:51:52.323573","status":"OK"},"hostID":14,"imageID":"d7cb1f7c-1737-4cad-95c1-16a927e969b1","maxmem":16,"maxproc":2,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["b656f9f4-ac42-4a3f-a85e-cf05161bd4d0"],"networks":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/afd27dad-9513-47f1-9dba-59a37b494127/networks/b656f9f4-ac42-4a3f-a85e-cf05161bd4d0","ip":"127.0.0.113","ipAddress":"127.0.0.113","macAddress":"fa:b0:7c:d0:50:20","networkID":"b656f9f4-ac42-4a3f-a85e-cf05161bd4d0","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"AIX
-        7.3, 7300-00-01-2148","osType":"aix","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.25,"pvmInstanceID":"afd27dad-9513-47f1-9dba-59a37b494127","serverName":"test-instance-aix-s922-shared-tier1","srcs":[[{"src":"00000000","timestamp":"2023-01-30T17:50:08Z"}]],"status":"ACTIVE","storagePool":"Tier1-Flash-1","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2023-01-30T17:46:57.000Z","virtualCores":{"assigned":1,"max":5,"min":1},"volumeIDs":["88c1c414-634d-47e7-81fe-041c0add78d9"]}
+      string: '{"creationDate":"2023-12-12T20:38:09.000Z","imageID":"69992304-1da0-4e66-a957-b95a58fb7d5c","lastUpdateDate":"2023-12-12T20:55:40.000Z","name":"CentOS-Stream-8","servers":[],"size":120,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":"","volumes":[]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:54 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:13 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/d7cb1f7c-1737-4cad-95c1-16a927e969b1
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"consoleLanguage":{"code":"037","language":"037
+        English"},"creationDate":"2024-01-18T18:43:09.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:28:14.516887","status":"OK"},"hostID":7,"imageID":"ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2","maxmem":16,"maxproc":2,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["925c13aa-9579-43a3-86e1-150131906835"],"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"V7R5M0
+        410 2","osType":"ibmi","pinPolicy":"none","placementGroup":"8334ba79-bd98-47af-ad25-6eb8a1c4c817","procType":"capped","processors":0.25,"pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a","serverName":"test-instance-ibmi-s922-capped-tier1","softwareLicenses":{"ibmiCSS":false,"ibmiDBQ":false,"ibmiPHA":false,"ibmiRDS":false},"srcs":[[{"src":"A6005008","timestamp":"2024-01-18T18:51:32Z"},{"src":"03B00061","timestamp":"2024-01-18T18:51:32Z"},{"src":"FFFF0000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"50070404","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"}]],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2024-01-18T18:43:09.000Z","virtualCores":{"assigned":1,"max":4,"min":1},"volumeIDs":["ed84f79b-b8d1-48c3-8766-2a92ff6a879b"]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:28:16 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -803,32 +711,30 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '530'
+      - '433'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"creationDate":"2022-03-04T21:48:50.000Z","imageID":"d7cb1f7c-1737-4cad-95c1-16a927e969b1","lastUpdateDate":"2022-03-04T22:15:21.000Z","name":"7300-00-01","servers":[],"size":25,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","operatingSystem":"aix"},"state":"active","storagePool":"Tier1-Flash-1","storageType":"tier1","volumes":[{"bootable":true,"name":"Imported
-        image volume","size":25,"volumeID":"dd9cf3f4-e672-49db-8d37-b402f3bbbba6"}]}
+      string: '{"creationDate":"2023-12-12T23:02:27.000Z","imageID":"ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2","lastUpdateDate":"2023-12-12T23:15:20.000Z","name":"IBMi-75-02-2984-1","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"","storageType":"","volumes":[]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:55 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:17 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -842,31 +748,31 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '988'
+      - '1635'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"networks":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/563c573d-edd8-4d26-a223-cb4b4d407abd","jumbo":true,"name":"test-network-vlan-jumbo","networkID":"563c573d-edd8-4d26-a223-cb4b4d407abd","type":"vlan","vlanID":1885},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/91cace34-2dcf-4b2d-8195-7202e8686cb3","jumbo":false,"name":"test-network-pub-vlan-dns","networkID":"91cace34-2dcf-4b2d-8195-7202e8686cb3","type":"pub-vlan","vlanID":2045},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/b656f9f4-ac42-4a3f-a85e-cf05161bd4d0","jumbo":false,"name":"test-network-vlan","networkID":"b656f9f4-ac42-4a3f-a85e-cf05161bd4d0","type":"vlan","vlanID":1884},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/f9c99b4d-9dd6-4af2-b76a-5ad030a93262","jumbo":false,"name":"test-network-pub-vlan","networkID":"f9c99b4d-9dd6-4af2-b76a-5ad030a93262","type":"pub-vlan","vlanID":2041}]}
+      string: '{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508/networks/3de2f865-8726-43a3-8ee8-a385aa851adf","ip":"127.0.0.186","ipAddress":"127.0.0.186","macAddress":"fa:46:3d:6b:a1:20","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T17:24:40.000Z","diskSize":25,"health":{"lastUpdate":"2024-01-18T19:28:18.466435","status":"OK"},"hostID":4,"imageID":"45afea97-e991-41f4-8ef9-44d5e893ff45","maxmem":16,"maxproc":2,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["3de2f865-8726-43a3-8ee8-a385aa851adf"],"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508/networks/3de2f865-8726-43a3-8ee8-a385aa851adf","ip":"127.0.0.186","ipAddress":"127.0.0.186","macAddress":"fa:46:3d:6b:a1:20","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"AIX
+        7.3, 7300-00-01-2148","osType":"aix","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.25,"pvmInstanceID":"502106d8-d969-49df-9103-184c3ab97508","serverName":"test-instance-aix-s922-shared-tier1","srcs":[[{"src":"00000000","timestamp":"2024-01-18T17:27:40Z"}]],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2024-01-18T17:24:40.000Z","virtualCores":{"assigned":1,"max":5,"min":1},"volumeIDs":["2e653913-14fe-4b3a-a4f3-c7396bed0862"]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:55 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:19 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/563c573d-edd8-4d26-a223-cb4b4d407abd
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/45afea97-e991-41f4-8ef9-44d5e893ff45
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -880,31 +786,30 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '419'
+      - '424'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"cidr":"127.0.0.0/25","dnsServers":["127.0.0.1"],"gateway":"127.0.0.16","ipAddressMetrics":{"available":123,"total":125,"used":2,"utilization":1},"ipAddressRanges":[{"endingIPAddress":"127.0.0.15","startingIPAddress":"127.0.0.1"},{"endingIPAddress":"127.0.0.126","startingIPAddress":"127.0.0.17"}],"jumbo":true,"name":"test-network-vlan-jumbo","networkID":"563c573d-edd8-4d26-a223-cb4b4d407abd","type":"vlan","vlanID":1885}
+      string: '{"creationDate":"2023-12-12T20:13:32.000Z","imageID":"45afea97-e991-41f4-8ef9-44d5e893ff45","lastUpdateDate":"2023-12-12T20:19:11.000Z","name":"7300-00-01","servers":[],"size":25,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"aix"},"state":"active","storagePool":"","storageType":"","volumes":[]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:56 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:20 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/563c573d-edd8-4d26-a223-cb4b4d407abd/ports
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -918,31 +823,30 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '994'
+      - '945'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"ports":[{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/563c573d-edd8-4d26-a223-cb4b4d407abd/ports/26a40e5a-8c5e-4422-8cfa-146475c4b270","ipAddress":"127.0.0.40","macAddress":"fa:da:83:7e:e2:20","portID":"26a40e5a-8c5e-4422-8cfa-146475c4b270","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/46578c3d-a771-4410-8c9c-33f95b470e88","pvmInstanceID":"46578c3d-a771-4410-8c9c-33f95b470e88"},"status":"ACTIVE"},{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/563c573d-edd8-4d26-a223-cb4b4d407abd/ports/438f7ec3-4a0d-46c9-ae31-026533ae64ad","ipAddress":"127.0.0.20","macAddress":"fa:ea:24:4e:c8:20","portID":"438f7ec3-4a0d-46c9-ae31-026533ae64ad","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a","pvmInstanceID":"b35fecac-450d-4344-a87b-a14c459de44a"},"status":"ACTIVE"}]}
+      string: '{"networks":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5","name":"test-network-pub-vlan","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","type":"pub-vlan","vlanID":2161},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3de2f865-8726-43a3-8ee8-a385aa851adf","name":"test-network-vlan","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","type":"vlan","vlanID":1182},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b","name":"test-network-pub-vlan-dns","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","type":"pub-vlan","vlanID":2171},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/925c13aa-9579-43a3-86e1-150131906835","jumbo":true,"name":"test-network-vlan-jumbo","networkID":"925c13aa-9579-43a3-86e1-150131906835","type":"vlan","vlanID":424}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:56 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:20 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/91cace34-2dcf-4b2d-8195-7202e8686cb3
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -956,31 +860,30 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '480'
+      - '456'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"cidr":"127.0.0.136/29","dnsServers":["127.0.0.9"],"gateway":"127.0.0.137","ipAddressMetrics":{"available":3,"total":5,"used":2,"utilization":40},"ipAddressRanges":[{"endingIPAddress":"127.0.0.142","startingIPAddress":"127.0.0.138"}],"jumbo":false,"name":"test-network-pub-vlan-dns","networkID":"91cace34-2dcf-4b2d-8195-7202e8686cb3","publicIPAddressRanges":[{"endingIPAddress":"127.0.0.14","startingIPAddress":"127.0.0.10"}],"type":"pub-vlan","vlanID":2045}
+      string: '{"cidr":"127.0.0.40/29","dnsServers":["127.0.0.9"],"gateway":"127.0.0.41","ipAddressMetrics":{"available":3,"total":5,"used":2,"utilization":40},"ipAddressRanges":[{"endingIPAddress":"127.0.0.46","startingIPAddress":"127.0.0.42"}],"name":"test-network-pub-vlan","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","publicIPAddressRanges":[{"endingIPAddress":"127.0.0.46","startingIPAddress":"127.0.0.42"}],"type":"pub-vlan","vlanID":2161}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:57 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:20 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/91cace34-2dcf-4b2d-8195-7202e8686cb3/ports
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5/ports
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -994,31 +897,30 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1064'
+      - '1060'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"ports":[{"description":"","externalIP":"127.0.0.11","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/91cace34-2dcf-4b2d-8195-7202e8686cb3/ports/7be65167-3179-47c9-b70b-f2e97c892dfd","ipAddress":"127.0.0.139","macAddress":"fa:a9:48:05:28:20","portID":"7be65167-3179-47c9-b70b-f2e97c892dfd","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/862a0a0f-92b6-409c-b2d0-852bff557669","pvmInstanceID":"862a0a0f-92b6-409c-b2d0-852bff557669"},"status":"ACTIVE"},{"description":"","externalIP":"127.0.0.10","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/91cace34-2dcf-4b2d-8195-7202e8686cb3/ports/1de5f2e6-7dd4-46b6-af9b-d0a3c08979e7","ipAddress":"127.0.0.138","macAddress":"fa:ea:24:4e:c8:21","portID":"1de5f2e6-7dd4-46b6-af9b-d0a3c08979e7","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b35fecac-450d-4344-a87b-a14c459de44a","pvmInstanceID":"b35fecac-450d-4344-a87b-a14c459de44a"},"status":"ACTIVE"}]}
+      string: '{"ports":[{"description":"","externalIP":"127.0.0.46","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5/ports/4e6d559a-1009-4920-a482-f2e40d9fb3a9","ipAddress":"127.0.0.46","macAddress":"fa:1a:90:7c:8a:21","portID":"4e6d559a-1009-4920-a482-f2e40d9fb3a9","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd","pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd"},"status":"ACTIVE"},{"description":"","externalIP":"127.0.0.45","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5/ports/43ac9d1e-a3b3-4796-a9a9-c07dacc82733","ipAddress":"127.0.0.45","macAddress":"fa:50:f2:44:d6:20","portID":"43ac9d1e-a3b3-4796-a9a9-c07dacc82733","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590","pvmInstanceID":"1ea38460-b3ff-4abd-802b-0289983be590"},"status":"ACTIVE"}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:57 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:20 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/b656f9f4-ac42-4a3f-a85e-cf05161bd4d0
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/3de2f865-8726-43a3-8ee8-a385aa851adf
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1032,31 +934,30 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '349'
+      - '335'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"cidr":"127.0.0.0/24","dnsServers":["127.0.0.1"],"gateway":"127.0.0.1","ipAddressMetrics":{"available":251,"total":253,"used":2,"utilization":0},"ipAddressRanges":[{"endingIPAddress":"127.0.0.254","startingIPAddress":"127.0.0.2"}],"jumbo":false,"name":"test-network-vlan","networkID":"b656f9f4-ac42-4a3f-a85e-cf05161bd4d0","type":"vlan","vlanID":1884}
+      string: '{"cidr":"127.0.0.0/24","dnsServers":["127.0.0.1"],"gateway":"127.0.0.1","ipAddressMetrics":{"available":251,"total":253,"used":2,"utilization":0},"ipAddressRanges":[{"endingIPAddress":"127.0.0.254","startingIPAddress":"127.0.0.2"}],"name":"test-network-vlan","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","type":"vlan","vlanID":1182}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:58 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:21 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/b656f9f4-ac42-4a3f-a85e-cf05161bd4d0/ports
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/3de2f865-8726-43a3-8ee8-a385aa851adf/ports
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1077,24 +978,23 @@ http_interactions:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"ports":[{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/b656f9f4-ac42-4a3f-a85e-cf05161bd4d0/ports/4574b864-0a73-4a31-9213-e5c94bc2d0af","ipAddress":"127.0.0.209","macAddress":"fa:20:48:80:0c:20","portID":"4574b864-0a73-4a31-9213-e5c94bc2d0af","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0","pvmInstanceID":"0c186073-26b2-4cbb-bf4e-e64057db23b0"},"status":"ACTIVE"},{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/b656f9f4-ac42-4a3f-a85e-cf05161bd4d0/ports/fb2d7662-b81a-4462-9f00-5f4ccc544b68","ipAddress":"127.0.0.113","macAddress":"fa:b0:7c:d0:50:20","portID":"fb2d7662-b81a-4462-9f00-5f4ccc544b68","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/afd27dad-9513-47f1-9dba-59a37b494127","pvmInstanceID":"afd27dad-9513-47f1-9dba-59a37b494127"},"status":"ACTIVE"}]}
+      string: '{"ports":[{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3de2f865-8726-43a3-8ee8-a385aa851adf/ports/1ba40a34-7b29-4893-a046-1c1762e745ca","ipAddress":"127.0.0.208","macAddress":"fa:1a:90:7c:8a:20","portID":"1ba40a34-7b29-4893-a046-1c1762e745ca","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd","pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd"},"status":"ACTIVE"},{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3de2f865-8726-43a3-8ee8-a385aa851adf/ports/a62e83af-8c0c-4f48-9c60-5d2985decf3e","ipAddress":"127.0.0.186","macAddress":"fa:46:3d:6b:a1:20","portID":"a62e83af-8c0c-4f48-9c60-5d2985decf3e","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/502106d8-d969-49df-9103-184c3ab97508","pvmInstanceID":"502106d8-d969-49df-9103-184c3ab97508"},"status":"ACTIVE"}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:58 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:21 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/f9c99b4d-9dd6-4af2-b76a-5ad030a93262
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1108,31 +1008,30 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '478'
+      - '466'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"cidr":"127.0.0.104/29","dnsServers":["127.0.0.9"],"gateway":"127.0.0.105","ipAddressMetrics":{"available":3,"total":5,"used":2,"utilization":40},"ipAddressRanges":[{"endingIPAddress":"127.0.0.110","startingIPAddress":"127.0.0.106"}],"jumbo":false,"name":"test-network-pub-vlan","networkID":"f9c99b4d-9dd6-4af2-b76a-5ad030a93262","publicIPAddressRanges":[{"endingIPAddress":"127.0.0.238","startingIPAddress":"127.0.0.234"}],"type":"pub-vlan","vlanID":2041}
+      string: '{"cidr":"127.0.0.120/29","dnsServers":["127.0.0.9"],"gateway":"127.0.0.121","ipAddressMetrics":{"available":3,"total":5,"used":2,"utilization":40},"ipAddressRanges":[{"endingIPAddress":"127.0.0.126","startingIPAddress":"127.0.0.122"}],"name":"test-network-pub-vlan-dns","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","publicIPAddressRanges":[{"endingIPAddress":"127.0.0.126","startingIPAddress":"127.0.0.122"}],"type":"pub-vlan","vlanID":2171}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:59 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:21 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/f9c99b4d-9dd6-4af2-b76a-5ad030a93262/ports
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b/ports
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1146,31 +1045,104 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1066'
+      - '1064'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"ports":[{"description":"","externalIP":"127.0.0.237","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/f9c99b4d-9dd6-4af2-b76a-5ad030a93262/ports/5148f15d-c5c7-4c5d-83d5-aa6937495b55","ipAddress":"127.0.0.109","macAddress":"fa:20:48:80:0c:21","portID":"5148f15d-c5c7-4c5d-83d5-aa6937495b55","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/0c186073-26b2-4cbb-bf4e-e64057db23b0","pvmInstanceID":"0c186073-26b2-4cbb-bf4e-e64057db23b0"},"status":"ACTIVE"},{"description":"","externalIP":"127.0.0.238","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/f9c99b4d-9dd6-4af2-b76a-5ad030a93262/ports/4599dbc2-7c86-42fa-92db-454f194a985a","ipAddress":"127.0.0.110","macAddress":"fa:24:f8:9a:85:20","portID":"4599dbc2-7c86-42fa-92db-454f194a985a","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/22f161cb-024d-42ba-8081-7d72019d6b59","pvmInstanceID":"22f161cb-024d-42ba-8081-7d72019d6b59"},"status":"ACTIVE"}]}
+      string: '{"ports":[{"description":"","externalIP":"127.0.0.122","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b/ports/434c6948-4eb0-43df-9259-109b135c3c84","ipAddress":"127.0.0.122","macAddress":"fa:7f:f8:6b:9e:21","portID":"434c6948-4eb0-43df-9259-109b135c3c84","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8","pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8"},"status":"ACTIVE"},{"description":"","externalIP":"127.0.0.124","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b/ports/f93f5be1-89a3-40a6-9f31-0ad01e7f5c9f","ipAddress":"127.0.0.124","macAddress":"fa:a0:0e:97:fe:20","portID":"f93f5be1-89a3-40a6-9f31-0ad01e7f5c9f","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","pvmInstanceID":"b9370d8d-8d73-4f0e-ad84-34f7fd52eb84"},"status":"ACTIVE"}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:51:59 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:22 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/tenants/1fdf5effc3f945688c021cd0a8b45c4d
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/925c13aa-9579-43a3-86e1-150131906835
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '429'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"cidr":"127.0.0.0/25","dnsServers":["127.0.0.1"],"gateway":"127.0.0.16","ipAddressMetrics":{"available":123,"total":125,"used":2,"utilization":1},"ipAddressRanges":[{"endingIPAddress":"127.0.0.126","startingIPAddress":"127.0.0.17"},{"endingIPAddress":"127.0.0.15","startingIPAddress":"127.0.0.1"}],"jumbo":true,"mtu":9000,"name":"test-network-vlan-jumbo","networkID":"925c13aa-9579-43a3-86e1-150131906835","type":"vlan","vlanID":424}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:28:22 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/925c13aa-9579-43a3-86e1-150131906835/ports
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '994'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"ports":[{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/925c13aa-9579-43a3-86e1-150131906835/ports/268a6d4f-4461-4c71-8114-2aab5337654e","ipAddress":"127.0.0.10","macAddress":"fa:7f:f8:6b:9e:20","portID":"268a6d4f-4461-4c71-8114-2aab5337654e","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8","pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8"},"status":"ACTIVE"},{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/925c13aa-9579-43a3-86e1-150131906835/ports/d3bbd78f-96c8-4981-b076-e8db416c96d9","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","portID":"d3bbd78f-96c8-4981-b076-e8db416c96d9","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a","pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a"},"status":"ACTIVE"}]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:28:22 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/tenants/1fdf5effc3f945688c021cd0a8b45c4d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1189,29 +1161,17 @@ http_interactions:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"cloudInstances":[{"capabilities":[],"cloudInstanceID":"1e2141a3a00f4ea09cb29ed55d090421","enabled":true,"href":"/pcloud/v1/cloud-instances/1e2141a3a00f4ea09cb29ed55d090421","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"97ce8888-250f-413c-9034-3131bce331f8","region":"us-east01"},{"capabilities":[],"cloudInstanceID":"323a5df0f79146fa83bc470d9d6d83b4","enabled":true,"href":"/pcloud/v1/cloud-instances/323a5df0f79146fa83bc470d9d6d83b4","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"6aaf801e-6674-454e-ab77-646c28c0aaee","region":"lon06"},{"capabilities":[],"cloudInstanceID":"367781069c3f41a2a33af29e3daf43d5","enabled":true,"href":"/pcloud/v1/cloud-instances/367781069c3f41a2a33af29e3daf43d5","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"5a2f84d3-ee77-4c16-b554-f99fbccdb419","region":"tor01"},{"capabilities":[],"cloudInstanceID":"4361d240c3b54582876849a1e0d51c48","enabled":true,"href":"/pcloud/v1/cloud-instances/4361d240c3b54582876849a1e0d51c48","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d83592cf-c86e-47a3-a470-749d564de104","region":"tor01"},{"capabilities":[],"cloudInstanceID":"5818fde64f5d409b906226c5c0c27654","enabled":true,"href":"/pcloud/v1/cloud-instances/5818fde64f5d409b906226c5c0c27654","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"3ea904f1-67df-4ae0-960f-e13ffa469f12","region":"sao01"},{"capabilities":[],"cloudInstanceID":"5ca792d77faa47b9a43c7cbb7258828d","enabled":true,"href":"/pcloud/v1/cloud-instances/5ca792d77faa47b9a43c7cbb7258828d","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"2ecd5951-eb56-4a79-9e7a-c72765115dd0","region":"lon06"},{"capabilities":[],"cloudInstanceID":"60dd8ebe0aef4beca1efd210cd0174e4","enabled":true,"href":"/pcloud/v1/cloud-instances/60dd8ebe0aef4beca1efd210cd0174e4","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"37fda19e-c1fd-4a29-9a7c-7d16b7eac73a","region":"sao01"},{"capabilities":[],"cloudInstanceID":"616d723acd01463bbe71a293be63d88f","enabled":true,"href":"/pcloud/v1/cloud-instances/616d723acd01463bbe71a293be63d88f","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"c507194a-4bc8-4cc7-9d55-aac47c17ba06","region":"syd05"},{"capabilities":[],"cloudInstanceID":"633f13eef34344a2b1370ba98643bbf3","enabled":true,"href":"/pcloud/v1/cloud-instances/633f13eef34344a2b1370ba98643bbf3","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"df3fea77-b9b6-4d48-b29c-9b5146c055ab","region":"us-east01"},{"capabilities":[],"cloudInstanceID":"64538eac23f64802850102654092ac82","enabled":true,"href":"/pcloud/v1/cloud-instances/64538eac23f64802850102654092ac82","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"851f82c2-034c-4c32-9764-94262d245a50","region":"us-east01"},{"capabilities":[],"cloudInstanceID":"64c6cfbd9ddd49758a6e83afdcec83e9","enabled":true,"href":"/pcloud/v1/cloud-instances/64c6cfbd9ddd49758a6e83afdcec83e9","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"4ee5f231-5e89-44d1-ba57-69796d222853","region":"us-east01"},{"capabilities":[],"cloudInstanceID":"8b77ae6ff945452d85e52447a3bfb41c","enabled":true,"href":"/pcloud/v1/cloud-instances/8b77ae6ff945452d85e52447a3bfb41c","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d68da88c-0624-44c5-a19b-8bc2df909e90","region":"syd04"},{"capabilities":[],"cloudInstanceID":"914b05caac05408694e562586a65478b","enabled":true,"href":"/pcloud/v1/cloud-instances/914b05caac05408694e562586a65478b","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"b9db6009-30fc-4718-98cb-16ba6fd37b82","region":"us-east01"},{"capabilities":[],"cloudInstanceID":"bd9dde6d07494018b6211b5066d92d9f","enabled":true,"href":"/pcloud/v1/cloud-instances/bd9dde6d07494018b6211b5066d92d9f","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"b7f1637d-96fe-46f0-9895-ce305d6e3865","region":"us-east01"},{"capabilities":[],"cloudInstanceID":"c8d0ac7c30c944f0ac3288eb8bb74aaa","enabled":true,"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"IBM_CLOUD_POWERVS_INSTANCE_ID","region":"us-east01"},{"capabilities":[],"cloudInstanceID":"d68aaa94c25d44b09c8f325aab92a498","enabled":true,"href":"/pcloud/v1/cloud-instances/d68aaa94c25d44b09c8f325aab92a498","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"952f1b8e-2fd3-43b6-ba7e-6e4439d258bd","region":"us-east01"},{"capabilities":[],"cloudInstanceID":"d88366450dff4149ba5032fc7058d9ea","enabled":true,"href":"/pcloud/v1/cloud-instances/d88366450dff4149ba5032fc7058d9ea","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"2f700624-6396-4ed7-b7c1-ae1533b8717f","region":"syd04"},{"capabilities":[],"cloudInstanceID":"dd39bb389d9e4eddb3d4434d9db029aa","enabled":true,"href":"/pcloud/v1/cloud-instances/dd39bb389d9e4eddb3d4434d9db029aa","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"9e671060-3902-4eab-ab6f-10b64f354c1c","region":"us-east01"},{"capabilities":[],"cloudInstanceID":"e75edc3d6b6348698960ec9a5d4e79e5","enabled":true,"href":"/pcloud/v1/cloud-instances/e75edc3d6b6348698960ec9a5d4e79e5","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"4587b311-5930-47fa-9e79-61296f714a06","region":"tok04"},{"capabilities":[],"cloudInstanceID":"e9f4c3fad00c4b20b3e4ede7133a80ba","enabled":true,"href":"/pcloud/v1/cloud-instances/e9f4c3fad00c4b20b3e4ede7133a80ba","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d0764634-2578-4d7d-a9a6-389dc8a7dca9","region":"osa21"}],"creationDate":"2019-06-17T13:00:30.592Z","enabled":true,"sshKeys":[{"creationDate":"2021-01-19T13:24:14.835Z","name":"jwcroppe-mac","sshKey":"ssh-rsa
+      string: '{"cloudInstances":[{"capabilities":[],"cloudInstanceID":"1e2141a3a00f4ea09cb29ed55d090421","enabled":true,"href":"/pcloud/v1/cloud-instances/1e2141a3a00f4ea09cb29ed55d090421","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"97ce8888-250f-413c-9034-3131bce331f8","region":"mon01"},{"capabilities":[],"cloudInstanceID":"323a5df0f79146fa83bc470d9d6d83b4","enabled":true,"href":"/pcloud/v1/cloud-instances/323a5df0f79146fa83bc470d9d6d83b4","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"6aaf801e-6674-454e-ab77-646c28c0aaee","region":"lon06"},{"capabilities":[],"cloudInstanceID":"367781069c3f41a2a33af29e3daf43d5","enabled":true,"href":"/pcloud/v1/cloud-instances/367781069c3f41a2a33af29e3daf43d5","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"5a2f84d3-ee77-4c16-b554-f99fbccdb419","region":"tor01"},{"capabilities":[],"cloudInstanceID":"4361d240c3b54582876849a1e0d51c48","enabled":true,"href":"/pcloud/v1/cloud-instances/4361d240c3b54582876849a1e0d51c48","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d83592cf-c86e-47a3-a470-749d564de104","region":"tor01"},{"capabilities":[],"cloudInstanceID":"5818fde64f5d409b906226c5c0c27654","enabled":true,"href":"/pcloud/v1/cloud-instances/5818fde64f5d409b906226c5c0c27654","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"3ea904f1-67df-4ae0-960f-e13ffa469f12","region":"sao01"},{"capabilities":[],"cloudInstanceID":"58bd80b9c85a4264967ff25aac6ace0f","enabled":true,"href":"/pcloud/v1/cloud-instances/58bd80b9c85a4264967ff25aac6ace0f","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"33d26fea-f20b-47d5-a863-b5bbf41a7c57","region":"mon01"},{"capabilities":[],"cloudInstanceID":"60dd8ebe0aef4beca1efd210cd0174e4","enabled":true,"href":"/pcloud/v1/cloud-instances/60dd8ebe0aef4beca1efd210cd0174e4","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"37fda19e-c1fd-4a29-9a7c-7d16b7eac73a","region":"sao01"},{"capabilities":[],"cloudInstanceID":"616d723acd01463bbe71a293be63d88f","enabled":true,"href":"/pcloud/v1/cloud-instances/616d723acd01463bbe71a293be63d88f","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"c507194a-4bc8-4cc7-9d55-aac47c17ba06","region":"syd05"},{"capabilities":[],"cloudInstanceID":"633f13eef34344a2b1370ba98643bbf3","enabled":true,"href":"/pcloud/v1/cloud-instances/633f13eef34344a2b1370ba98643bbf3","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"df3fea77-b9b6-4d48-b29c-9b5146c055ab","region":"mon01"},{"capabilities":[],"cloudInstanceID":"64538eac23f64802850102654092ac82","enabled":true,"href":"/pcloud/v1/cloud-instances/64538eac23f64802850102654092ac82","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"851f82c2-034c-4c32-9764-94262d245a50","region":"mon01"},{"capabilities":[],"cloudInstanceID":"64c6cfbd9ddd49758a6e83afdcec83e9","enabled":true,"href":"/pcloud/v1/cloud-instances/64c6cfbd9ddd49758a6e83afdcec83e9","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"4ee5f231-5e89-44d1-ba57-69796d222853","region":"mon01"},{"capabilities":[],"cloudInstanceID":"6b88538cb7394fe8bb41be949c5fa8ee","enabled":true,"href":"/pcloud/v1/cloud-instances/6b88538cb7394fe8bb41be949c5fa8ee","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d4cc6d16-b80b-464b-8b09-dcf972f28b5f","region":"syd05"},{"capabilities":[],"cloudInstanceID":"8b77ae6ff945452d85e52447a3bfb41c","enabled":true,"href":"/pcloud/v1/cloud-instances/8b77ae6ff945452d85e52447a3bfb41c","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d68da88c-0624-44c5-a19b-8bc2df909e90","region":"syd04"},{"capabilities":[],"cloudInstanceID":"914b05caac05408694e562586a65478b","enabled":true,"href":"/pcloud/v1/cloud-instances/914b05caac05408694e562586a65478b","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"b9db6009-30fc-4718-98cb-16ba6fd37b82","region":"mon01"},{"capabilities":[],"cloudInstanceID":"a1a6d247e7f34df1bdcdac03fc45e443","enabled":true,"href":"/pcloud/v1/cloud-instances/a1a6d247e7f34df1bdcdac03fc45e443","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"63dce3d0-89b3-4e6a-b49c-d8a36db64106","region":"mad02"},{"capabilities":[],"cloudInstanceID":"ac6f36efacd9470d9859adbd153c8aea","enabled":true,"href":"/pcloud/v1/cloud-instances/ac6f36efacd9470d9859adbd153c8aea","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"20835aba-2926-407d-9a2a-3dcf07fec934","region":"mon01"},{"capabilities":[],"cloudInstanceID":"bd9dde6d07494018b6211b5066d92d9f","enabled":true,"href":"/pcloud/v1/cloud-instances/bd9dde6d07494018b6211b5066d92d9f","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"b7f1637d-96fe-46f0-9895-ce305d6e3865","region":"mon01"},{"capabilities":[],"cloudInstanceID":"bf368eaf05a8467091cbcb8e4bcc185c","enabled":true,"href":"/pcloud/v1/cloud-instances/bf368eaf05a8467091cbcb8e4bcc185c","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"8f3d13de-8503-4898-a313-f560343ce78a","region":"syd04"},{"capabilities":[],"cloudInstanceID":"c8d0ac7c30c944f0ac3288eb8bb74aaa","enabled":true,"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"IBM_CLOUD_POWERVS_INSTANCE_ID","region":"mon01"},{"capabilities":[],"cloudInstanceID":"dd39bb389d9e4eddb3d4434d9db029aa","enabled":true,"href":"/pcloud/v1/cloud-instances/dd39bb389d9e4eddb3d4434d9db029aa","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"9e671060-3902-4eab-ab6f-10b64f354c1c","region":"mon01"},{"capabilities":[],"cloudInstanceID":"e75edc3d6b6348698960ec9a5d4e79e5","enabled":true,"href":"/pcloud/v1/cloud-instances/e75edc3d6b6348698960ec9a5d4e79e5","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"4587b311-5930-47fa-9e79-61296f714a06","region":"tok04"},{"capabilities":[],"cloudInstanceID":"e9f4c3fad00c4b20b3e4ede7133a80ba","enabled":true,"href":"/pcloud/v1/cloud-instances/e9f4c3fad00c4b20b3e4ede7133a80ba","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d0764634-2578-4d7d-a9a6-389dc8a7dca9","region":"osa21"},{"capabilities":[],"cloudInstanceID":"f7a5f0a3b1b94047a090ab097cbf8207","enabled":true,"href":"/pcloud/v1/cloud-instances/f7a5f0a3b1b94047a090ab097cbf8207","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"1f6e4394-4346-4dcb-be81-eeed2152c4b7","region":"mon01"}],"creationDate":"2019-06-17T13:00:30.592Z","enabled":true,"sshKeys":[{"creationDate":"2021-01-19T13:24:14.835Z","name":"jwcroppe-mac","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABAQDCv9DfTRHiHFqQMB+qNX0d9TyIP7TowEK2WWYrOLJPG7EJVyoTitXc/3Y5+/MLj28fyn52d9Ut+WZErjBMTlF30d180yVXlB2Gv6RztufC7sbSNM8w20E/DIHPVJS3E8fuIPft91T0HFH6OC+8YH/W72PSTraLFDVTq1U57338TdEexCmzFz2ABJ4Dzza1k9mHA372P1SQ8CgR9ipHXPE32Fvn2T8+3kDDhDdxpfkwxgX4p1JI9gfn2VMui8NsEhSetEQ5KuLtgNwC7S7DaOzgNsreJmWIiur9/ceCTHXZlMVS//tWcwrrvikXXn5cJhO+TJpcE88L0txiJG9KoI0/
-        jwcroppe@jwcroppe-mac"},{"creationDate":"2021-02-09T15:08:56.001Z","name":"dbergami","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABgQCsKlWfOFVAnCW1uRExKJ91WT9B3ikdx8ZWA6cVFT3z2ApbqtA0ZnDP5odAxaIxDw7pX9UBMurNgJkAujwymG2DcWxBui+MXnlO1p8J5veGsWz6xktRmAHoY2G2MNAP877ww1QkBWkewrJf/Js018JKkOQE2Cnrb3rcpzPmgeXDfaZzAK13OhbZOv6gZGvuNcZ4Z2bMSTDEQoJ5P2tH6NONxDQSo5O98gtjp3CcxJv6Rh6Bmb3RmgF+uNOPp6fHWoeflPvg9DZCKTMj7pVGPKib7tlnKrWmgD16/Ce51YkF05YnUN/V3ti7SI9weCbgM3AUHH3EfEdP2IrpqxyLmkPA1dgiBrxX0ymy75196I2bGCuuLnxmJLYv3794PBjRo4A2Woe7tMjpb5KNajUlrOGkqWSkv2nV74LhajadPdpZc+vQ+o6su7Mma5UrhtZxoMRFFgygjf71naSjoQYFvULidUy3FD2Zhosjrlc7lH3x81zSwWdtMvSn09J2o8N6R9c=
-        WW930+A453037@LAPTOP-L5LSBNN4"},{"creationDate":"2021-02-11T13:34:02.059Z","name":"vrobin","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAABIwAAAQEAz720aYVL7bnqvmo/KLes+voMR+JgAzqOej9d8GS1Gj5TYfieQGgbzVmmG4jMo3LPhfOLR8EDchvCo+VbHme2lsKiCYADgNrDBDXDQVBs7P9wkLlLtXwAxPhI//sR78OthTxVy399gKQRVRNOx4BzfLj5g7XqEWH6DAu53WMViHrXhB+FnRDxcrlYsctNGTc4kV9fHmllcrYOPtfm1vw8yVGYn6SSN+ztpF3oMp+4xr9GUUHFhyG5qHdJzWb5SyGbBzJa48XDWJHkCAhzm9ZYSdtrUnGlo7zTKQ8b7DOPbQjYHZ+b+biTvBNOk8Ad88CPEPUV8qAZSQgxlc6Tk5EJWw==
-        imported-openssh-key"},{"creationDate":"2021-02-12T17:53:34.397Z","name":"beta","sshKey":"ssh-rsa
+        jwcroppe@jwcroppe-mac"},{"creationDate":"2021-02-12T17:53:34.397Z","name":"beta","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDm+dD4O+oqKCNyhpV0Qj5QRCerPBsCysunyw8WP14X/AwqG8iyg5z9C5k/gOc1zCN+FWanQO2T+A6JfW8PZU02qhYC3mEzjiYhyAyFvfx74FGcBLdtbI9QchjwNLt2sZGy387mkW50+uroTLujZtGoF6xfX4mwxqYeDNC74YSF+gzcqJGWwb7rTdKKSgWfXQFLiegC4GLFOuKNZ1DluUsQD/+dfrQ3SUzp484x/efDPf33hWEsqCbS210U1h/iUa7PQ489v4VC147oSxyiiWAHbEryZ8pW9JDDiPxaLM5LqSJFuJguPlTUsap8oL/zPiDDL7guCzswKzLUOOxWtSBwv7XoGdKlYXNXSDZtaGIGKTpU+cHjz18q4xfuoR57j+rsqQOIhyzDDt6KusKihMapRVceqJyz+HNunwN0mLJiFFvAtzOHoOneM7bYZAXXzY9YgAI+x6CHFhg0VsyXWEtpL0b2iGL/XA3dXh8zV3Kw0HRuUPjb02rhWJjuQLY3cpU=
-        jwcarman@li-a36b264c-2e6f-11b2-a85c-fdfb37238350.ibm.com"},{"creationDate":"2021-02-17T10:20:14.751Z","name":"chanriat","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABAQDZACoGMoDinK/RBdmEavlL2qVtT3Yt46d033hssZJzvRppINIjBQUbZjW/qSM8SvPXEWVE01l0XtcRgCb5n670xfxcL2Kq6j1B7IPU12ZGgiXtGFVVn34BFcG6yb05QNL0dHSguiCq39yZoD5qPPVDi7tb1a2uQQ5LFDLauL/uWzTCzZd3SZXjQnhyaOUQG8kDwI642/kpEq/hplv+mKJzpTCEzon/iVbaaJ1dbTzdy0QtLU4OKEu2qxiKDXA7C9tSEjN1ZfoXrZzuyq+Rv+ybr3PEIEIVAPUdXBkCfUtoWdKCja271bh3h/r2w2ZLaygl0uavXBS/7Ot7Ol89xO99
-        chanriat@us.ibm.com"},{"creationDate":"2021-02-26T14:38:32.784Z","name":"dev1-hanriat","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABgQCv0YHBF+tFyRVM0SgDl4G/thGkCf8KVGSasDn0VAm+/GOlhD9En8cUuWKwBe63gVgE7ExAaWhHxwXrVGleLvqSctzQwBpJL14rBz+15dWLiHEQMltjXWga6tJ2zm8+Bwp0EU0GXOSZbZ4Jr8fmBCGLv//xCeLJj9ZTH2q2UaCr76pZZh+lQZ0vJJsXoJJ1jXsAkR6Ji06OSXyJrx2R5QtCHvxfZaK+FFtUxdNzdl4W4HahUMYkuRWnG8KNAm7bMYRe0VtVsCtsp9uHyVKaN0VyyURSOXhfIKMiflBqooWZfeCyYURk6gzlmp3rYbpj/mCvyOSRkxcuzYiMCUxvBwsBKQFXdUL6eC9ESpTLy3to3rdw2ajwARl6AUySoGIEOg0HWq8eUoGggL4VW2PgbE9Cy4v8AdLIo6Dd06uZy/uz8Kg/BmHA0mGiFZl1LOySxtEOw+P3ceq/Nqv6/YIqxY55MqAUNgMPpQ6k+Tff9XIT9v4b0Nirqhe4wtXh9mNtRB0=
-        rhacm-power-dev1"},{"creationDate":"2021-03-26T22:14:18.657Z","name":"jwcarman","sshKey":"ssh-rsa
+        jwcarman@li-a36b264c-2e6f-11b2-a85c-fdfb37238350.ibm.com"},{"creationDate":"2021-03-26T22:14:18.657Z","name":"jwcarman","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQDByJlNGneMixFQXcww1o4gIOo/MiUTgknh0gnGvI5mDM+iiGoVvauW2b7pc39Xvtne/SbuKogRcq5ZzXQzccgM/KHfiT2VM1isplWMutG4ycOolcCL1D5eZzq5HYCTZVMF5SXJKLiv22y5elq3oV8ALR8oWvrMSIzgTOzSlJKVYl8wq3AHQ7bTSxgoFrWjGLreC5NXKp/qpnQA7PjS3jYxXaGoRoeZO0qlUD5BLX5SJ3Rqzl6gpT1OmJxqFh5zbcY9KlRXPZrVmSmdwFIBa0VN+jc0eg8TS0Ore7b5INpqgtQLEuZpZKjGKF/uCes8BmUg/dx5L4R7Myn50kaOoETAG9cYyc5tPojgJ8vHknbNAkHLYSdjs3iO+IqmNQdOmusGCPiAIOH3SAn8dHnBQVf9bTxhd6qiqO/fbn+Ihm6nO8sL35nNi+sz5ZVbFiZXa7pFcmo2ZU1bWrhj43W2VWYluf8NhYtbGIFvPCdXMWS5SGR3e+m1BQD/W+gxu2wOhrXhrpMyaC0goA98SP1RtVltlXXBW+fe7+vX5hHThI9wcXEgrVrtQX51V3OGetjS2DMBGRhx+pCT1nsQPbaKPtBDgS7sBQ9mHNQIi+Va497A6Efxri+f+7YYC9xdHNSwWkuWr4tkh7HAREUdTUc3i56tqNfZX3+S18YYpsoT6PJG+w==
-        jwcarman@us.ibm.com"},{"creationDate":"2021-05-03T12:29:47.393Z","name":"vfebvre","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABgQDuoKmJxB9Y71ICiU7cub3RSARavYyWaj/TK3HAP0wQBKwfrNHBKa2WyH/HTd7dXwh45KfOOJ9u07F1fdGm5e5RGlpu7ynQkz/5Gp7uaIPc0r8yPNwggwmdeHJDSczWH5JwDbDfR3Zh19zItToHYGTCFGlXCkl1kfhARMo/0rv4TCKUsqUjs9rygfTZ0jUDpgKKDzV3pRumRyxvtCDMoYh6s76PSvwFnYMSeE7b3vm8oD0sEp20xqePFLtyK8R1mQ0pePc51OzeUVixN8Cns0GysFlcRSDzsV/RYNBf7y0A+O3hLYVamPwbnFh6jqfLtFvcD6/Ty69vKCzi+Qy+qbvOK8rkRmO22yN83iJR5KlCl6qGsl4hxCa3x18eUmIIt1JaLGcn/0IiHQVCY+O4LTaN9fGMa76akr4qDg691wlccKmGgtMLnEjSWq/4SydECu9gxCv+7kMEfufoTwW5CVU+5wjEyWKWfNxFtpvftxnjqWM8LWFRDNgpyKobQlLMdRc=
-        vfebvre@DESKTOP-PVOGU38"},{"creationDate":"2021-05-17T12:24:11.244Z","name":"power_servers_sshkey","sshKey":"ssh-rsa
+        jwcarman@us.ibm.com"},{"creationDate":"2021-05-17T12:24:11.244Z","name":"power_servers_sshkey","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABAQC9W+l4Zri6CYg2ZVB0DC4XhqN9NDH+3BVP0+oUDJ5bH9qGdz1WmGZ4GrNTWu1pHhombHymH3vUPhJ488BmkQ+bkCJM5vJX5pN2YmSgobe7BMhhLZ11iED/QA1YIbN7OwhkP/b/4hEkLCALsRh1ST3VeiBtQ6gxmMAFJHAIZuLbyba9OZzI8U2aj1vfUpl2CyN551QXEtE7ui303F2tlpx2rSrImL5QKKS2BpXGh/1MaAPySLwVpuBRoPs+AQn3Lz2UL8vjgkYkhgr+cG8ai4CFgnSKPgEKUeLrTZ5H4adZ/HUQclqDzyKvtDYdvJSoLLpTMTKiL28W6igmKC+txfyr
-        iv1004@ThinkPad-X1-Carbon-3rd"},{"creationDate":"2021-06-08T20:22:20.679Z","name":"rdr-rhop-788dfe-us-east01-keypair","sshKey":"ssh-rsa
+        iv1004@ThinkPad-X1-Carbon-3rd"},{"creationDate":"2021-06-08T20:22:20.679Z","name":"rdr-rhop-788dfe-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQD3enKzAy6d9yP91w/KXOPdt1yBgt7v9dkSsDRZQVGtemWQPrRAGfU+x+3q39q0LqwYy3ywwNlIfC0cNP9QbOb1PJMlWgQNLY5Y6z1MHgKkHDURxFYAiR7mQKz+yAlUTLwoeGvq1QzqlGEktzMuzlvn27pSj2uxleoY97G1CSCWJy32nH3a4+H6PDy9DrGTOGd/Qp7ZkYg0Xa1qprn3MoG5uUrEpi1+nD4EYHNwLYNQD8R8sQLEEQVzRxKxRSqo6xk8REsYVWdOOPZvJbSM+KIQ/tV1M3GURBRT2+i/5iaWscmloHx7olr9SV+v5aPXvsvjAAW6vLkqg0NXhbozGq1vVR+2Ct+o+aOiAFAJz7+AptHz5NLn3MsYZqO+Mf7QHsc5u0HZKZlG1zBAF08EQP07NT5iUMhcurq3D0OiHdbn4ePiGZXdeslKeocrLAxo6QqYsyxDEfENNsonVV1lSqyP/kl9y08e3u5QLYQhzgL7By/i2NcJn/UnPcWi5MiWFHs=
-        root@ea766bf09860\n"},{"creationDate":"2021-06-17T18:08:25.069Z","name":"rpsene","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABAQC5buSBI6u37UwOKejw+voqxd52ft9KhRjaHzMIAaTAKzxhzZnScryEeGcrue+wP+pE2J3b+/YRSbtFLgHhTXRgR9NyzX7YtnpDPt0ic30bvYxNqSGmURpLED7O0hvucke7BM6KYuIT/ZqMM9gSMRQfHr5XiCzAAxqX4CLb/bpMHKmJp1ydKOeEYAp2SaHCg2DF63+qdFWkdxTdb+h1nbWF7mZE/7COmDOzqu0oEAEP2B3oJy5LR2aTr1+LxP3cd0NzMANDqdDc2c/2vhrfuKozhfsXk7bTDeef51sNwdZVSjY7dS6nIDR/kB9WNOqbeBmDZlT03NYSLQwtQdsQ4C0J
-        rpsene@rpsene"},{"creationDate":"2021-06-18T13:37:07.678Z","name":"bastion-sao01-sshkey","sshKey":"ssh-rsa
+        root@ea766bf09860\n"},{"creationDate":"2021-06-18T13:37:07.678Z","name":"bastion-sao01-sshkey","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQD2Y7/6BjCa/5EKUaojeImBxti+ZwcBAO8ht+dAE5jB7te2VewwYbyz7XhuOD7dup7EF4CAhGYPpJJVwNwcKYlejUlWkM+Ltd9b6SXCk/Q76pcAJNjeDEOQRF2OzlTkyynmPMXrYgzPc9Bq8dlrHIGkghgJlryspw85lQeArNw/CUxKk5EEavowJrCQgFN9cJfIJxmq7z8oZPjd9HapZ1YSjQsXdXSxNkmJAWuK2nQGEIF/suGWsVgb7rSRGQ6Ve4RYAv7DknrSohxptongBAUUV5NaRl3p4KNEp7/rj4Xb5bPFE06wu83it0p960Ut1HU6nU289HsRp1bh1J97Rwx7mg5rWFJa9ZYUATm2TS5eiLPZTqdB4DgbYAH3MmGZdPM7U6mAiep7fLQ3kjhwq/Vlf7pUNk79Ln/9U3a17Ye76L9/ykNOhx/Cl5IA9rjx1WMyhtBYXD+26H9wBV6oi1fWln5Ss6oC2E5F/rWe7audgHea54ZN8syoTXXrQz2CkNM=
         root@bastion-sao01"},{"creationDate":"2021-06-23T00:48:39.941Z","name":"bastion-osa21-sshkey","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQCub6NkObdDs51q2Lt9qAzGPhZNuf1SBoBtH1YuM0IIA0TKkrTNtOfK4sWuP6gpxS0gLUgp2ECJCi7SB6oMLxm95k3Feabf+/YdWySYVyTg5s8MynPj4uGVG6SJRdpKXyzVuE4zz/QcOENMDVUmqip9a4HEEUrXmbeyvGFwzOaKjl34MlJDZnlBNyZrmB7XDvFjG94sBYwYFXkfucbxJhh97NTvXyrkeyk+JTFPkqzQm1PqTKU3CEHtG3PyNsHaJGkd4spRjFM7HRXeCl+AFy2fxZed8CRV21WFnZTtdZjff5H6R4ND6TkrDsVx5U7fkxFLvQKHpdY0WrkL5DbujNnMV70k2+Cz9tyXVwPPxGcCsaJCyV3wVLDvoLJvnsJk++gdrxU5OAqTN3UFlq7R52d/fOfGHK8aEYq71n2qihqCwXP7+IImKaq7ms/W7fIZsaM+KZ/0FR9sgHqu+SN00cM59unukU4iE4fuzAOh3nlAGnG7QDIJymQb+SIrs1hD/FU=
@@ -1219,7 +1179,7 @@ http_interactions:
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDNolRtJ3ru4z6v3RjNU117fb0Ur4rqOsRvmp7B7CMww7jAH2bGDM8hulCW3PbmuBQ3qbrO6woR6bVAe1aiI+67vP+O6+QJFChyhdogtxOcIeNRt62DM0RISie+xjbDwbKiLOTXmB16BcLb/jEhOOw9St94fISsQsSCHPqMSETupqBC4NdyRui1lXpli228BA8JaDbSc9oR2Vt9G4QgXLrwT0iuwbCIEW14xpheVT6gb/Pc0p4LB738XCv6+kd4rNEr/5b92L3NS2tAqUCSEVTq0EpY74x9EVABesP2mJmWuJx8q+L09KhN22fTy4S0X9S5LJhDFjMAZlH7ZPAydRRZrGtSOueI5w29ARjzx+7xHZQZuoW6YxGqYXUpY6SS0ArQ+79H4kyTbGwMYr3mKqg4V1XTiMvBwYu+/zKX41voV5FTozobRsrmW9PvoZ1UTu5So+SqcJ0QiVgkVReyDTG6vBELKTKRcuoY+cmZZjYl9sDO0VmPkAzlaJp4ASQ+C+M=
         cedric.ziel@instana.com"},{"creationDate":"2021-07-15T22:21:44.140Z","name":"endre-sara-turbo","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABAQC0cnhrw1eXx2m2VLefNTbKLRsJeO389fiqbZX9CjjYu19eYGrEG2cw2fCwoEVXuP3UOvZk4vxLF9uLDCyQVMI48MgR5mh2SLXdab3E5VVNJEaxaJmX2IoxPkC4XDvRmrU7VFVet1qtLb+6YxAKNghZ1i3j3V+83ZKcb0QjQTeCAUJJqDIp1tVejqvg7Nrikq7z3zn5agBF+DE/G6SO21Z9L5sIaPiBdNQANBj0w53tT0R0cfEp4F/ZcQ4Xc2HmQJt4HeD77yPBYrX8hpJoxRsjhgl9SRw8e0MiC44kA80YACEqCOsHSEoAPsBgbv0uVPrGwtO+XHhzy0id+ePInjxP
-        endresara@gmail.com"},{"creationDate":"2021-07-30T01:32:05.387Z","name":"rdr-instana-2-us-east01-keypair","sshKey":"ssh-rsa
+        endresara@gmail.com"},{"creationDate":"2021-07-30T01:32:05.387Z","name":"rdr-instana-2-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQC5M/BmAkj1IW+kX6lJmua0+wo44mVP/as8TarResht3/vKaZh0k8/8jd4eujAwT59o2Xmk5QYdeYnlgzcwojgpMWu00P7TAeNQDJwSeRmbkQMnB68gXFSXyJoziyla5l1/q7Kz55wqvCQ2JccWAuC51zl+J1f+1j46cui0QWWnewduXn5hgvqFrZ18jUyiimZSIHyvKzUkM3NxijMVlbajqgm6Z7FyzKZOKK84sw2cxM39iuZsMveJt5U3ErHTmJn/tPD90Lidv2HddbGl5nWkt7vhaynj3JTSgKJqaB+TZ/lqmiNqPjjQuLs7EFFINf5d0DgP6GCZw2U73XlxAVW+DIPAizePlHVBfiZy0HEY9ZvGZvX5/kugpCjk9/CtSpCUU6N8gCoAuSZKdakMHRqufjcHTFuAHx6meHczffRFVxO1AjJV5YDWMDyJTAK7Wp3ViB/PJGAY7VqpFzrDEAKf0FZY0S2FjfYRmnr94GylgJQiSFa7Vs1tGTR8M9HdKD8=
         jwcarman@li-a36b264c-2e6f-11b2-a85c-fdfb37238350.ibm.com\n"},{"creationDate":"2021-09-01T17:27:09.709Z","name":"rdr-rhop-d852be-tor01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQCawRJh8eV9QdhaxLFG1eubYvQDSmZ5qE4o6i2zNbaIbTlBVAoFF0O1OlzdJRDz7oS24C1nBGpQHQPfhA9NCLXW3olm6lTEPQyz3z4DWkwKARoHUhPPMPoBNc66p1naJfnsqMSolfTtqKkQHcKdUenKiEo+1QjSNvpyMsHceFu0+KBi5mKtd8UFvgFpv0zgZ1f9YJKus1kOg7qpGiH87lxV/s2cD1z41pAZ3853kKtFd6tohYBU17svDev16h+KX78I9zuEuL2xoXTsvwjlg6a8ooD/dh5iyAzxPwsskck6c2mKzaOyxyBRGh1qHMBMdb1AgvU/WWulmf+iWlgkDCQ09jcxC2K30m/BhneueeiQgg3KDRMjow/OTToh8XG6RkBMfFVKYM3ZQ5Lyvufld0DdZFuwMJdIA+npzhxmv0jCnYnt8apxG6CQ6YfLRfapcfyuzMmSEy45cpd2zVhym76r34iSpOyogtdtNGg6YOlRrzHiYg11Ho09BhqvgD8zCyk=
@@ -1231,7 +1191,7 @@ http_interactions:
         AAAAB3NzaC1yc2EAAAADAQABAAABgQCv9kWoc5Sv01CJMOl345jG5aLRogSJmdNr3GqdgmgFwhwZ8CIT5Cu42Us07VvJcBjL962yjRhDG/kv2VpJ77wSfaZVakplPZrFLRlFBwiRYF+Zn7s2cIqpFOuV3vVOyMIFzcJtVElFVPOljz6uAds+k8d7VxS1D9fjSR6ElAD1Mgvbu4S4AG2ivKXwR1vIYelbTcbRxm93ti1WR6fLFwlZiWRrXpJnrcAdMWqjWIQ/7du8Jt+A0XmJgRdJkb7ErSwHM4njjdCQLY7yOwlrGib79pOSrTjXlhPF9i6V1aRSRyLCfnXC7gKR2bT+oHmRiZf1dD0TDHwgSmwLz0AqOboB4JhE7geTHdL1Xdb7vW5pMsUUpTkMyU/12p8p2xASeZJ7yczf4k1uO5e/romh1UHnA/j6VY9RkLeCNOlYIY+hUyjAuJHJ73yS70hIxJGk9lYtyaHBXH3A2Ucx+4uZRK4lGwg7jWB++LZOHdTOqUIdR+LV29VkUDVR6Fb4ldc3Fu0=
         root@1727d1f4ba7a\n"},{"creationDate":"2021-11-30T16:27:24.313Z","name":"rdr-rhop-68d788-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDNHzqoFWX8MFVpfgoUj14Yq/K3dXnRTA5rMW7oWHGi9YD65syyMpr6/StaE2bb1lXvNuhWERRJZULbDqxhqeHVKD4RdEtEKVh6zVNZnbs58cevTrN8GSLMnHpfk6EB+66vdKREALeQc0TwDjeSa93Srw7kNE8c1FzodZY6LzbZcf5xrASga8tO/xzK827v7/LPqjd6tbaDpsIpd/HxGhwZp5xlZYei4z28QX68mpqTkpZE7Vtoj0d3i1wPQpKMa35Qkcv1Ju4qHI3z7fIgolO58H3INw3TdSpXraN1F79Gm2Px6qYLsIHxbLwrgptOlDgmCs60EpvSFmLSf7Hm7zqNOFxBnMDb4jtI9MnVPPA/aqgtxF0DPUGkQq3mLGvtrUDa2yCm4e7grxhVDXKldbyvIMh/Hce+rD7LLueref+ouUxLLVEa2XcTOjQC83Dzulv5ZpcGPtCAoRLe/94eJASNmAa7ePirLeNQ3bFbOWIHO2r0iDCQ+42jb87AiXeWrRE=
-        root@7568323679bd\n"},{"creationDate":"2021-12-07T13:23:43.897Z","name":"rdr-acm-spoke2-49-us-east01-keypair","sshKey":"ssh-rsa
+        root@7568323679bd\n"},{"creationDate":"2021-12-07T13:23:43.897Z","name":"rdr-acm-spoke2-49-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDuIWArFe6OZrUPrkqf4rBCVMdslPJJ5wF/CLFb3WsQbDHzv4d5Iv7fE/BSGqoYIrAwujZ6gBwRr/NWJlVcPJy6UrqS4joRo+P4RIfQqUeBNiAd3K9rZvYdGCfJOKVHDO+Ww1b8DfozUTHdAWAVD8FiDNCcbBG2BjyLWNGW77hEoHKlQcpwAsyQxiwlovj5OpRNJ5rXAc0QDNlSaPyb6AcSBaaTUA6rtkhtdLFE2xn9JHYM2yuhFPWZt3unVHHw8bpWHHeQNZ1X/ZSNpD6b5c0pWMtsAm0+Be3BCrSPhYu6ZvcJp+gR7eNMDKZzM683Itht3OCqobi2OX6RAfqOcPcI7iGQcn7EmkphJOTuigYFmxPbZEELsc2iqBY5LOJr/F5RmvqdgYS8cIF6ZmvUAF+MTiw2gGzWxsq7THQpXOe5rUBlBtokLJfzRI6JSyDGDKe/0ELOfbYCBqQTyuMMAu+vpeHvUZgDuIOGEzg1CLi1FGq1WNT/crone7t+L6e5wgM=
         acm@power\n"},{"creationDate":"2022-01-06T20:48:27.584Z","name":"miyamotoh","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAABIwAAAQEAvgnCouivU5OFNBbV5dZIH+2RQ+U0/SnJGY5dRVIyCk2gYPT4AzsM4g4/OTOMpjgId2IcuqNVKpY9YQcetyZiMdJN5QjuNecPvYbEaKvSawHsbUbH7/pAZsU4RjsFHxmr28nG2ses3MiakFZdPmY9pUu2yrPZU0AXNyKpZYcbxDWG/W1jf6njC8HUg91LhXkZH6iLcP/UFQ4kJDsz7PUirF0WZahKMuxQzy3F3KH2mYJx94HozBJAAZvwVeTvI+Q32zVoAmAkovbm4wx2y5G3CD3pPnaLX3aUr1yHgXxPpnanz5vaPYb7ng7EWjqC7BpLbiL+oxa2pqXzuD/AHdkxow==
@@ -1253,7 +1213,7 @@ http_interactions:
         AAAAB3NzaC1yc2EAAAADAQABAAABgQC8rRnsfjOWl7VmXQRpFqHPwmqC1u+UI4YHSih3lJ2fCQUW2+4ASJq0PRHib0F/SkmdH2hZ4Boo/jw3nT0Ml3FhFF7b3j/9NwWof0LIDqzy0jTzvKOA2wH0Z+rjXhp2XNg1KFsBKzi3TufMxjcEHZop5t1ykYx+QR4CcirtQAY5yxD11ixBeLViBLu6uGmLFieQNFOb0nHJcHTvljXQjSwErXRHw36jlyrQWLSh70StVyqElE8bQIELLWTHcAf2I8YAGXxJ2+mF5112pYvt2saNOd6xc6U8CQ6uihXCUYuxeuGh0LoBTVGyOAqvx0DJUBmKi6uzyEEPozI/wETeSgqw7EBbL6xJISA9lveJyi/BF2v053pVtv/+VDW1AZ8ym+8zNssrqUWMa7n8BG39LofC2AVEW0MzhGdAboBePlsS3OMXXxepfBr/VTF/JxX+M9apqxMSLHf09vtAx4e9aDPzH1jYYY3E9m9A0fQnQ6EgB1Mxw3npX6ynQSZLM/6otnc=
         root@3718b298d936\n"},{"creationDate":"2022-02-02T13:11:19.063Z","name":"tmp_ansible","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDBe5MEmz+aKDl/SnhX21l0wOFZICWWB63+68A/jqR48eFccnVvG7100T+MiRtTZeFm1ZZbXfCmlqX7L+xDmme2kd0tGXcok0RsQU1uaip+T22SRJsQyDUL94RwCcd/e82tOJcTLah5YEno/EaLR3Numr5c0AUksmCDirikUvdxCc3q2T1NSjBmK+PBWKaEwEF9AQiLmx/sxqmYXiatOlLb3HELpEmRuTcRzkpOsXYXfP5yMBtktPDFz0BXsLgoa1e5ooEfiYfXH2w64hNS+c9pASXD+pFnLtnTotl+BeG7TgWdw/3P2BRiGrtFkxaHfAsYJ+g5abs0cj+UpLjNYhv/zCiC/ewTAAXhw+7asKxuenhM1aQ5p9KnUK/MevqcCQf49R+8h88kcJC9B7xvRC5sPZGalzM478Vr1jt6IEXFrf5sPieLfODrBQS7CpI6OI2Z8Rddcnuyngu6ivERXXhaSiayimZ6CjcKsqdHlg4mekOjzrLRjPguc5RVW8QSLPc=
-        jwcarman@jwcarman-t490"},{"creationDate":"2022-02-04T11:24:48.750Z","name":"rdr-rhacm-us-east01-keypair","sshKey":"ssh-rsa
+        jwcarman@jwcarman-t490"},{"creationDate":"2022-02-04T11:24:48.750Z","name":"rdr-rhacm-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDuIWArFe6OZrUPrkqf4rBCVMdslPJJ5wF/CLFb3WsQbDHzv4d5Iv7fE/BSGqoYIrAwujZ6gBwRr/NWJlVcPJy6UrqS4joRo+P4RIfQqUeBNiAd3K9rZvYdGCfJOKVHDO+Ww1b8DfozUTHdAWAVD8FiDNCcbBG2BjyLWNGW77hEoHKlQcpwAsyQxiwlovj5OpRNJ5rXAc0QDNlSaPyb6AcSBaaTUA6rtkhtdLFE2xn9JHYM2yuhFPWZt3unVHHw8bpWHHeQNZ1X/ZSNpD6b5c0pWMtsAm0+Be3BCrSPhYu6ZvcJp+gR7eNMDKZzM683Itht3OCqobi2OX6RAfqOcPcI7iGQcn7EmkphJOTuigYFmxPbZEELsc2iqBY5LOJr/F5RmvqdgYS8cIF6ZmvUAF+MTiw2gGzWxsq7THQpXOe5rUBlBtokLJfzRI6JSyDGDKe/0ELOfbYCBqQTyuMMAu+vpeHvUZgDuIOGEzg1CLi1FGq1WNT/crone7t+L6e5wgM=
         acm@power\n"},{"creationDate":"2022-02-09T16:17:31.660Z","name":"rdr-rhop-7d22cb-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDpTTeiPL8JLwRO5FbkWSxdJKiTv247lY4OPc4FxCLtQT50RB9s3UZygwTrlh4OjsP2G5p0mavq8KsdYEOqgpreChNc+oY0QpYlPHbFKVN5Ii7ahkUn/At0VKvzzo2Kgrm6DTwS0NO1iY2M6PEVxV4XpbfNQkj4LTBZ5qra3JT46EqCCEYybgUwGndUmK8p9/gpK/d/Wcdlkki/q4t88ZX2Rmth/DtRYcb4d+QuIGiqoRshrMhOES/6ouq5mQbJhyehdrDk2WkYcxHixeqc+hTIP12CX/icN4v5WWPfJBxgdbG7EuAbFQtZ89wjtz9odqEb2LDGrOSeahX58w36HuLOtxKSD/23tIj0EWspEnAJ5K+tKxQQpO5rqWsRQ6BpiZuk5sYs2LPw/0oz47yqc2E/tLHK/Gd8EmhH8/ZPf7/y83a+SYRVCrpe+RO7mOs1l4oA00Q2ArH1LPGvWPde6ZSQUsfkaZ9mkCjTcgHb5JgAt3Fb1PFazWl3Xz5/0XRa7NE=
@@ -1394,7 +1354,7 @@ http_interactions:
         root@bff216ea609b\n"},{"creationDate":"2022-03-31T07:37:40.197Z","name":"rdr-rhop-410688-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQC7L9MT4wSIwjP4K/C4gLd0CgsVPv7JEQT06H0VPA2pkWIoZnUIvEHVFW6ntI9V8Bo0/DTFXRgTaT18Rh3AWAh3btgXplLHmuprs1oJtgijpXPhiQC+hJvg5rFTd4op4r1tn/KHLl2uxuTW1ngv8kM4al9SwtSAhlshqrtIv4TVAa5HsVuT3yJchlXbosd/R2mfDLzupo62Abt7ZqooyzG0g5UhZfH2zxU5AiAC38ncsIgvKyneHWJvHbFvB6z9Q8ze2AmZDBxXs1bz9Rydik2fYNJuT8dbwqYQOLbO2MXLELG1wqQq1yZsO05wr8mrOXIpfSkdDFQ0Y0tsHs9Cb4RVflvWIVyHsUXHYBRyc00sfIDjtiEKS4Oh1uM3b+9+owuDB6YWTt2R7lYveih8KlguDX28mMoBx4OBX84D75JXhVPN4iI8Tjq9xxghk6MEtg6oYgYAX8/K/XKL7//xGOJJ3Lcv6MNsJYap30y9rf3LjaNWhA9KQZcD3j+n5asQsSE=
         root@49428045e663\n"},{"creationDate":"2022-03-31T08:17:38.202Z","name":"rdr-rhop-2d0da9-keypair","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABgQDjqOG5Y1IzqP0sEsGGu8UGzfL9keAHH6P8/ANf+sIno0uk1QEBDWEdzfkEMwG7UNDsmscmGXtIpwRe9d/nDe7GDnh+qG6Nv5KcQhx6nadqIiqnlP74Vuv+1TdPi6UBm91Xr/ad1hGtUFWaOr22wWQASr/TEvSVJmlu3zGQDTLA7F5eaxbnHF0sf+A6vX6yFQ57YAlQmPTge50mk+eBG/VU3cCeXlwcNhq6psBVPkxLC+PlvP/UjVvDqchjl/hTHxdd4BgBFRq/biIXrm7xhGVDJ7OLWOzWSmty2gKTHgth9Q2VnVTlB3KhRMpeBmZZnPuus-east9JzI2X2/RYL/W8kfdfW0OEU8H0BtfChgTHtfNyWFdbanY3DnfmezX0GfKc1cU3N0T3B7tVbunkbU39ZRhxyf/v+unMqZLIIxFCbl9utnUaSyfZ4A+byYTFu9xJuiIjqzjFnn/wLe+DYkRe/TE1OofZAWJCsO+VHq7kpda4WZTxU3F6qM9FJfAMHtV2Wu0=
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDjqOG5Y1IzqP0sEsGGu8UGzfL9keAHH6P8/ANf+sIno0uk1QEBDWEdzfkEMwG7UNDsmscmGXtIpwRe9d/nDe7GDnh+qG6Nv5KcQhx6nadqIiqnlP74Vuv+1TdPi6UBm91Xr/ad1hGtUFWaOr22wWQASr/TEvSVJmlu3zGQDTLA7F5eaxbnHF0sf+A6vX6yFQ57YAlQmPTge50mk+eBG/VU3cCeXlwcNhq6psBVPkxLC+PlvP/UjVvDqchjl/hTHxdd4BgBFRq/biIXrm7xhGVDJ7OLWOzWSmty2gKTHgth9Q2VnVTlB3KhRMpeBmZZnPumon9JzI2X2/RYL/W8kfdfW0OEU8H0BtfChgTHtfNyWFdbanY3DnfmezX0GfKc1cU3N0T3B7tVbunkbU39ZRhxyf/v+unMqZLIIxFCbl9utnUaSyfZ4A+byYTFu9xJuiIjqzjFnn/wLe+DYkRe/TE1OofZAWJCsO+VHq7kpda4WZTxU3F6qM9FJfAMHtV2Wu0=
         root@e194f0c7b16f\n"},{"creationDate":"2022-03-31T08:38:03.313Z","name":"rdr-rhop-9fb34d-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDA0QL43oZQ34EBxioDmPQ1unHDA2Q7fzuG92tGPMZVFUKmpVAlXIYmrutE3/xO/ggP+ar0aOb8w1Tz/mzj1bkWHhtD2RqerhA4aXPHX7yfLweGQduVzgcdF+tEtSSJYmrcPEDbikPnxkKb+bZMkcBVTpYx1iVLgKtfn63Zqu5GcErB4anV8cfp4o1TVdHO4CxFCd/ESvnMfIRGqerVcvaKdHN94I9AGIFpZgY8o3wrjjrPffPh6cx7mvRfXzNbCezwB7ZYwXpSqQ3zr9P2j9ZWh/PYARadpwvkQ/EcYrSa1L9FctyWGCtKsY4jMUpis/zo8hYePaU4gEUI2qsgu6UaMIUHU+7sXkF4n313ywZZickSt9HoFUZ8bH1xkexhjVQiZlA2xp9Qo7FEKxcS7xaGCfBLRM6NES61em2Z/YkO4y+zC6oh7C9/v8Z8t1ovBOimf+NVw7lzZAno+ZzTs9Oeqol3+m1B3NxgUUbPjlDhOGzUlAAB6+1iqUP6llm7ToM=
         root@90f87653076c\n"},{"creationDate":"2022-03-31T09:27:53.191Z","name":"rdr-rhop-2995ce-keypair","sshKey":"ssh-rsa
@@ -1483,7 +1443,7 @@ http_interactions:
         AAAAB3NzaC1yc2EAAAADAQABAAABgQC5xwJ60ngnWEp71SBJFNI84k71NLmkKzFsWI6eBLGfpilKLzN00Z8IfYkoJb14gZOGAbPgenaFB5SFe6hCigsT8yW2Biqqus5fPDpkM5smtlMfo+m+fun/bS+31Xu+6ajAffdn5Vqutv0KsS1QYwTnpwwjuxmiKek/vOcwc/9WOGqB3JaaOuyEMVQG3CFjUPUEsjLum2sOP5QN/RgpdCtWKsHxUfFjniQBsnwWXS4Wrio8mgWmLT7Op4d21NPtpRvFWmNg2UQAZ5D3BWntZg3l4zxAM9Qd/60siN1dnwxAN3FkyVJhsQ1cE441PVlhUElPSBmZf3SZXWSZyvHO6Z41PI7MdExRswr+bRxKR1zO2Vd0vRTiKEqKCLfdYfutYDrCBS+EkcvXSxX8bf4nz6DYstARu4mMm7i/kstIRA+Z1hkHerXOS2DDp8spaELemjwp+J2RKITv/JFDX7fIWbPgvy29TPV+nVTTZPDs+bTbUPIZSNbt/EdlbfGOKVRfGaU=
         root@utex-installer\n"},{"creationDate":"2022-06-22T13:46:10.582Z","name":"luks-test","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQD1EV8/3Osbi+R5fMe3/RzvIHIpSJrbYLwmfE89DlCgo+RUebx4lmKEVpV6dGIbaE121Azce21L8zeVSBA39X8QUdH+CJMIMyLnTZpNYfID4lij+RSwdSFjsXdpJNGTL+/+Nc1plvmS5wLtibxlGHCpn99DEONZnVgkIaxsCEfS0DnKGRgyQqtTy2aGykM3VGBXZaRL555lPr8D1j9qjA4FT5vBr9EdSuVnDM8QL6cIf0viyp9sMGWRSqCWbLUthvepnencFU+nNa+DWSYLpMCiLmY+IMsQ52lwU1mnU4bwnNsiAXrl1zgbX0N43wf63YqLOz/KZRbi6SShAuszcPPO6oxOcbrZ8OPRJ9aFFFvNRiSzp3Eb2v2ArSruOakG/AoPIcg0JdIQPM9gKPM6XioWe8SyMT6/CkqwaHPIo0aFsNp6aY9qZJ7EUXEODL+7c+FxjEjPP955U70z90nRq6C3BZ/AL8WdaeDlj7WwP57qzgF9ePl8FePa0qJdhdbj6GU=
-        root@stocked1.fyre.ibm.com"},{"creationDate":"2022-06-22T16:49:18.191Z","name":"test-ocp-992b-us-east01-keypair","sshKey":"ssh-rsa
+        root@stocked1.fyre.ibm.com"},{"creationDate":"2022-06-22T16:49:18.191Z","name":"test-ocp-992b-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQDdZAueVOe7fSynp6IGHFcw5gAPlbse0E1rLNKvSe0rABc1DeOWj0fgRTg3WuEjb3uBVsZtUuXE0B/y8s+rdCBB6x8qAshbiOCEYJSzn0Vdv15J04Reop4vOoC892tUCMBG6WHv7E9/w05UzbW0Vu2txkcGKBal5kyb2moT/78OOUdX0Ga6jh9oCoZZkU1pQADVgewRq/FJhV1hhP+7wU3sHAkb8ZDz0QT59MLItqN8RU7sZbsf75k0l9OfTRUrzbRXXgfYLCA5a3yI23nZ2IiV14Js72QbMZ8pnD6LLVZ63JPMHPqIMWXxVss8KJmFz/biWjufQ0OeIHTNgnHpHiA3BJMSRTtiJQdyHeHALliliuaLeIXzxF1EUwCVA+VQXUv40DzZOKWVcKLhF9EI8gCsUuoEt+nOvfcoTQxK91vKaaPc+F67o1nF1NcKtfdV43gUGboaLIVD6XZQO1WpkGypJDHKX1fFKjpFpvMLD4p5XNQL3Laoxzm9nsqqaOdo0jNEBpgJO5RwQfTGBzLCQpU73W53nX1UEHKXmtNDx6tw4Fr8V3rNFV1u3TL7WntJwpssGIUC+7c/HLi7mMT1iExDuHQNd9NlAuwkPdkodY2uwGZ6OgcnjboEGaJaJ0YPdL5qfwy5f20SPKTzZQR9cWG4UFFnhEXheLzJnDHNXEbDzw==
         jacobdenver@Jacobs-MacBook-Pro.local\n"},{"creationDate":"2022-07-07T12:46:34.907Z","name":"gaurav","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQD1EV8/3Osbi+R5fMe3/RzvIHIpSJrbYLwmfE89DlCgo+RUebx4lmKEVpV6dGIbaE121Azce21L8zeVSBA39X8QUdH+CJMIMyLnTZpNYfID4lij+RSwdSFjsXdpJNGTL+/+Nc1plvmS5wLtibxlGHCpn99DEONZnVgkIaxsCEfS0DnKGRgyQqtTy2aGykM3VGBXZaRL555lPr8D1j9qjA4FT5vBr9EdSuVnDM8QL6cIf0viyp9sMGWRSqCWbLUthvepnencFU+nNa+DWSYLpMCiLmY+IMsQ52lwU1mnU4bwnNsiAXrl1zgbX0N43wf63YqLOz/KZRbi6SShAuszcPPO6oxOcbrZ8OPRJ9aFFFvNRiSzp3Eb2v2ArSruOakG/AoPIcg0JdIQPM9gKPM6XioWe8SyMT6/CkqwaHPIo0aFsNp6aY9qZJ7EUXEODL+7c+FxjEjPP955U70z90nRq6C3BZ/AL8WdaeDlj7WwP57qzgF9ePl8FePa0qJdhdbj6GU=
@@ -1499,9 +1459,9 @@ http_interactions:
         AAAAB3NzaC1yc2EAAAADAQABAAABgQChCTEyTr2iv1wdqNY5V/J76vnEHvLKmwbBucqwarlhipCqd4xqRqNuTlk0IqvQCp12JbPi8dGtudPFg+pPPC080oNOUwyR9PMnRiBGPWmVLfzPS+1r/fg0ZfbThDvnFYR4oMnBkgxGrOMqHabArks+Ervg2rDzWiONDrt5tVqp0lYSbMXRVcJdCLwOYWenS1epZmYa6DMtWUu5nOdOqm/V5/zUHM/cuIJEd8ggDuiW1vVI6YeomcyMwGTXMMSYUSb/STfP/f1NdD/1mU/2zv8AYW7Sam26jcBHZWI5tGjY8tphgj+h+cF9XdaBqmCfq1K0/v6ex+fDHwkyqfXIdpJCQBsH94sCtTs7Jxadxq9oyU1hCMRmEdh6d7XDWxF3RUuw7T0FMpNJmn0Bo4Fo71fl1OJ3v8zp46N58ZyXTcHUVtwhHxTB7SqTOQtEgOEsqn6S84JW4ddRKH4DALbG6FjSsTyatBzd+7DYNurTID1p6Wk4vJHZBa4t1hMVyDFj4Vk=
         root@shend1.fyre.ibm.com\n"},{"creationDate":"2022-07-15T20:47:42.808Z","name":"rdr-gaurav-ocp-410-upi-tor01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQChCTEyTr2iv1wdqNY5V/J76vnEHvLKmwbBucqwarlhipCqd4xqRqNuTlk0IqvQCp12JbPi8dGtudPFg+pPPC080oNOUwyR9PMnRiBGPWmVLfzPS+1r/fg0ZfbThDvnFYR4oMnBkgxGrOMqHabArks+Ervg2rDzWiONDrt5tVqp0lYSbMXRVcJdCLwOYWenS1epZmYa6DMtWUu5nOdOqm/V5/zUHM/cuIJEd8ggDuiW1vVI6YeomcyMwGTXMMSYUSb/STfP/f1NdD/1mU/2zv8AYW7Sam26jcBHZWI5tGjY8tphgj+h+cF9XdaBqmCfq1K0/v6ex+fDHwkyqfXIdpJCQBsH94sCtTs7Jxadxq9oyU1hCMRmEdh6d7XDWxF3RUuw7T0FMpNJmn0Bo4Fo71fl1OJ3v8zp46N58ZyXTcHUVtwhHxTB7SqTOQtEgOEsqn6S84JW4ddRKH4DALbG6FjSsTyatBzd+7DYNurTID1p6Wk4vJHZBa4t1hMVyDFj4Vk=
-        root@shend1.fyre.ibm.com\n"},{"creationDate":"2022-07-20T11:53:19.451Z","name":"rdr-acm-hub-411-us-east01-keypair","sshKey":"ssh-rsa
+        root@shend1.fyre.ibm.com\n"},{"creationDate":"2022-07-20T11:53:19.451Z","name":"rdr-acm-hub-411-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDuIWArFe6OZrUPrkqf4rBCVMdslPJJ5wF/CLFb3WsQbDHzv4d5Iv7fE/BSGqoYIrAwujZ6gBwRr/NWJlVcPJy6UrqS4joRo+P4RIfQqUeBNiAd3K9rZvYdGCfJOKVHDO+Ww1b8DfozUTHdAWAVD8FiDNCcbBG2BjyLWNGW77hEoHKlQcpwAsyQxiwlovj5OpRNJ5rXAc0QDNlSaPyb6AcSBaaTUA6rtkhtdLFE2xn9JHYM2yuhFPWZt3unVHHw8bpWHHeQNZ1X/ZSNpD6b5c0pWMtsAm0+Be3BCrSPhYu6ZvcJp+gR7eNMDKZzM683Itht3OCqobi2OX6RAfqOcPcI7iGQcn7EmkphJOTuigYFmxPbZEELsc2iqBY5LOJr/F5RmvqdgYS8cIF6ZmvUAF+MTiw2gGzWxsq7THQpXOe5rUBlBtokLJfzRI6JSyDGDKe/0ELOfbYCBqQTyuMMAu+vpeHvUZgDuIOGEzg1CLi1FGq1WNT/crone7t+L6e5wgM=
-        acm@power\n"},{"creationDate":"2022-07-20T13:47:52.294Z","name":"rdr-aditi-ocp-us-east1-us-east01-keypair","sshKey":"ssh-rsa
+        acm@power\n"},{"creationDate":"2022-07-20T13:47:52.294Z","name":"rdr-aditi-ocp-mon1-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQChCTEyTr2iv1wdqNY5V/J76vnEHvLKmwbBucqwarlhipCqd4xqRqNuTlk0IqvQCp12JbPi8dGtudPFg+pPPC080oNOUwyR9PMnRiBGPWmVLfzPS+1r/fg0ZfbThDvnFYR4oMnBkgxGrOMqHabArks+Ervg2rDzWiONDrt5tVqp0lYSbMXRVcJdCLwOYWenS1epZmYa6DMtWUu5nOdOqm/V5/zUHM/cuIJEd8ggDuiW1vVI6YeomcyMwGTXMMSYUSb/STfP/f1NdD/1mU/2zv8AYW7Sam26jcBHZWI5tGjY8tphgj+h+cF9XdaBqmCfq1K0/v6ex+fDHwkyqfXIdpJCQBsH94sCtTs7Jxadxq9oyU1hCMRmEdh6d7XDWxF3RUuw7T0FMpNJmn0Bo4Fo71fl1OJ3v8zp46N58ZyXTcHUVtwhHxTB7SqTOQtEgOEsqn6S84JW4ddRKH4DALbG6FjSsTyatBzd+7DYNurTID1p6Wk4vJHZBa4t1hMVyDFj4Vk=
         root@shend1.fyre.ibm.com\n"},{"creationDate":"2022-07-20T14:01:35.807Z","name":"tang-shend","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQChCTEyTr2iv1wdqNY5V/J76vnEHvLKmwbBucqwarlhipCqd4xqRqNuTlk0IqvQCp12JbPi8dGtudPFg+pPPC080oNOUwyR9PMnRiBGPWmVLfzPS+1r/fg0ZfbThDvnFYR4oMnBkgxGrOMqHabArks+Ervg2rDzWiONDrt5tVqp0lYSbMXRVcJdCLwOYWenS1epZmYa6DMtWUu5nOdOqm/V5/zUHM/cuIJEd8ggDuiW1vVI6YeomcyMwGTXMMSYUSb/STfP/f1NdD/1mU/2zv8AYW7Sam26jcBHZWI5tGjY8tphgj+h+cF9XdaBqmCfq1K0/v6ex+fDHwkyqfXIdpJCQBsH94sCtTs7Jxadxq9oyU1hCMRmEdh6d7XDWxF3RUuw7T0FMpNJmn0Bo4Fo71fl1OJ3v8zp46N58ZyXTcHUVtwhHxTB7SqTOQtEgOEsqn6S84JW4ddRKH4DALbG6FjSsTyatBzd+7DYNurTID1p6Wk4vJHZBa4t1hMVyDFj4Vk=
@@ -1537,67 +1497,134 @@ http_interactions:
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDPrjaj59l1DFR5ZS+P3fmY+MuV62Kyewm2+kKCUKVyxZdGE3p7QFmwUiAzP2ZrYkSEsn0QZBK+li4q4i5l/SIA8XdjolfUFCtKNgdKTCFVdecR6iXTxLekaS/z2ehU/4PPJ1OMi6Gqrd3gZMgDRmKbZMj2RH/b0IcIdF3yrl49SF04G3GVNvvRhLAdDGe9BWi0cBjwd3mw6fQrLUvVRDfpZ1+HsyGAq1x8AjyiE0EA6WnV4yip9AAWIVisk25pQRPEDcGduMgLXbU7RjlYE73Cqv4UTryndKSdpKE1joxo+R/OhFoS9tMjXiA8qhhhM8m7p36QFIhnZ5FSNOoPwSSh9at2PXtyPJh5UmVx1fgBeseIvQxel25uEuELutA0ZR1IIglcleiqNH8FsVN+ktrl9TgqrWIYkl/C4cDxrZSWTEnx5j1yAtHDDxOi5NtV0cd2x7EtFkeOYz6B9oBvClmnLEi3MgjQOG291bDsL1FYGIvLxjVmYYjFlXUlzGnd8/E=
         rajeshjeyapaul@Rajeshs-MacBook-Pro.local"},{"creationDate":"2022-10-14T15:04:39.505Z","name":"rdr-rhop-ab0ebe-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQC2btElbJb2v8/R+Jtyr0iY31vysoVMJJtoyjNYmUm/PUhCXFzs88NtrSnDQBxsgNgOnozqJf1QLCNncFV9WWpZ9cef7iTA+rGNL3/1eQbAIhcmRSiBvU9zJYV85dmcYAEZKyoPJeue3qv8EsxoM9oe+dvNRLgVLxhb0IodSvxp8rP2yyJaWtAZCWOs73CBZ4UPpfld2wDQtEyeBxRW6pQ52qM8lFz1t6zjPIJ+nDoLC2+JKZB0sWOySCEryoWQ+0CEmOBPC0CE0uDu1YYjK17zlr9DDHFMj4ioSKOwcSO8jB80VoVjQo3YK/xlCl2d4QvzlZIaJriDJ8J3MeoQb+kxwsnZpiclQp32otdUz2kP7lK7qPPb2ujfgOZdX7gx8gAPxKC3kqdBOvfmAiF+81NRGu7TmuFtRuZEIaKbTPSeR5mTzjB7Q6PERyxq02B7Cwy5Bs2YWP7/RbfA4GqGGFT0ZJMo4AUE5yaYFfTHTA/yRIlQ1CD6X9GQEJfWA/TRiek=
-        root@11e5e1c4db4a\n"},{"creationDate":"2022-10-18T14:36:24.071Z","name":"rdr-acm-hub-backup-410-us-east01-keypair","sshKey":"ssh-rsa
+        root@11e5e1c4db4a\n"},{"creationDate":"2022-10-18T14:36:24.071Z","name":"rdr-acm-hub-backup-410-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDuIWArFe6OZrUPrkqf4rBCVMdslPJJ5wF/CLFb3WsQbDHzv4d5Iv7fE/BSGqoYIrAwujZ6gBwRr/NWJlVcPJy6UrqS4joRo+P4RIfQqUeBNiAd3K9rZvYdGCfJOKVHDO+Ww1b8DfozUTHdAWAVD8FiDNCcbBG2BjyLWNGW77hEoHKlQcpwAsyQxiwlovj5OpRNJ5rXAc0QDNlSaPyb6AcSBaaTUA6rtkhtdLFE2xn9JHYM2yuhFPWZt3unVHHw8bpWHHeQNZ1X/ZSNpD6b5c0pWMtsAm0+Be3BCrSPhYu6ZvcJp+gR7eNMDKZzM683Itht3OCqobi2OX6RAfqOcPcI7iGQcn7EmkphJOTuigYFmxPbZEELsc2iqBY5LOJr/F5RmvqdgYS8cIF6ZmvUAF+MTiw2gGzWxsq7THQpXOe5rUBlBtokLJfzRI6JSyDGDKe/0ELOfbYCBqQTyuMMAu+vpeHvUZgDuIOGEzg1CLi1FGq1WNT/crone7t+L6e5wgM=
-        acm@power\n"},{"creationDate":"2022-10-18T20:18:51.732Z","name":"rdr-turbo-us-east01-keypair","sshKey":"ssh-rsa
+        acm@power\n"},{"creationDate":"2022-10-18T20:18:51.732Z","name":"rdr-turbo-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDFDedsNrOi3iuHr7vMykVhRfeRu6Ms57Kw8xDbjgftfHjGf1a8Di5o5TZLYB80R3teyFfWixy75W36aLXhcJQa6ePcmqzQGCuUiVVanLZdIAJjVzqFitl8bD6uwu6LGGf1NZ0d8frCbCzKwmy1pyJEdVX0BJOIttDm1gajeVr530YLM2TXS4x3UYut98PO60zIvgess6lfrIcoZX1bPj2UJOUQ2BD8tWMDS7Zx9I0dR08MtlogPVDG25zSRFAe42qxiGrbmdCc7HeYABBJDpImg77jM5AOhA9/3K4Mn9b7Bn3h2DTo8T7NfWJS+Oe5cEdfs+BPwYFpchErwd9dljNvACZGC+PjB4tnnl8Z3+dOT9NL3NjbNeiqKTmjhErrgJX4l3cc17E6kRSb2QkJOaRdoL60DTAcyToFHH9+7XlkKlSrUKwLfJONAoKC4J7qMTJuSLhy3EXeRTsTXWpCWghh4jsfOq0DWsMpGL/9q7dnOiiA8qhTk+eOGI6udMt9Yn0=
         jwcarman@jwcarman-t490\n"},{"creationDate":"2022-11-02T19:01:58.526Z","name":"rdr-instana-syd05-syd05-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQC5M/BmAkj1IW+kX6lJmua0+wo44mVP/as8TarResht3/vKaZh0k8/8jd4eujAwT59o2Xmk5QYdeYnlgzcwojgpMWu00P7TAeNQDJwSeRmbkQMnB68gXFSXyJoziyla5l1/q7Kz55wqvCQ2JccWAuC51zl+J1f+1j46cui0QWWnewduXn5hgvqFrZ18jUyiimZSIHyvKzUkM3NxijMVlbajqgm6Z7FyzKZOKK84sw2cxM39iuZsMveJt5U3ErHTmJn/tPD90Lidv2HddbGl5nWkt7vhaynj3JTSgKJqaB+TZ/lqmiNqPjjQuLs7EFFINf5d0DgP6GCZw2U73XlxAVW+DIPAizePlHVBfiZy0HEY9ZvGZvX5/kugpCjk9/CtSpCUU6N8gCoAuSZKdakMHRqufjcHTFuAHx6meHczffRFVxO1AjJV5YDWMDyJTAK7Wp3ViB/PJGAY7VqpFzrDEAKf0FZY0S2FjfYRmnr94GylgJQiSFa7Vs1tGTR8M9HdKD8=
-        jwcarman@li-a36b264c-2e6f-11b2-a85c-fdfb37238350.ibm.com\n"},{"creationDate":"2022-11-16T18:13:59.792Z","name":"power-ocp-us-east01-us-east01-keypair","sshKey":"ssh-rsa
+        jwcarman@li-a36b264c-2e6f-11b2-a85c-fdfb37238350.ibm.com\n"},{"creationDate":"2022-11-16T18:13:59.792Z","name":"power-ocp-mon01-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQC4hW5cTmFKH3kxr4KhfDB5b99Mn8AmlHT05i1+Cp/hHYTkwdTxfnB8/1Ik1FTLGVn07M5cK1x/Cqce8LAcaQODZanWIZKTIN6JsekKc8bc4mMbVK1W09M0o5+42V880OeKlGl+bWPq4dSW50bTpdr0vwSgMEbBexA21hXdX1E036bfUHbJJwMDSzWNix5qQ2lW8zB0Iz3yocucjgiL8ffeVsAQ7kST4MBqpxIMfShzIggoRwDc6i73t294/oH39wmredyaAXPePTAd9kf9QC3mV2MQiZiRKGz54xP7V9mIGY3hBFh6ubJGPilQ0LjAzefaFn3sFx/cvV6HuJgrIvAlLW7rkRxRFTsHw7wFvdlDZc7bFZCMUKlGAJghkJscYYE7sFuUopdLeWw0TxymVZ88RakOdseugQwZVM/mT47qMfSoRwc4M/ezT8810xrNKHAZn3+1CjklW29mHuVVR+j0ITrT66DFUm32oj/63jaDIiVvxEitNBwSyi3FMUuSB5cy45gvgd0YArsPGFK5z4HDJgy8962v1tnWwsQv0SAsnGHsdP2vMV5fjuc4ESrEMAP2ZwOHWKLRJgy3x4TJLgorrFj8zS+sg0/nAom6d/u0knXs+Dn6+KDPe7Zr1edQSINyy7kniWEB+9/IVHj+h7lLljLf8bnzYpLbgxmHlzpsXw==
-        aliza.peikes@ibm.com\n"},{"creationDate":"2022-11-16T19:41:47.547Z","name":"power-ocp-3672-us-east01-keypair","sshKey":"ssh-rsa
+        aliza.peikes@ibm.com\n"},{"creationDate":"2022-11-16T19:41:47.547Z","name":"power-ocp-3672-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQC4hW5cTmFKH3kxr4KhfDB5b99Mn8AmlHT05i1+Cp/hHYTkwdTxfnB8/1Ik1FTLGVn07M5cK1x/Cqce8LAcaQODZanWIZKTIN6JsekKc8bc4mMbVK1W09M0o5+42V880OeKlGl+bWPq4dSW50bTpdr0vwSgMEbBexA21hXdX1E036bfUHbJJwMDSzWNix5qQ2lW8zB0Iz3yocucjgiL8ffeVsAQ7kST4MBqpxIMfShzIggoRwDc6i73t294/oH39wmredyaAXPePTAd9kf9QC3mV2MQiZiRKGz54xP7V9mIGY3hBFh6ubJGPilQ0LjAzefaFn3sFx/cvV6HuJgrIvAlLW7rkRxRFTsHw7wFvdlDZc7bFZCMUKlGAJghkJscYYE7sFuUopdLeWw0TxymVZ88RakOdseugQwZVM/mT47qMfSoRwc4M/ezT8810xrNKHAZn3+1CjklW29mHuVVR+j0ITrT66DFUm32oj/63jaDIiVvxEitNBwSyi3FMUuSB5cy45gvgd0YArsPGFK5z4HDJgy8962v1tnWwsQv0SAsnGHsdP2vMV5fjuc4ESrEMAP2ZwOHWKLRJgy3x4TJLgorrFj8zS+sg0/nAom6d/u0knXs+Dn6+KDPe7Zr1edQSINyy7kniWEB+9/IVHj+h7lLljLf8bnzYpLbgxmHlzpsXw==
-        aliza.peikes@ibm.com\n"},{"creationDate":"2022-12-02T22:16:17.888Z","name":"rdr-instana-autotrace-us-east01-keypair","sshKey":"ssh-rsa
+        aliza.peikes@ibm.com\n"},{"creationDate":"2022-12-02T22:16:17.888Z","name":"rdr-instana-autotrace-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQC5M/BmAkj1IW+kX6lJmua0+wo44mVP/as8TarResht3/vKaZh0k8/8jd4eujAwT59o2Xmk5QYdeYnlgzcwojgpMWu00P7TAeNQDJwSeRmbkQMnB68gXFSXyJoziyla5l1/q7Kz55wqvCQ2JccWAuC51zl+J1f+1j46cui0QWWnewduXn5hgvqFrZ18jUyiimZSIHyvKzUkM3NxijMVlbajqgm6Z7FyzKZOKK84sw2cxM39iuZsMveJt5U3ErHTmJn/tPD90Lidv2HddbGl5nWkt7vhaynj3JTSgKJqaB+TZ/lqmiNqPjjQuLs7EFFINf5d0DgP6GCZw2U73XlxAVW+DIPAizePlHVBfiZy0HEY9ZvGZvX5/kugpCjk9/CtSpCUU6N8gCoAuSZKdakMHRqufjcHTFuAHx6meHczffRFVxO1AjJV5YDWMDyJTAK7Wp3ViB/PJGAY7VqpFzrDEAKf0FZY0S2FjfYRmnr94GylgJQiSFa7Vs1tGTR8M9HdKD8=
-        jwcarman@li-a36b264c-2e6f-11b2-a85c-fdfb37238350.ibm.com\n"},{"creationDate":"2022-12-08T08:52:54.766Z","name":"rdr-acm-niharika-412-us-east01-keypair","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABgQC98MZwFNhuf/wcCcoQTdUEE81RsFAJG8ibKVxV2nvjlSaLj+I9Gz0k9qEAbT82RcgH2jt/1DETGZRi/+HFCCyEy9NVPtaQKdzQVUaeKpbtJztI/dxvETo4HRuGBkYA2y/Ye0sPVEjyAFT9PGClMODAwhxfcXmQyA1a/uJ9PkJ9qEgS3ESyB3uiyu4LrNYnNNG0BtSDy59PWvlaPXgWSgGpnJh5WqoYqIf/p9sF3TUotN5VwUgUlb32bfsA8UDT5bc5fA9E70SI+0DVWbDaVLrD3kkS28E04ttlMtvVLhEdof2azTVfr5NmqDDQgDaXYjHqi/NmXzHoFK8uCSLHySVTlh7p6EiTg0W852dWeNz7A5s0tCcFdVlE7OPYbC4C+W5zjI/NjPD1Jfkd6WLVyv9s6KOcrhsuZl2IyWqz+nbnNuuijWaEDoWZYAbjXSm6c3Oc+rTo8N0r9+MrF5rtbW/gHeM9UwIyvqx1FvLWNNUTJqorGDtjXStaBHB2wFIlFWE=
-        root@finales1.fyre.ibm.com\n"},{"creationDate":"2022-12-08T11:16:38.380Z","name":"rdr-acm-hub-412-us-east01-keypair","sshKey":"ssh-rsa
+        jwcarman@li-a36b264c-2e6f-11b2-a85c-fdfb37238350.ibm.com\n"},{"creationDate":"2022-12-08T11:16:38.380Z","name":"rdr-acm-hub-412-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDuIWArFe6OZrUPrkqf4rBCVMdslPJJ5wF/CLFb3WsQbDHzv4d5Iv7fE/BSGqoYIrAwujZ6gBwRr/NWJlVcPJy6UrqS4joRo+P4RIfQqUeBNiAd3K9rZvYdGCfJOKVHDO+Ww1b8DfozUTHdAWAVD8FiDNCcbBG2BjyLWNGW77hEoHKlQcpwAsyQxiwlovj5OpRNJ5rXAc0QDNlSaPyb6AcSBaaTUA6rtkhtdLFE2xn9JHYM2yuhFPWZt3unVHHw8bpWHHeQNZ1X/ZSNpD6b5c0pWMtsAm0+Be3BCrSPhYu6ZvcJp+gR7eNMDKZzM683Itht3OCqobi2OX6RAfqOcPcI7iGQcn7EmkphJOTuigYFmxPbZEELsc2iqBY5LOJr/F5RmvqdgYS8cIF6ZmvUAF+MTiw2gGzWxsq7THQpXOe5rUBlBtokLJfzRI6JSyDGDKe/0ELOfbYCBqQTyuMMAu+vpeHvUZgDuIOGEzg1CLi1FGq1WNT/crone7t+L6e5wgM=
         acm@power\n"},{"creationDate":"2022-12-09T18:08:11.857Z","name":"rdr-acm-vijayv-oldMac-sshkey","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABAQDQ+kBOvZ6jCu0i/B6TwsOTTxOffnagoz5A5s1+EcU6JM2+hnJugxbuGutNkdbu0PDIJKoFIPV1sn/ZMQi46GcWhIR5R09oysMjnR/GhqgnGSXuLFUVr4SumqsoQ+XOwg/V2MbJySQnEoXnfiRl3C2aBQc3m7aISWCq+k+793m7Ec0dTV9n2HL//51xhT00o2Ntk1QErbSm5g6PVFARkinfJnKH5l8CGUZpSyGrQSuLmtKJbXI0Km71zb8ss/9TrP8OTm6bgt2WVLJ7H055I199JXK7AJp0lQqbXjOiiS7WWYd2ajcuxClpEbhx2aBG1o7h6IPfIYZs10oDXnIbANg3
-        vijayv@Vijays-MacBook-Pro.local"},{"creationDate":"2023-01-12T10:40:50.560Z","name":"rdr-acm-spoke-412-us-east01-keypair","sshKey":"ssh-rsa
+        vijayv@Vijays-MacBook-Pro.local"},{"creationDate":"2023-01-12T10:40:50.560Z","name":"rdr-acm-spoke-412-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQCojUXkPF7/iP6/U4ITQtL1DY9IlEVfkNX9PpyDthrH3BhiUPl+niTGFN2bdq+pyIBryS7FDC/97D9+mH+qnJS9knOTQchWLoJXu9H/E6dGb1yFL5h7axEqkrLtKCnF+WsrBtMoVhXUa9kg8KTAlq7beCxauq1T0Ue/+u0zRz04CJPuFEW/ZIaMcOa0syMOMPruwZBCcg1v6Q0KxEDJLnyPTXhfb+SnlN8HUBmX2f2GPRBNkcjtNfBHauzbHM8tHjsba+u7FAvB3bjIxIaMCA0uhHKTc6J6WFunHaQGX/i5+KR0km/PboB0G048RHkMe3Jgj3N7J+75vzMF+lR5E5RpEtAAPut09s7ntyXLU0FA6zHtbynIfBJr+dUzrFGQLY3fU8r6FKS7z8xLvEdnWf4+Nl2dht8M3B4BAIzeXFzcS/IaoF6yPa7SGekQD8k9CfPzwaooJYPCqNas2ZJ06ZeUk0uMIZXymv1xIT5ZDpVjFsnG3srubyN2ZpP0a/7iXYtYo+aOVKv44hSK9socmO6slX+p/ssTdFm0l1C6kUxVeJQrI4IrnLJljLfMlgFXaFRRwUaBPMTxRAFzgNcMv1trq6P3iR5AWgO3B3YVHR4qhSwuc74nOGVVyan8BTK1Jl/zFQ11h0LKPOx2Bfq8DC8hN8Qkqf+y5tZPZ9FxoNp2SQ==
         basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-13T10:30:02.732Z","name":"rdr-acm-tor01-managed-tor01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQCojUXkPF7/iP6/U4ITQtL1DY9IlEVfkNX9PpyDthrH3BhiUPl+niTGFN2bdq+pyIBryS7FDC/97D9+mH+qnJS9knOTQchWLoJXu9H/E6dGb1yFL5h7axEqkrLtKCnF+WsrBtMoVhXUa9kg8KTAlq7beCxauq1T0Ue/+u0zRz04CJPuFEW/ZIaMcOa0syMOMPruwZBCcg1v6Q0KxEDJLnyPTXhfb+SnlN8HUBmX2f2GPRBNkcjtNfBHauzbHM8tHjsba+u7FAvB3bjIxIaMCA0uhHKTc6J6WFunHaQGX/i5+KR0km/PboB0G048RHkMe3Jgj3N7J+75vzMF+lR5E5RpEtAAPut09s7ntyXLU0FA6zHtbynIfBJr+dUzrFGQLY3fU8r6FKS7z8xLvEdnWf4+Nl2dht8M3B4BAIzeXFzcS/IaoF6yPa7SGekQD8k9CfPzwaooJYPCqNas2ZJ06ZeUk0uMIZXymv1xIT5ZDpVjFsnG3srubyN2ZpP0a/7iXYtYo+aOVKv44hSK9socmO6slX+p/ssTdFm0l1C6kUxVeJQrI4IrnLJljLfMlgFXaFRRwUaBPMTxRAFzgNcMv1trq6P3iR5AWgO3B3YVHR4qhSwuc74nOGVVyan8BTK1Jl/zFQ11h0LKPOx2Bfq8DC8hN8Qkqf+y5tZPZ9FxoNp2SQ==
         basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-13T10:57:20.877Z","name":"rdr-acm-tor01-managed1-tor01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQCojUXkPF7/iP6/U4ITQtL1DY9IlEVfkNX9PpyDthrH3BhiUPl+niTGFN2bdq+pyIBryS7FDC/97D9+mH+qnJS9knOTQchWLoJXu9H/E6dGb1yFL5h7axEqkrLtKCnF+WsrBtMoVhXUa9kg8KTAlq7beCxauq1T0Ue/+u0zRz04CJPuFEW/ZIaMcOa0syMOMPruwZBCcg1v6Q0KxEDJLnyPTXhfb+SnlN8HUBmX2f2GPRBNkcjtNfBHauzbHM8tHjsba+u7FAvB3bjIxIaMCA0uhHKTc6J6WFunHaQGX/i5+KR0km/PboB0G048RHkMe3Jgj3N7J+75vzMF+lR5E5RpEtAAPut09s7ntyXLU0FA6zHtbynIfBJr+dUzrFGQLY3fU8r6FKS7z8xLvEdnWf4+Nl2dht8M3B4BAIzeXFzcS/IaoF6yPa7SGekQD8k9CfPzwaooJYPCqNas2ZJ06ZeUk0uMIZXymv1xIT5ZDpVjFsnG3srubyN2ZpP0a/7iXYtYo+aOVKv44hSK9socmO6slX+p/ssTdFm0l1C6kUxVeJQrI4IrnLJljLfMlgFXaFRRwUaBPMTxRAFzgNcMv1trq6P3iR5AWgO3B3YVHR4qhSwuc74nOGVVyan8BTK1Jl/zFQ11h0LKPOx2Bfq8DC8hN8Qkqf+y5tZPZ9FxoNp2SQ==
-        basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-23T08:05:09.058Z","name":"rdr-acm-spoke-411-us-east01-keypair","sshKey":"ssh-rsa
+        basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-23T08:05:09.058Z","name":"rdr-acm-spoke-411-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQCojUXkPF7/iP6/U4ITQtL1DY9IlEVfkNX9PpyDthrH3BhiUPl+niTGFN2bdq+pyIBryS7FDC/97D9+mH+qnJS9knOTQchWLoJXu9H/E6dGb1yFL5h7axEqkrLtKCnF+WsrBtMoVhXUa9kg8KTAlq7beCxauq1T0Ue/+u0zRz04CJPuFEW/ZIaMcOa0syMOMPruwZBCcg1v6Q0KxEDJLnyPTXhfb+SnlN8HUBmX2f2GPRBNkcjtNfBHauzbHM8tHjsba+u7FAvB3bjIxIaMCA0uhHKTc6J6WFunHaQGX/i5+KR0km/PboB0G048RHkMe3Jgj3N7J+75vzMF+lR5E5RpEtAAPut09s7ntyXLU0FA6zHtbynIfBJr+dUzrFGQLY3fU8r6FKS7z8xLvEdnWf4+Nl2dht8M3B4BAIzeXFzcS/IaoF6yPa7SGekQD8k9CfPzwaooJYPCqNas2ZJ06ZeUk0uMIZXymv1xIT5ZDpVjFsnG3srubyN2ZpP0a/7iXYtYo+aOVKv44hSK9socmO6slX+p/ssTdFm0l1C6kUxVeJQrI4IrnLJljLfMlgFXaFRRwUaBPMTxRAFzgNcMv1trq6P3iR5AWgO3B3YVHR4qhSwuc74nOGVVyan8BTK1Jl/zFQ11h0LKPOx2Bfq8DC8hN8Qkqf+y5tZPZ9FxoNp2SQ==
-        basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-25T06:52:35.620Z","name":"rdr-bkhadars-local-key","sshKey":"ssh-rsa
+        basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-28T09:15:03.143Z","name":"rdr-cc-acm-412-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQCojUXkPF7/iP6/U4ITQtL1DY9IlEVfkNX9PpyDthrH3BhiUPl+niTGFN2bdq+pyIBryS7FDC/97D9+mH+qnJS9knOTQchWLoJXu9H/E6dGb1yFL5h7axEqkrLtKCnF+WsrBtMoVhXUa9kg8KTAlq7beCxauq1T0Ue/+u0zRz04CJPuFEW/ZIaMcOa0syMOMPruwZBCcg1v6Q0KxEDJLnyPTXhfb+SnlN8HUBmX2f2GPRBNkcjtNfBHauzbHM8tHjsba+u7FAvB3bjIxIaMCA0uhHKTc6J6WFunHaQGX/i5+KR0km/PboB0G048RHkMe3Jgj3N7J+75vzMF+lR5E5RpEtAAPut09s7ntyXLU0FA6zHtbynIfBJr+dUzrFGQLY3fU8r6FKS7z8xLvEdnWf4+Nl2dht8M3B4BAIzeXFzcS/IaoF6yPa7SGekQD8k9CfPzwaooJYPCqNas2ZJ06ZeUk0uMIZXymv1xIT5ZDpVjFsnG3srubyN2ZpP0a/7iXYtYo+aOVKv44hSK9socmO6slX+p/ssTdFm0l1C6kUxVeJQrI4IrnLJljLfMlgFXaFRRwUaBPMTxRAFzgNcMv1trq6P3iR5AWgO3B3YVHR4qhSwuc74nOGVVyan8BTK1Jl/zFQ11h0LKPOx2Bfq8DC8hN8Qkqf+y5tZPZ9FxoNp2SQ==
-        basheerkhadarsabagari@Basheers-MacBook-Pro.local"},{"creationDate":"2023-01-28T06:05:10.891Z","name":"rdr-bkhadars-acm-412-us-east01-keypair","sshKey":"ssh-rsa
+        basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-29T04:37:34.796Z","name":"rdr-acm-spoke2-411-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQCojUXkPF7/iP6/U4ITQtL1DY9IlEVfkNX9PpyDthrH3BhiUPl+niTGFN2bdq+pyIBryS7FDC/97D9+mH+qnJS9knOTQchWLoJXu9H/E6dGb1yFL5h7axEqkrLtKCnF+WsrBtMoVhXUa9kg8KTAlq7beCxauq1T0Ue/+u0zRz04CJPuFEW/ZIaMcOa0syMOMPruwZBCcg1v6Q0KxEDJLnyPTXhfb+SnlN8HUBmX2f2GPRBNkcjtNfBHauzbHM8tHjsba+u7FAvB3bjIxIaMCA0uhHKTc6J6WFunHaQGX/i5+KR0km/PboB0G048RHkMe3Jgj3N7J+75vzMF+lR5E5RpEtAAPut09s7ntyXLU0FA6zHtbynIfBJr+dUzrFGQLY3fU8r6FKS7z8xLvEdnWf4+Nl2dht8M3B4BAIzeXFzcS/IaoF6yPa7SGekQD8k9CfPzwaooJYPCqNas2ZJ06ZeUk0uMIZXymv1xIT5ZDpVjFsnG3srubyN2ZpP0a/7iXYtYo+aOVKv44hSK9socmO6slX+p/ssTdFm0l1C6kUxVeJQrI4IrnLJljLfMlgFXaFRRwUaBPMTxRAFzgNcMv1trq6P3iR5AWgO3B3YVHR4qhSwuc74nOGVVyan8BTK1Jl/zFQ11h0LKPOx2Bfq8DC8hN8Qkqf+y5tZPZ9FxoNp2SQ==
-        basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-28T09:15:03.143Z","name":"rdr-cc-acm-412-us-east01-keypair","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAACAQCojUXkPF7/iP6/U4ITQtL1DY9IlEVfkNX9PpyDthrH3BhiUPl+niTGFN2bdq+pyIBryS7FDC/97D9+mH+qnJS9knOTQchWLoJXu9H/E6dGb1yFL5h7axEqkrLtKCnF+WsrBtMoVhXUa9kg8KTAlq7beCxauq1T0Ue/+u0zRz04CJPuFEW/ZIaMcOa0syMOMPruwZBCcg1v6Q0KxEDJLnyPTXhfb+SnlN8HUBmX2f2GPRBNkcjtNfBHauzbHM8tHjsba+u7FAvB3bjIxIaMCA0uhHKTc6J6WFunHaQGX/i5+KR0km/PboB0G048RHkMe3Jgj3N7J+75vzMF+lR5E5RpEtAAPut09s7ntyXLU0FA6zHtbynIfBJr+dUzrFGQLY3fU8r6FKS7z8xLvEdnWf4+Nl2dht8M3B4BAIzeXFzcS/IaoF6yPa7SGekQD8k9CfPzwaooJYPCqNas2ZJ06ZeUk0uMIZXymv1xIT5ZDpVjFsnG3srubyN2ZpP0a/7iXYtYo+aOVKv44hSK9socmO6slX+p/ssTdFm0l1C6kUxVeJQrI4IrnLJljLfMlgFXaFRRwUaBPMTxRAFzgNcMv1trq6P3iR5AWgO3B3YVHR4qhSwuc74nOGVVyan8BTK1Jl/zFQ11h0LKPOx2Bfq8DC8hN8Qkqf+y5tZPZ9FxoNp2SQ==
-        basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-28T19:11:16.713Z","name":"rdr-bkhadars-spoke2-411-us-east01-keypair","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAACAQCojUXkPF7/iP6/U4ITQtL1DY9IlEVfkNX9PpyDthrH3BhiUPl+niTGFN2bdq+pyIBryS7FDC/97D9+mH+qnJS9knOTQchWLoJXu9H/E6dGb1yFL5h7axEqkrLtKCnF+WsrBtMoVhXUa9kg8KTAlq7beCxauq1T0Ue/+u0zRz04CJPuFEW/ZIaMcOa0syMOMPruwZBCcg1v6Q0KxEDJLnyPTXhfb+SnlN8HUBmX2f2GPRBNkcjtNfBHauzbHM8tHjsba+u7FAvB3bjIxIaMCA0uhHKTc6J6WFunHaQGX/i5+KR0km/PboB0G048RHkMe3Jgj3N7J+75vzMF+lR5E5RpEtAAPut09s7ntyXLU0FA6zHtbynIfBJr+dUzrFGQLY3fU8r6FKS7z8xLvEdnWf4+Nl2dht8M3B4BAIzeXFzcS/IaoF6yPa7SGekQD8k9CfPzwaooJYPCqNas2ZJ06ZeUk0uMIZXymv1xIT5ZDpVjFsnG3srubyN2ZpP0a/7iXYtYo+aOVKv44hSK9socmO6slX+p/ssTdFm0l1C6kUxVeJQrI4IrnLJljLfMlgFXaFRRwUaBPMTxRAFzgNcMv1trq6P3iR5AWgO3B3YVHR4qhSwuc74nOGVVyan8BTK1Jl/zFQ11h0LKPOx2Bfq8DC8hN8Qkqf+y5tZPZ9FxoNp2SQ==
-        basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-29T04:37:34.796Z","name":"rdr-acm-spoke2-411-us-east01-keypair","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAACAQCojUXkPF7/iP6/U4ITQtL1DY9IlEVfkNX9PpyDthrH3BhiUPl+niTGFN2bdq+pyIBryS7FDC/97D9+mH+qnJS9knOTQchWLoJXu9H/E6dGb1yFL5h7axEqkrLtKCnF+WsrBtMoVhXUa9kg8KTAlq7beCxauq1T0Ue/+u0zRz04CJPuFEW/ZIaMcOa0syMOMPruwZBCcg1v6Q0KxEDJLnyPTXhfb+SnlN8HUBmX2f2GPRBNkcjtNfBHauzbHM8tHjsba+u7FAvB3bjIxIaMCA0uhHKTc6J6WFunHaQGX/i5+KR0km/PboB0G048RHkMe3Jgj3N7J+75vzMF+lR5E5RpEtAAPut09s7ntyXLU0FA6zHtbynIfBJr+dUzrFGQLY3fU8r6FKS7z8xLvEdnWf4+Nl2dht8M3B4BAIzeXFzcS/IaoF6yPa7SGekQD8k9CfPzwaooJYPCqNas2ZJ06ZeUk0uMIZXymv1xIT5ZDpVjFsnG3srubyN2ZpP0a/7iXYtYo+aOVKv44hSK9socmO6slX+p/ssTdFm0l1C6kUxVeJQrI4IrnLJljLfMlgFXaFRRwUaBPMTxRAFzgNcMv1trq6P3iR5AWgO3B3YVHR4qhSwuc74nOGVVyan8BTK1Jl/zFQ11h0LKPOx2Bfq8DC8hN8Qkqf+y5tZPZ9FxoNp2SQ==
-        basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-29T21:06:06.337Z","name":"rdr-cc-bashr-acm-412-us-east01-keypair","sshKey":"ssh-rsa
+        basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-01-29T21:06:06.337Z","name":"rdr-cc-bashr-acm-412-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQDtKd5svnJLGfe7QB8ZkX/jtL9bNwtarIQ7NDThCBQuN5hZpKYJtaWjawjA6FtxklV+iVuDXQleFMVLp/NkNPP+DDv7LtLb9TaxR8pWenZBxzUfKA2iIGHoQdlA+Sobv0pzz2zDy7hcLmEc3ehB2QSuiNB/iGO8PaUpCcY2Vj6FaG8yD5zvfnffvDO6tEWaabDakOzlA3GMxtGJKaOgfhCgC2xAfJCXun1ssyGgao3dZWUUU2p1zq3Qeg69IQOUWOXshGHwsEHOR10E3HAgmqfL+tEdvoXo88OymtCqGnEZmbt9S2Oy/KRf+szNPeRHaRS8k2zwuDm3ojlQ13CtO+mj/MqdSntKfAEHZca1s11kSY/sxgn4n3wOnlVyjNMzbYt6Zs3SGe2LC9QWVvmOC03cABmLqBNg0HQr2ESaBtSuoSSG1aKFxgnEK0QWMqDBkJeOgMqc9jGmMLWVlyt0UKT2ZYMjtoKbNHO19XlNZbf8TH9JMEFJEY3dmyYrShYdNP4+kz1Lxs5PXuqh2PY/hVVh3GD4cdA9hH4WGYDsFPmQDAK7OvRicDzEjM+OxJoW//1+iHHepZkNB3PqeYt54myISRI8aMMufmFBEUrscApg5WPN7o+4SIlydj1WtTEyunwS5SZj1DYQ6D8EbCV38Vn2fpMX+yUjSHDStfeWQd8YkQ==
-        Niharika.Gurram1@ibm.com\n"},{"creationDate":"2023-01-30T17:46:31.011Z","name":"test-ssh-key-no-comment","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABgQCooZYGrwhEl5kCa0Pcdh2x0Xz/rOdru94tC8QI24bRFHPUAT88TKz48UciQE6/VaMdxxb9zrvA2eIU0/Td9lQU44B1LyEDLfILdxH1mHd2wehDM78V7804jvsxTMYXgNU8NEAJM+gyJ/K0rwvCReofL4jq/y4bbSEvVE+DxTnqzry2+SRCy0tEIfrHkJv2DMiB0oY680qEkZsAMZjE2JFrK8bN88kPhDb52x12llPMvUpppT4RBU3dDnweA50sxabV4SX0XVVJncw9nKh1EsUWrI4O7N3h8i8bLoiJvmGjIEpAQxE80ftvcbpJf0hPGsIr0BR+Qc+S6nBMdgpXj5RWlYS/ekxAVPe4xQsM01gMziwiX1RrcektajR8x/D3z28u7Nv1530b3rSqTMiydyXqcKMlTItqArpZVamo3UZ2CfuYRUdcpM+fbPCRsj0GH7pRxLqYag2klUIc9hZSgxQ85Yo5da+E7QjEvwxN5zxSyMy/ekRwsgWg6nDar9BFBV0="},{"creationDate":"2023-01-30T17:46:31.322Z","name":"test-ssh-key-with-comment","sshKey":"ssh-rsa
+        Niharika.Gurram1@ibm.com\n"},{"creationDate":"2023-02-02T07:17:18.682Z","name":"rdr-cc-hub-acm-412-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCojUXkPF7/iP6/U4ITQtL1DY9IlEVfkNX9PpyDthrH3BhiUPl+niTGFN2bdq+pyIBryS7FDC/97D9+mH+qnJS9knOTQchWLoJXu9H/E6dGb1yFL5h7axEqkrLtKCnF+WsrBtMoVhXUa9kg8KTAlq7beCxauq1T0Ue/+u0zRz04CJPuFEW/ZIaMcOa0syMOMPruwZBCcg1v6Q0KxEDJLnyPTXhfb+SnlN8HUBmX2f2GPRBNkcjtNfBHauzbHM8tHjsba+u7FAvB3bjIxIaMCA0uhHKTc6J6WFunHaQGX/i5+KR0km/PboB0G048RHkMe3Jgj3N7J+75vzMF+lR5E5RpEtAAPut09s7ntyXLU0FA6zHtbynIfBJr+dUzrFGQLY3fU8r6FKS7z8xLvEdnWf4+Nl2dht8M3B4BAIzeXFzcS/IaoF6yPa7SGekQD8k9CfPzwaooJYPCqNas2ZJ06ZeUk0uMIZXymv1xIT5ZDpVjFsnG3srubyN2ZpP0a/7iXYtYo+aOVKv44hSK9socmO6slX+p/ssTdFm0l1C6kUxVeJQrI4IrnLJljLfMlgFXaFRRwUaBPMTxRAFzgNcMv1trq6P3iR5AWgO3B3YVHR4qhSwuc74nOGVVyan8BTK1Jl/zFQ11h0LKPOx2Bfq8DC8hN8Qkqf+y5tZPZ9FxoNp2SQ==
+        basheerkhadarsabagari@Basheers-MacBook-Pro.local\n"},{"creationDate":"2023-02-14T08:39:50.543Z","name":"rdr-bkhadars-local-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com"},{"creationDate":"2023-03-07T09:56:18.185Z","name":"rdr-acm1-hub2-412-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-03-15T09:21:42.006Z","name":"rdr-acm-tor-hub1-412-tor01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-04-27T21:30:14.253Z","name":"ansible-demo-power-vm-ssh-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABAQC0eZ4uNSH6rtxNM7MagrBtxwlASw0iKcxDdXq9eNu93xDpsvxdn6xE/JESlIHhf9/45oLw9AKpu/MZYwqQ0O+uedwgtLvorv++fyXI36cls4xmUCuNnEhoK1aXh26N+V+lxejqF3DJhMKHYprQCnyl/8RWkWIFc2Jo60ACZ98MY4rRHgBP/0t1tqmb0I4IdBaYLctVIdv16gYJ5zqGYKeJBMG7XtgkrtOeacVoArrmjHY6n2cNgE5jLt9n9MyyGLjzq1agIpwwsWJGfhzqo2I98UhGWtUlD2UeNHbuJZmbXeyibuoV7RhDZg9LafkOXOTojjZc9rUrd8BChoHhbW3X
+        anil@Anils-MacBook-Pro.local"},{"creationDate":"2023-05-05T07:16:20.424Z","name":"rdr-acm-man103-413-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-05-23T10:02:23.644Z","name":"rdr-acm-hub303-413-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-05-23T11:17:40.718Z","name":"rdr-acm-vinay-local-tp","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABAQC/brP5+Q2RPvb5Clkg19YSHlGibJ8v7p1307G1cHabzaVhN8F6H20dgCCaYMbYJ1KXZ1QS8RW/orHTRmeTedupdrPqEeEwPizf8oVjkJokSoF5P1+0akYBhxOjPYZ2a2HsQ/ovHOUy5rN6zc+XCfi8QhAQUjlW4DDkk5JYjiVapjAHzBh22DQoZ3HDQq2hLuf4nQWymgcACGo8e+J6SnxQOD1Tgcc1mhdG+/TISaRCB1XPJ51P/vQjqLp7Db0L7qSk0U4Oz6rXeC7cKBym3zWH9vVwOFkB7v0F5XyKAqlYQNYio/l6nTNmY7gqEWs/dQExP61p6Xaq3DGh3TuvipHB
+        rsa-key-20230523"},{"creationDate":"2023-05-25T06:40:38.611Z","name":"rdr-acm-hub603-413-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-05-25T07:52:18.790Z","name":"rdr-acm-hub103-413-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-05-30T19:51:53.706Z","name":"rdr-acm-vinay-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDANMJGx87Mjf1+D6xMbUs9bSLceOdDgWnzJM4x8PMPOSn3iYx1hEsH2eyzPBIQPIBllFr/gti0Hyu52KENk8SvkkCczmNNjipEMlk2oY11EvJhzRDD1iPjBiu9rMa3bS4gSwNjwdpZWKwcqJwGQUCmA76aeeJUtqUMQejf9sBsr6Oc1Ota6a+FZC+7pZ2GXaImcbeS5adQz9eyQ3dNIIyryfEunZfrMYkWer4Hlx3iIxkmCxnjKGkvekbITQtfqwefVXEjHI/lu5oovVWCPhwVkOHPvmMZQghggXKoMWh/tO4Xv4bJ+tlvcfiOF/7i/+5cBBADqfGMwi9eYomwCWexJeLYfnvuClWMai9LhHr6gPGHgQw7e/pwSk3B2vhf+whDOQLKFFV2A87y8EUCyPusSy4NedmKa8LiCyPJtrcNFrtHQnH7BOWgEwdY1d4RHRPvT1Nkqt3aUVVlDojLYgsFkp8L/jtvqx8A46k9BiU2Jx5hKD18tGWXqthHBBm0x/8=
+        gmx\\a00020744@IBM-PF3XEKD9"},{"creationDate":"2023-06-07T07:01:03.074Z","name":"rdr-acm-hub404-413-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-06-07T09:03:59.083Z","name":"rdr-acm-hub504-413-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-06-07T09:14:47.218Z","name":"rdr-acm-hub604-413-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-06-07T10:17:05.318Z","name":"rdr-acm-ng-hub6-413-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQDtKd5svnJLGfe7QB8ZkX/jtL9bNwtarIQ7NDThCBQuN5hZpKYJtaWjawjA6FtxklV+iVuDXQleFMVLp/NkNPP+DDv7LtLb9TaxR8pWenZBxzUfKA2iIGHoQdlA+Sobv0pzz2zDy7hcLmEc3ehB2QSuiNB/iGO8PaUpCcY2Vj6FaG8yD5zvfnffvDO6tEWaabDakOzlA3GMxtGJKaOgfhCgC2xAfJCXun1ssyGgao3dZWUUU2p1zq3Qeg69IQOUWOXshGHwsEHOR10E3HAgmqfL+tEdvoXo88OymtCqGnEZmbt9S2Oy/KRf+szNPeRHaRS8k2zwuDm3ojlQ13CtO+mj/MqdSntKfAEHZca1s11kSY/sxgn4n3wOnlVyjNMzbYt6Zs3SGe2LC9QWVvmOC03cABmLqBNg0HQr2ESaBtSuoSSG1aKFxgnEK0QWMqDBkJeOgMqc9jGmMLWVlyt0UKT2ZYMjtoKbNHO19XlNZbf8TH9JMEFJEY3dmyYrShYdNP4+kz1Lxs5PXuqh2PY/hVVh3GD4cdA9hH4WGYDsFPmQDAK7OvRicDzEjM+OxJoW//1+iHHepZkNB3PqeYt54myISRI8aMMufmFBEUrscApg5WPN7o+4SIlydj1WtTEyunwS5SZj1DYQ6D8EbCV38Vn2fpMX+yUjSHDStfeWQd8YkQ==
+        Niharika.Gurram1@ibm.com\n"},{"creationDate":"2023-06-12T06:15:19.853Z","name":"rdr-acm28-hub404-413-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-06-12T09:03:41.175Z","name":"rdr-acm28-hub504-413-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-06-12T09:44:01.734Z","name":"rdr-acm28-hub104-413-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-06-23T05:05:50.426Z","name":"test-ocp-95a5-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDANMJGx87Mjf1+D6xMbUs9bSLceOdDgWnzJM4x8PMPOSn3iYx1hEsH2eyzPBIQPIBllFr/gti0Hyu52KENk8SvkkCczmNNjipEMlk2oY11EvJhzRDD1iPjBiu9rMa3bS4gSwNjwdpZWKwcqJwGQUCmA76aeeJUtqUMQejf9sBsr6Oc1Ota6a+FZC+7pZ2GXaImcbeS5adQz9eyQ3dNIIyryfEunZfrMYkWer4Hlx3iIxkmCxnjKGkvekbITQtfqwefVXEjHI/lu5oovVWCPhwVkOHPvmMZQghggXKoMWh/tO4Xv4bJ+tlvcfiOF/7i/+5cBBADqfGMwi9eYomwCWexJeLYfnvuClWMai9LhHr6gPGHgQw7e/pwSk3B2vhf+whDOQLKFFV2A87y8EUCyPusSy4NedmKa8LiCyPJtrcNFrtHQnH7BOWgEwdY1d4RHRPvT1Nkqt3aUVVlDojLYgsFkp8L/jtvqx8A46k9BiU2Jx5hKD18tGWXqthHBBm0x/8=
+        gmx\\a00020744@IBM-PF3XEKD9\r\n"},{"creationDate":"2023-06-26T08:47:06.502Z","name":"rdr-power-demo-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDANMJGx87Mjf1+D6xMbUs9bSLceOdDgWnzJM4x8PMPOSn3iYx1hEsH2eyzPBIQPIBllFr/gti0Hyu52KENk8SvkkCczmNNjipEMlk2oY11EvJhzRDD1iPjBiu9rMa3bS4gSwNjwdpZWKwcqJwGQUCmA76aeeJUtqUMQejf9sBsr6Oc1Ota6a+FZC+7pZ2GXaImcbeS5adQz9eyQ3dNIIyryfEunZfrMYkWer4Hlx3iIxkmCxnjKGkvekbITQtfqwefVXEjHI/lu5oovVWCPhwVkOHPvmMZQghggXKoMWh/tO4Xv4bJ+tlvcfiOF/7i/+5cBBADqfGMwi9eYomwCWexJeLYfnvuClWMai9LhHr6gPGHgQw7e/pwSk3B2vhf+whDOQLKFFV2A87y8EUCyPusSy4NedmKa8LiCyPJtrcNFrtHQnH7BOWgEwdY1d4RHRPvT1Nkqt3aUVVlDojLYgsFkp8L/jtvqx8A46k9BiU2Jx5hKD18tGWXqthHBBm0x/8=
+        gmx\\a00020744@IBM-PF3XEKD9\r\n"},{"creationDate":"2023-06-26T08:59:41.892Z","name":"rdr-power-5fed-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDANMJGx87Mjf1+D6xMbUs9bSLceOdDgWnzJM4x8PMPOSn3iYx1hEsH2eyzPBIQPIBllFr/gti0Hyu52KENk8SvkkCczmNNjipEMlk2oY11EvJhzRDD1iPjBiu9rMa3bS4gSwNjwdpZWKwcqJwGQUCmA76aeeJUtqUMQejf9sBsr6Oc1Ota6a+FZC+7pZ2GXaImcbeS5adQz9eyQ3dNIIyryfEunZfrMYkWer4Hlx3iIxkmCxnjKGkvekbITQtfqwefVXEjHI/lu5oovVWCPhwVkOHPvmMZQghggXKoMWh/tO4Xv4bJ+tlvcfiOF/7i/+5cBBADqfGMwi9eYomwCWexJeLYfnvuClWMai9LhHr6gPGHgQw7e/pwSk3B2vhf+whDOQLKFFV2A87y8EUCyPusSy4NedmKa8LiCyPJtrcNFrtHQnH7BOWgEwdY1d4RHRPvT1Nkqt3aUVVlDojLYgsFkp8L/jtvqx8A46k9BiU2Jx5hKD18tGWXqthHBBm0x/8=
+        gmx\\a00020744@IBM-PF3XEKD9\r\n"},{"creationDate":"2023-07-18T06:26:39.693Z","name":"rdr-power-vinay-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDkSoLJhlBQ/bTTRaBy6IK4zhLaOcl/KRojsg3ajHZULoJ4TvbIkuebUyFB+S9I1UHdTLHvxXKLOdMVbYoBKkxsKS1AFiCR4sptItcwfcx2E0+COvRWzS3ytF7Y7PqTCJPFWnak63GmWcmzu6W/J+Z9SVUBHh5z9uWqXsWlg33AvLF2tS1ILYSliOkjhg5qzitrPDieKZW1ftECOoK/pn/D0V+QC8uf9Nfp/0d+IXelaRAomLX+8yXk3QJu8waEvkEhXKh1BCkjJ/Axoj5TTtB6pifcmFsLu5Xtu/b8wfW+0OmIbifbKmXIwaWRzenxiZurzLNe4DtOB1zLDhBuk4NxpBaUCRXfRYbYemRjSrAQANhyzPFlQ9p4m2hQaQZ14BIwRyHGzPAsIYsn92GuP1CRaz0fPoO8oCAwEuMZPNohJDwL3ctuWYqleWfX2IdPanKcU0bcKMNqxsU8g8WRQWOh3EN+lHD0EU9FXNwH1Gk6n7fk557XN6OPzYaYgRIfTmU=
+        gmx\\004ncn744@IBM-PF3XEKD9\n"},{"creationDate":"2023-07-19T09:41:19.028Z","name":"rdr-acm-c46b-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDkSoLJhlBQ/bTTRaBy6IK4zhLaOcl/KRojsg3ajHZULoJ4TvbIkuebUyFB+S9I1UHdTLHvxXKLOdMVbYoBKkxsKS1AFiCR4sptItcwfcx2E0+COvRWzS3ytF7Y7PqTCJPFWnak63GmWcmzu6W/J+Z9SVUBHh5z9uWqXsWlg33AvLF2tS1ILYSliOkjhg5qzitrPDieKZW1ftECOoK/pn/D0V+QC8uf9Nfp/0d+IXelaRAomLX+8yXk3QJu8waEvkEhXKh1BCkjJ/Axoj5TTtB6pifcmFsLu5Xtu/b8wfW+0OmIbifbKmXIwaWRzenxiZurzLNe4DtOB1zLDhBuk4NxpBaUCRXfRYbYemRjSrAQANhyzPFlQ9p4m2hQaQZ14BIwRyHGzPAsIYsn92GuP1CRaz0fPoO8oCAwEuMZPNohJDwL3ctuWYqleWfX2IdPanKcU0bcKMNqxsU8g8WRQWOh3EN+lHD0EU9FXNwH1Gk6n7fk557XN6OPzYaYgRIfTmU=
+        gmx\\004ncn744@IBM-PF3XEKD9\r\n"},{"creationDate":"2023-07-24T09:55:24.569Z","name":"rdr-power-learning4-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDkSoLJhlBQ/bTTRaBy6IK4zhLaOcl/KRojsg3ajHZULoJ4TvbIkuebUyFB+S9I1UHdTLHvxXKLOdMVbYoBKkxsKS1AFiCR4sptItcwfcx2E0+COvRWzS3ytF7Y7PqTCJPFWnak63GmWcmzu6W/J+Z9SVUBHh5z9uWqXsWlg33AvLF2tS1ILYSliOkjhg5qzitrPDieKZW1ftECOoK/pn/D0V+QC8uf9Nfp/0d+IXelaRAomLX+8yXk3QJu8waEvkEhXKh1BCkjJ/Axoj5TTtB6pifcmFsLu5Xtu/b8wfW+0OmIbifbKmXIwaWRzenxiZurzLNe4DtOB1zLDhBuk4NxpBaUCRXfRYbYemRjSrAQANhyzPFlQ9p4m2hQaQZ14BIwRyHGzPAsIYsn92GuP1CRaz0fPoO8oCAwEuMZPNohJDwL3ctuWYqleWfX2IdPanKcU0bcKMNqxsU8g8WRQWOh3EN+lHD0EU9FXNwH1Gk6n7fk557XN6OPzYaYgRIfTmU=
+        gmx\\004ncn744@IBM-PF3XEKD9\n"},{"creationDate":"2023-08-27T19:06:00.705Z","name":"rdr-acm29-man-4-14-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2023-09-12T22:27:42.087Z","name":"carl-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABAQDMwBlhrcmoY2uzvsaMOejZCwaDILnrqHNFxuX8Dd56DawlwZYYBi3Zr8ri1ER5KeASpYLZfkwe9LvexGPBO+0x3fRQWsOxUBsYxbWgC3i2LPdwwq0BnYwt58lw2B62joYhWiOMFlBfVIbjbxR6wn6Tx99SlCiVqXxLjxSshKOb7ic7v3kTUySxyPP1Pqvac/ULzuHdqFQ86bccXI3pVjoZ2ugbzxoenapvZ1cn6Hlb2hRlYZ4AdenpWt+PJtwa/aXJ+d3+rg4d40f00aj77JxvXeo4ppSoizKx4RIpLW4XVcADOjz5SmvvN9BUKZmjiHNxmEaFO7u3dRqjoinpRgJH
+        cburnett.wk"},{"creationDate":"2023-10-05T06:36:38.255Z","name":"rdr-acm-29-train07-mon01-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDkSoLJhlBQ/bTTRaBy6IK4zhLaOcl/KRojsg3ajHZULoJ4TvbIkuebUyFB+S9I1UHdTLHvxXKLOdMVbYoBKkxsKS1AFiCR4sptItcwfcx2E0+COvRWzS3ytF7Y7PqTCJPFWnak63GmWcmzu6W/J+Z9SVUBHh5z9uWqXsWlg33AvLF2tS1ILYSliOkjhg5qzitrPDieKZW1ftECOoK/pn/D0V+QC8uf9Nfp/0d+IXelaRAomLX+8yXk3QJu8waEvkEhXKh1BCkjJ/Axoj5TTtB6pifcmFsLu5Xtu/b8wfW+0OmIbifbKmXIwaWRzenxiZurzLNe4DtOB1zLDhBuk4NxpBaUCRXfRYbYemRjSrAQANhyzPFlQ9p4m2hQaQZ14BIwRyHGzPAsIYsn92GuP1CRaz0fPoO8oCAwEuMZPNohJDwL3ctuWYqleWfX2IdPanKcU0bcKMNqxsU8g8WRQWOh3EN+lHD0EU9FXNwH1Gk6n7fk557XN6OPzYaYgRIfTmU=
+        gmx\\004ncn744@IBM-PF3XEKD9\n"},{"creationDate":"2023-11-10T02:01:19.952Z","name":"mac-6345-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQC9ZDmRlBpkjQvT1Ctp2mVuwYgjcZsuzmDvcJHIe3fGLqwnh30SxHDOFZwzg2pwQbk7SVwLK1Cb/+ZGfU8oMyHXYtbKBC7UuEbZ1wIXDinmzB+ATPMEIxbItIoDcCC4Bwv50RhZi/uxaDpZcBmg67LdroN7WdBXoJdHykmPRhdWUR4oPd/Ebsm7KFnhTTRO7f4kk1xE/KQR9nn/O7x7rddAKa550+mGbOdrafD7RsmW8gB0q1aQllbhgFH0XnAWUhkwLIN+3QWL5cuZdaS7p+j6YMsZly2D324xIQRhhcrlvRNaaZwDrZ+meO+OHQzMBBuJ+jzL/HG7gpGLJvN2xmfXltW6KsZF4giXXi5sjaiHHhu91gea4iRl0gqRNknoOcLghWu6+L3w42TCiVVj5hrmXzEA0RBY494onk3IemONobDjaM9yeZRDhABIbIPDshHRUZViUX8PfDspWhBg/16s4H47DczhBg4fAOHQRzwVErySdg+d5+XONR+E9L5884qOIP0eqcjzart1zHMshZWARDX/s9cq3VoZTuP5fGzObStctwcwzKWLfyrKMxw4kg7q1nHkRj5kRSK+k1rCLBInk9s+7Pep/gFZO7LOIhAqGCdQJ5qDJYHt36ltDmtrIc18V9N3WiPOQFekJImhsuo/u7dzUOkLeMV3xp5FHr7LeQ==
+        paulbastide@pauls-mbp-2.lan\n"},{"creationDate":"2023-11-10T11:27:22.180Z","name":"mac-573b-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQC9ZDmRlBpkjQvT1Ctp2mVuwYgjcZsuzmDvcJHIe3fGLqwnh30SxHDOFZwzg2pwQbk7SVwLK1Cb/+ZGfU8oMyHXYtbKBC7UuEbZ1wIXDinmzB+ATPMEIxbItIoDcCC4Bwv50RhZi/uxaDpZcBmg67LdroN7WdBXoJdHykmPRhdWUR4oPd/Ebsm7KFnhTTRO7f4kk1xE/KQR9nn/O7x7rddAKa550+mGbOdrafD7RsmW8gB0q1aQllbhgFH0XnAWUhkwLIN+3QWL5cuZdaS7p+j6YMsZly2D324xIQRhhcrlvRNaaZwDrZ+meO+OHQzMBBuJ+jzL/HG7gpGLJvN2xmfXltW6KsZF4giXXi5sjaiHHhu91gea4iRl0gqRNknoOcLghWu6+L3w42TCiVVj5hrmXzEA0RBY494onk3IemONobDjaM9yeZRDhABIbIPDshHRUZViUX8PfDspWhBg/16s4H47DczhBg4fAOHQRzwVErySdg+d5+XONR+E9L5884qOIP0eqcjzart1zHMshZWARDX/s9cq3VoZTuP5fGzObStctwcwzKWLfyrKMxw4kg7q1nHkRj5kRSK+k1rCLBInk9s+7Pep/gFZO7LOIhAqGCdQJ5qDJYHt36ltDmtrIc18V9N3WiPOQFekJImhsuo/u7dzUOkLeMV3xp5FHr7LeQ==
+        paulbastide@pauls-mbp-2.lan\n"},{"creationDate":"2023-11-11T00:33:02.031Z","name":"mac-f582-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQC9ZDmRlBpkjQvT1Ctp2mVuwYgjcZsuzmDvcJHIe3fGLqwnh30SxHDOFZwzg2pwQbk7SVwLK1Cb/+ZGfU8oMyHXYtbKBC7UuEbZ1wIXDinmzB+ATPMEIxbItIoDcCC4Bwv50RhZi/uxaDpZcBmg67LdroN7WdBXoJdHykmPRhdWUR4oPd/Ebsm7KFnhTTRO7f4kk1xE/KQR9nn/O7x7rddAKa550+mGbOdrafD7RsmW8gB0q1aQllbhgFH0XnAWUhkwLIN+3QWL5cuZdaS7p+j6YMsZly2D324xIQRhhcrlvRNaaZwDrZ+meO+OHQzMBBuJ+jzL/HG7gpGLJvN2xmfXltW6KsZF4giXXi5sjaiHHhu91gea4iRl0gqRNknoOcLghWu6+L3w42TCiVVj5hrmXzEA0RBY494onk3IemONobDjaM9yeZRDhABIbIPDshHRUZViUX8PfDspWhBg/16s4H47DczhBg4fAOHQRzwVErySdg+d5+XONR+E9L5884qOIP0eqcjzart1zHMshZWARDX/s9cq3VoZTuP5fGzObStctwcwzKWLfyrKMxw4kg7q1nHkRj5kRSK+k1rCLBInk9s+7Pep/gFZO7LOIhAqGCdQJ5qDJYHt36ltDmtrIc18V9N3WiPOQFekJImhsuo/u7dzUOkLeMV3xp5FHr7LeQ==
+        paulbastide@pauls-mbp-2.lan\n"},{"creationDate":"2023-11-11T03:03:01.386Z","name":"mac-10ab-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQC9ZDmRlBpkjQvT1Ctp2mVuwYgjcZsuzmDvcJHIe3fGLqwnh30SxHDOFZwzg2pwQbk7SVwLK1Cb/+ZGfU8oMyHXYtbKBC7UuEbZ1wIXDinmzB+ATPMEIxbItIoDcCC4Bwv50RhZi/uxaDpZcBmg67LdroN7WdBXoJdHykmPRhdWUR4oPd/Ebsm7KFnhTTRO7f4kk1xE/KQR9nn/O7x7rddAKa550+mGbOdrafD7RsmW8gB0q1aQllbhgFH0XnAWUhkwLIN+3QWL5cuZdaS7p+j6YMsZly2D324xIQRhhcrlvRNaaZwDrZ+meO+OHQzMBBuJ+jzL/HG7gpGLJvN2xmfXltW6KsZF4giXXi5sjaiHHhu91gea4iRl0gqRNknoOcLghWu6+L3w42TCiVVj5hrmXzEA0RBY494onk3IemONobDjaM9yeZRDhABIbIPDshHRUZViUX8PfDspWhBg/16s4H47DczhBg4fAOHQRzwVErySdg+d5+XONR+E9L5884qOIP0eqcjzart1zHMshZWARDX/s9cq3VoZTuP5fGzObStctwcwzKWLfyrKMxw4kg7q1nHkRj5kRSK+k1rCLBInk9s+7Pep/gFZO7LOIhAqGCdQJ5qDJYHt36ltDmtrIc18V9N3WiPOQFekJImhsuo/u7dzUOkLeMV3xp5FHr7LeQ==
+        paulbastide@pauls-mbp-2.lan\n"},{"creationDate":"2023-11-11T11:00:52.798Z","name":"mac-d947-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQC9ZDmRlBpkjQvT1Ctp2mVuwYgjcZsuzmDvcJHIe3fGLqwnh30SxHDOFZwzg2pwQbk7SVwLK1Cb/+ZGfU8oMyHXYtbKBC7UuEbZ1wIXDinmzB+ATPMEIxbItIoDcCC4Bwv50RhZi/uxaDpZcBmg67LdroN7WdBXoJdHykmPRhdWUR4oPd/Ebsm7KFnhTTRO7f4kk1xE/KQR9nn/O7x7rddAKa550+mGbOdrafD7RsmW8gB0q1aQllbhgFH0XnAWUhkwLIN+3QWL5cuZdaS7p+j6YMsZly2D324xIQRhhcrlvRNaaZwDrZ+meO+OHQzMBBuJ+jzL/HG7gpGLJvN2xmfXltW6KsZF4giXXi5sjaiHHhu91gea4iRl0gqRNknoOcLghWu6+L3w42TCiVVj5hrmXzEA0RBY494onk3IemONobDjaM9yeZRDhABIbIPDshHRUZViUX8PfDspWhBg/16s4H47DczhBg4fAOHQRzwVErySdg+d5+XONR+E9L5884qOIP0eqcjzart1zHMshZWARDX/s9cq3VoZTuP5fGzObStctwcwzKWLfyrKMxw4kg7q1nHkRj5kRSK+k1rCLBInk9s+7Pep/gFZO7LOIhAqGCdQJ5qDJYHt36ltDmtrIc18V9N3WiPOQFekJImhsuo/u7dzUOkLeMV3xp5FHr7LeQ==
+        paulbastide@pauls-mbp-2.lan\n"},{"creationDate":"2023-11-12T20:14:01.657Z","name":"mac-980b-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQC9ZDmRlBpkjQvT1Ctp2mVuwYgjcZsuzmDvcJHIe3fGLqwnh30SxHDOFZwzg2pwQbk7SVwLK1Cb/+ZGfU8oMyHXYtbKBC7UuEbZ1wIXDinmzB+ATPMEIxbItIoDcCC4Bwv50RhZi/uxaDpZcBmg67LdroN7WdBXoJdHykmPRhdWUR4oPd/Ebsm7KFnhTTRO7f4kk1xE/KQR9nn/O7x7rddAKa550+mGbOdrafD7RsmW8gB0q1aQllbhgFH0XnAWUhkwLIN+3QWL5cuZdaS7p+j6YMsZly2D324xIQRhhcrlvRNaaZwDrZ+meO+OHQzMBBuJ+jzL/HG7gpGLJvN2xmfXltW6KsZF4giXXi5sjaiHHhu91gea4iRl0gqRNknoOcLghWu6+L3w42TCiVVj5hrmXzEA0RBY494onk3IemONobDjaM9yeZRDhABIbIPDshHRUZViUX8PfDspWhBg/16s4H47DczhBg4fAOHQRzwVErySdg+d5+XONR+E9L5884qOIP0eqcjzart1zHMshZWARDX/s9cq3VoZTuP5fGzObStctwcwzKWLfyrKMxw4kg7q1nHkRj5kRSK+k1rCLBInk9s+7Pep/gFZO7LOIhAqGCdQJ5qDJYHt36ltDmtrIc18V9N3WiPOQFekJImhsuo/u7dzUOkLeMV3xp5FHr7LeQ==
+        paulbastide@pauls-mbp-2.lan\n"},{"creationDate":"2023-12-18T08:40:36.356Z","name":"rdr-acm-210-test-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDkSoLJhlBQ/bTTRaBy6IK4zhLaOcl/KRojsg3ajHZULoJ4TvbIkuebUyFB+S9I1UHdTLHvxXKLOdMVbYoBKkxsKS1AFiCR4sptItcwfcx2E0+COvRWzS3ytF7Y7PqTCJPFWnak63GmWcmzu6W/J+Z9SVUBHh5z9uWqXsWlg33AvLF2tS1ILYSliOkjhg5qzitrPDieKZW1ftECOoK/pn/D0V+QC8uf9Nfp/0d+IXelaRAomLX+8yXk3QJu8waEvkEhXKh1BCkjJ/Axoj5TTtB6pifcmFsLu5Xtu/b8wfW+0OmIbifbKmXIwaWRzenxiZurzLNe4DtOB1zLDhBuk4NxpBaUCRXfRYbYemRjSrAQANhyzPFlQ9p4m2hQaQZ14BIwRyHGzPAsIYsn92GuP1CRaz0fPoO8oCAwEuMZPNohJDwL3ctuWYqleWfX2IdPanKcU0bcKMNqxsU8g8WRQWOh3EN+lHD0EU9FXNwH1Gk6n7fk557XN6OPzYaYgRIfTmU=
+        gmx\\004ncn744@IBM-PF3XEKD9\r\n"},{"creationDate":"2024-01-10T07:20:55.683Z","name":"rdr-acm-210-train1-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQDtKd5svnJLGfe7QB8ZkX/jtL9bNwtarIQ7NDThCBQuN5hZpKYJtaWjawjA6FtxklV+iVuDXQleFMVLp/NkNPP+DDv7LtLb9TaxR8pWenZBxzUfKA2iIGHoQdlA+Sobv0pzz2zDy7hcLmEc3ehB2QSuiNB/iGO8PaUpCcY2Vj6FaG8yD5zvfnffvDO6tEWaabDakOzlA3GMxtGJKaOgfhCgC2xAfJCXun1ssyGgao3dZWUUU2p1zq3Qeg69IQOUWOXshGHwsEHOR10E3HAgmqfL+tEdvoXo88OymtCqGnEZmbt9S2Oy/KRf+szNPeRHaRS8k2zwuDm3ojlQ13CtO+mj/MqdSntKfAEHZca1s11kSY/sxgn4n3wOnlVyjNMzbYt6Zs3SGe2LC9QWVvmOC03cABmLqBNg0HQr2ESaBtSuoSSG1aKFxgnEK0QWMqDBkJeOgMqc9jGmMLWVlyt0UKT2ZYMjtoKbNHO19XlNZbf8TH9JMEFJEY3dmyYrShYdNP4+kz1Lxs5PXuqh2PY/hVVh3GD4cdA9hH4WGYDsFPmQDAK7OvRicDzEjM+OxJoW//1+iHHepZkNB3PqeYt54myISRI8aMMufmFBEUrscApg5WPN7o+4SIlydj1WtTEyunwS5SZj1DYQ6D8EbCV38Vn2fpMX+yUjSHDStfeWQd8YkQ==
+        Niharika.Gurram1@ibm.com\n"},{"creationDate":"2024-01-16T09:02:43.713Z","name":"rdr-acm-210-man-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDkSoLJhlBQ/bTTRaBy6IK4zhLaOcl/KRojsg3ajHZULoJ4TvbIkuebUyFB+S9I1UHdTLHvxXKLOdMVbYoBKkxsKS1AFiCR4sptItcwfcx2E0+COvRWzS3ytF7Y7PqTCJPFWnak63GmWcmzu6W/J+Z9SVUBHh5z9uWqXsWlg33AvLF2tS1ILYSliOkjhg5qzitrPDieKZW1ftECOoK/pn/D0V+QC8uf9Nfp/0d+IXelaRAomLX+8yXk3QJu8waEvkEhXKh1BCkjJ/Axoj5TTtB6pifcmFsLu5Xtu/b8wfW+0OmIbifbKmXIwaWRzenxiZurzLNe4DtOB1zLDhBuk4NxpBaUCRXfRYbYemRjSrAQANhyzPFlQ9p4m2hQaQZ14BIwRyHGzPAsIYsn92GuP1CRaz0fPoO8oCAwEuMZPNohJDwL3ctuWYqleWfX2IdPanKcU0bcKMNqxsU8g8WRQWOh3EN+lHD0EU9FXNwH1Gk6n7fk557XN6OPzYaYgRIfTmU=
+        gmx\\004ncn744@IBM-PF3XEKD9\n"},{"creationDate":"2024-01-16T09:45:10.169Z","name":"rdr-acm-2-10-hub-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQDtKd5svnJLGfe7QB8ZkX/jtL9bNwtarIQ7NDThCBQuN5hZpKYJtaWjawjA6FtxklV+iVuDXQleFMVLp/NkNPP+DDv7LtLb9TaxR8pWenZBxzUfKA2iIGHoQdlA+Sobv0pzz2zDy7hcLmEc3ehB2QSuiNB/iGO8PaUpCcY2Vj6FaG8yD5zvfnffvDO6tEWaabDakOzlA3GMxtGJKaOgfhCgC2xAfJCXun1ssyGgao3dZWUUU2p1zq3Qeg69IQOUWOXshGHwsEHOR10E3HAgmqfL+tEdvoXo88OymtCqGnEZmbt9S2Oy/KRf+szNPeRHaRS8k2zwuDm3ojlQ13CtO+mj/MqdSntKfAEHZca1s11kSY/sxgn4n3wOnlVyjNMzbYt6Zs3SGe2LC9QWVvmOC03cABmLqBNg0HQr2ESaBtSuoSSG1aKFxgnEK0QWMqDBkJeOgMqc9jGmMLWVlyt0UKT2ZYMjtoKbNHO19XlNZbf8TH9JMEFJEY3dmyYrShYdNP4+kz1Lxs5PXuqh2PY/hVVh3GD4cdA9hH4WGYDsFPmQDAK7OvRicDzEjM+OxJoW//1+iHHepZkNB3PqeYt54myISRI8aMMufmFBEUrscApg5WPN7o+4SIlydj1WtTEyunwS5SZj1DYQ6D8EbCV38Vn2fpMX+yUjSHDStfeWQd8YkQ==
+        Niharika.Gurram1@ibm.com\n"},{"creationDate":"2024-01-17T09:10:38.760Z","name":"rdr-acm-210-man2-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDkSoLJhlBQ/bTTRaBy6IK4zhLaOcl/KRojsg3ajHZULoJ4TvbIkuebUyFB+S9I1UHdTLHvxXKLOdMVbYoBKkxsKS1AFiCR4sptItcwfcx2E0+COvRWzS3ytF7Y7PqTCJPFWnak63GmWcmzu6W/J+Z9SVUBHh5z9uWqXsWlg33AvLF2tS1ILYSliOkjhg5qzitrPDieKZW1ftECOoK/pn/D0V+QC8uf9Nfp/0d+IXelaRAomLX+8yXk3QJu8waEvkEhXKh1BCkjJ/Axoj5TTtB6pifcmFsLu5Xtu/b8wfW+0OmIbifbKmXIwaWRzenxiZurzLNe4DtOB1zLDhBuk4NxpBaUCRXfRYbYemRjSrAQANhyzPFlQ9p4m2hQaQZ14BIwRyHGzPAsIYsn92GuP1CRaz0fPoO8oCAwEuMZPNohJDwL3ctuWYqleWfX2IdPanKcU0bcKMNqxsU8g8WRQWOh3EN+lHD0EU9FXNwH1Gk6n7fk557XN6OPzYaYgRIfTmU=
+        gmx\\004ncn744@IBM-PF3XEKD9\n"},{"creationDate":"2024-01-18T17:24:21.228Z","name":"test-ssh-key-no-comment","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCooZYGrwhEl5kCa0Pcdh2x0Xz/rOdru94tC8QI24bRFHPUAT88TKz48UciQE6/VaMdxxb9zrvA2eIU0/Td9lQU44B1LyEDLfILdxH1mHd2wehDM78V7804jvsxTMYXgNU8NEAJM+gyJ/K0rwvCReofL4jq/y4bbSEvVE+DxTnqzry2+SRCy0tEIfrHkJv2DMiB0oY680qEkZsAMZjE2JFrK8bN88kPhDb52x12llPMvUpppT4RBU3dDnweA50sxabV4SX0XVVJncw9nKh1EsUWrI4O7N3h8i8bLoiJvmGjIEpAQxE80ftvcbpJf0hPGsIr0BR+Qc+S6nBMdgpXj5RWlYS/ekxAVPe4xQsM01gMziwiX1RrcektajR8x/D3z28u7Nv1530b3rSqTMiydyXqcKMlTItqArpZVamo3UZ2CfuYRUdcpM+fbPCRsj0GH7pRxLqYag2klUIc9hZSgxQ85Yo5da+E7QjEvwxN5zxSyMy/ekRwsgWg6nDar9BFBV0="},{"creationDate":"2024-01-18T17:24:21.529Z","name":"test-ssh-key-with-comment","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQCvyVUxkBtMlmTemse/JcMhSxI4kIK4SzpMqQaUBaon9X30x62fjOik7lnqxqg/BXWVYI15nslSI/t5IbQGPGPBzR9RplBn/dx/Yxzcfgq5U5YBkvP9yXRYdp5f51z17a5+wWKI8Dka7vrLmv62thB83pjgiTsgFvqdSx7aYC4U3GFpboYHX/tQjrEpNBHRiRTeB9Ux/O+/gzGULlR0jd4denrWpng9Nn9n+N1e+tAkkUjUY0xTnodZfjnpYO/qhWSPwCglZeP9i9KdZFLCKuGTHkWbmQ1SnehRYEnLJ9lZRkhMsYq6uW1SNzMn16bGs3T7c+RkZUzs2JxFEjBIpEkq/uVDwVyIYd6dKQMp1cC8MEHQB2G6udrcvzwOJkb9xYqcJVpp0MzWApeBPwXUYJjCaxIHwF4TciYT0tleaoyZep9of0Wnrfv0BAtmY1f9obyEuRXKBFYmFlIvXripuueCL38KlQfVgmLuhnpSxXTVeiTZ8qTCxUkrJc6DZXh/z90=
-        This is only a test!"},{"creationDate":"2023-01-30T17:46:31.596Z","name":"test-ssh-key-with-comment-line-breaks","sshKey":"ssh-rsa
+        This is only a test!"},{"creationDate":"2024-01-18T17:24:21.796Z","name":"test-ssh-key-with-comment-line-breaks","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQD06A0pk378CjUm3LR5O9BW03ZNKgQPsB0IdMzdM4pBOyiPMubmcvOvItDz0XmtRIBJxqxRZftJAq01ej2ZSq+Fk+cbGtGQngEVceaz2GnrGNLasyF0zKG5mLXkoQsm3tofRdCuLecBFPSVN31yuxeVxsNCYKunGtwNejC/GIroptuRANJYVAv3TaVl99MYHfhkJCEvomdimYWZmi4eEML9bAhqr7LBK7j6rcivcp6Z8LpIg4LUP1+jniV0dXbhycJhYaAvQtKySBwnx70LiShyy9R2P31LL8g19Dn75NK1kWNV5mRrWFdyX+GJ8lnalOyBN4irZ7T1wAnbJfd/Vfs9PtYz2iR9IFEKYaxpEgNB5FQQY3UoP5gPezfRstG0ohmJ2zYxHC6PYuYQUpgp6xhf7jEtC+WHjWtmN5/LJ74k13BVPlhrSAduYrZJ8mCS29b4gjBuIirW8nByaGh5HBToyjbxdlBqDJS0+qMeWPqwSlZGK/jTulNpmvAibX7CawM=\nYes,
         placing line breaks in SSH public\nkey comments doesn''t break anything"}],"tenantID":"1fdf5effc3f945688c021cd0a8b45c4d"}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:52:01 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:24 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/placement-groups
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/placement-groups
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1618,24 +1645,23 @@ http_interactions:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"placementGroups":[{"id":"3fad2500-22df-4f2e-a0f8-530564a7163f","members":["46578c3d-a771-4410-8c9c-33f95b470e88"],"name":"test-placement-group-affinity","policy":"affinity"},{"id":"cc87f5d8-af58-4644-a16b-7571e0d5d9e8","members":["b35fecac-450d-4344-a87b-a14c459de44a"],"name":"test-placement-group-anti-affinity","policy":"anti-affinity"}]}
+      string: '{"placementGroups":[{"id":"8334ba79-bd98-47af-ad25-6eb8a1c4c817","members":["e8cf72cf-7685-4bfb-a386-66422f71820a"],"name":"test-placement-group-affinity","policy":"affinity"},{"id":"f99c2fc5-73ba-4387-9736-61dc51f53471","members":["d6a661a8-fed1-4a52-9d50-24fc9f9956b8"],"name":"test-placement-group-anti-affinity","policy":"anti-affinity"}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:52:02 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:24 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/snapshots
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/snapshots
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1654,30 +1680,29 @@ http_interactions:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"snapshots":[{"action":"snapshot","creationDate":"2023-01-30T17:59:14.000Z","description":"server
-        name: test-instance-sles-s922-shared-tier3","lastUpdateDate":"2023-01-30T17:59:22.000Z","name":"test-instance-sles-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"0c186073-26b2-4cbb-bf4e-e64057db23b0","snapshotID":"3dc68e65-5ad2-4459-85d9-e7eb05db483e","status":"available","volumeSnapshots":{"70ecc94d-ff42-4a33-b1fd-ca4c4d76152d":"6ff5501f-586a-48c4-b6e8-a568b48ead85"}},{"action":"snapshot","creationDate":"2023-01-30T17:58:45.000Z","description":"server
-        name: test-instance-ibmi-s922-capped-tier1","lastUpdateDate":"2023-01-30T17:58:53.000Z","name":"test-instance-ibmi-s922-capped-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"46578c3d-a771-4410-8c9c-33f95b470e88","snapshotID":"7d4105dd-b9d0-485b-88c3-b2af8e22949a","status":"available","volumeSnapshots":{"5cdf032a-5c6f-409f-8413-2214f14f2a69":"a7217f85-150d-41ae-ae41-8f8a140284b4"}},{"action":"snapshot","creationDate":"2023-01-30T17:58:38.000Z","description":"server
-        name: test-instance-aix-s922-shared-tier1","lastUpdateDate":"2023-01-30T17:58:47.000Z","name":"test-instance-aix-s922-shared-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"afd27dad-9513-47f1-9dba-59a37b494127","snapshotID":"bb515591-24bf-4c94-82a8-0190a5000003","status":"available","volumeSnapshots":{"88c1c414-634d-47e7-81fe-041c0add78d9":"3fb49fe1-ab67-4e00-aaf8-7e5a525d20e8"}},{"action":"snapshot","creationDate":"2023-01-31T01:31:17.000Z","description":"server
-        name: test-instance-rhel-s922-shared-tier3","lastUpdateDate":"2023-01-31T01:31:26.000Z","name":"test-instance-rhel-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"862a0a0f-92b6-409c-b2d0-852bff557669","snapshotID":"e01c6741-5daf-4fdf-b5f9-7aa00fc711b7","status":"available","volumeSnapshots":{"72995028-8f21-4a3c-83a9-620c82699c4a":"f643c650-0b8b-4cd2-8ac7-2ce30cad3f5b"}},{"action":"snapshot","creationDate":"2023-01-30T17:58:52.000Z","description":"server
-        name: test-instance-centos-e980-dedicated-tier3","lastUpdateDate":"2023-01-30T17:59:01.000Z","name":"test-instance-centos-e980-dedicated-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"22f161cb-024d-42ba-8081-7d72019d6b59","snapshotID":"e5f55579-143f-4a43-ba12-f0accb7c749d","status":"available","volumeSnapshots":{"043cd4de-15e1-41fc-8dc4-1b6714785078":"52bd12fe-3a58-439a-9dea-2b94513e0648"}},{"action":"snapshot","creationDate":"2023-01-30T17:59:21.000Z","description":"server
-        name: test-instance-rhcos-s922-shared-tier3","lastUpdateDate":"2023-01-30T17:59:30.000Z","name":"test-instance-rhcos-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"b35fecac-450d-4344-a87b-a14c459de44a","snapshotID":"ee096c37-ea0d-44cd-b466-632771d896c3","status":"available","volumeSnapshots":{"ac381925-fb6b-4fcc-8306-444c1ba99e2d":"3a87bfa5-3552-4fc6-bc5f-2e5e0b4bd902"}}]}
+      string: '{"snapshots":[{"action":"snapshot","creationDate":"2024-01-18T19:14:39.000Z","description":"server
+        name: test-instance-ibmi-s922-capped-tier1","lastUpdateDate":"2024-01-18T19:14:49.000Z","name":"test-instance-ibmi-s922-capped-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a","snapshotID":"0e536300-ad93-40f3-92f9-f5153785d2ac","status":"available","volumeSnapshots":{"ed84f79b-b8d1-48c3-8766-2a92ff6a879b":"2ad97524-7d8e-48dc-ace4-f66c544e2775"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:53.000Z","description":"server
+        name: test-instance-sles-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:15:02.000Z","name":"test-instance-sles-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd","snapshotID":"2d3fa834-5212-4ea4-ac2a-d28a244041c2","status":"available","volumeSnapshots":{"ba26d663-1e76-4457-8732-9d9235df8019":"5c7be867-f103-4a83-87af-53ffa26b07be"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:57.000Z","description":"server
+        name: test-instance-rhcos-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:15:05.000Z","name":"test-instance-rhcos-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8","snapshotID":"9c6127c6-b71d-417d-8238-e4642cf3df83","status":"available","volumeSnapshots":{"7d6f53e6-4adf-4792-8b5f-07cc618dff78":"7fabb55d-38e4-40c0-bd0c-ba44e706135e"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:44.000Z","description":"server
+        name: test-instance-centos-e980-dedicated-tier3","lastUpdateDate":"2024-01-18T19:14:53.000Z","name":"test-instance-centos-e980-dedicated-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"1ea38460-b3ff-4abd-802b-0289983be590","snapshotID":"9f192329-1470-4532-b609-16b56914fad0","status":"available","volumeSnapshots":{"cdfebbb2-d64e-41e1-9834-4f6b5d249489":"563ac449-f811-4ff7-bd91-adb026c82562"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:48.000Z","description":"server
+        name: test-instance-rhel-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:14:58.000Z","name":"test-instance-rhel-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","snapshotID":"d5332d55-9d8f-4745-b26e-203387b59d55","status":"available","volumeSnapshots":{"984498df-5554-4685-a109-821d5e39b27b":"ccc567e7-63db-4441-ab3c-a206e41ff9b3"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:35.000Z","description":"server
+        name: test-instance-aix-s922-shared-tier1","lastUpdateDate":"2024-01-18T19:14:44.000Z","name":"test-instance-aix-s922-shared-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"502106d8-d969-49df-9103-184c3ab97508","snapshotID":"e47f1ab4-22eb-4262-9b8c-b670afcbf6ef","status":"available","volumeSnapshots":{"2e653913-14fe-4b3a-a4f3-c7396bed0862":"0d6df030-deb6-4fe4-8247-42a61d7c4cad"}}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:52:04 GMT
+  recorded_at: Thu, 18 Jan 2024 19:28:24 GMT
 - request:
     method: get
-    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/shared-processor-pools
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/shared-processor-pools
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.0/ruby
+      - OpenAPI-Generator/2.1.1/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:us-east01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1691,18 +1716,16 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '654'
+      - '384'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
     body:
       encoding: UTF-8
-      string: '{"sharedProcessorPools":[{"allocatedCores":0,"availableCores":1,"hostGroup":"s922","hostID":22,"id":"6505e260-5cb3-4b35-8312-cfcaa39cb30d","name":"hiro_pool","reservedCores":1,"sharedProcessorPoolPlacementGroups":[],"status":"active","statusDetail":"shared
-        processor pool hiro_pool is active"},{"allocatedCores":0.5,"availableCores":0.5,"hostGroup":"s922","hostID":22,"id":"6a0f7faf-1cf4-4533-9871-3426085394ff","name":"test_pool","reservedCores":1,"sharedProcessorPoolPlacementGroups":[{"id":"bb252e11-c5f9-43fb-9801-2218058fe030","name":"test_spppg","policy":"affinity"}],"status":"active","statusDetail":"shared
+      string: '{"sharedProcessorPools":[{"allocatedCores":0.5,"availableCores":0.5,"hostGroup":"s922","hostID":6,"id":"85029156-8753-4d06-9a56-d13e3bd4c27d","name":"test_pool","reservedCores":1,"sharedProcessorPoolPlacementGroups":[{"id":"bb252e11-c5f9-43fb-9801-2218058fe030","name":"test_spppg","policy":"affinity"}],"status":"active","statusDetail":"shared
         processor pool test_pool is active"}]}
 
         '
-    http_version:
-  recorded_at: Tue, 31 Jan 2023 16:52:04 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Thu, 18 Jan 2024 19:28:25 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr_cassettes/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher/vm_target.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher/vm_target.yml
@@ -1,0 +1,542 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.cloud.ibm.com/identity/token#apikey
+    body:
+      encoding: UTF-8
+      string: apikey=IBM_CLOUD_POWERVS_API_KEY&grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/1.0.2/ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Content-Type-Options:
+      - nosniff
+      Transaction-Id:
+      - bXhmZmY-77039fb193cb401597e98f075c32b62a
+      X-Request-Id:
+      - 5303b21e-1445-428b-9249-2d30f0ba7d4b
+      X-Correlation-Id:
+      - bXhmZmY-77039fb193cb401597e98f075c32b62a
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json
+      Content-Language:
+      - en-US
+      Content-Length:
+      - '1532'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Thu, 18 Jan 2024 19:31:02 GMT
+      Connection:
+      - keep-alive
+      Akamai-Grn:
+      - 0.b8f8cd17.1705606261.8547f8e
+      X-Proxy-Upstream-Service-Time:
+      - '550'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"IAMBEARERTOKEN","refresh_token":"not_supported","ims_user_id":7771420,"token_type":"Bearer","expires_in":3600,"expiration":1705609859,"scope":"ibm
+        openid"}'
+  recorded_at: Thu, 18 Jan 2024 19:31:02 GMT
+- request:
+    method: get
+    uri: https://resource-controller.cloud.ibm.com/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      User-Agent:
+      - ibm_cloud_resource_controller-ruby-sdk-2.0.2 x86_64-pc-linux-gnu ruby-3.1.4
+      X-Ibmcloud-Sdk-Analytics:
+      - service_name=resource_controller;service_version=V2;operation_id=get_resource_instance
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer IAMBEARERTOKEN
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Request-Id:
+      - b40d3e24-5472-436c-a98d-a0185087f50c
+      Retry-After:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      Transaction-Id:
+      - bss-835b50c7df234cf9
+      X-Content-Type-Options:
+      - nosniff
+      X-Global-Transaction-Id:
+      - bss-835b50c7df234cf9
+      X-Op-Completion-Time:
+      - ''
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '99'
+      X-Ratelimit-Reset:
+      - '0'
+      X-Request-Id:
+      - b40d3e24-5472-436c-a98d-a0185087f50c
+      X-Transaction-Id:
+      - bss-835b50c7df234cf9
+      X-Envoy-Upstream-Service-Time:
+      - '166'
+      Server:
+      - istio-envoy
+      Content-Length:
+      - '2116'
+      Expires:
+      - Thu, 18 Jan 2024 19:31:02 GMT
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 18 Jan 2024 19:31:02 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"id":"crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","guid":"IBM_CLOUD_POWERVS_INSTANCE_ID","url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID","created_at":"2022-01-04T19:19:27.00879531Z","updated_at":"2022-05-28T10:58:12.563242645Z","deleted_at":null,"created_by":"IBMid-2700063YVN","updated_by":"IBMid-2700063YVN","deleted_by":"","scheduled_reclaim_at":null,"restored_at":null,"scheduled_reclaim_by":"","restored_by":"","name":"rdr-power.control.plane.test-hcm-mon01-miq-specs","region_id":"mon01","account_id":"1fdf5effc3f945688c021cd0a8b45c4d","reseller_channel_id":"","resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","resource_group_id":"2f9167fcfa9c4e2a951c5d8fa22bd01f","resource_group_crn":"crn:v1:bluemix:public:resource-controller::a/1fdf5effc3f945688c021cd0a8b45c4d::resource-group:2f9167fcfa9c4e2a951c5d8fa22bd01f","target_crn":"crn:v1:bluemix:public:globalcatalog::::deployment:f165dd34-3a40-423b-9d95-e90a23f724dd%3Amon0159210","allow_cleanup":false,"crn":"crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","state":"active","type":"service_instance","resource_id":"abd259f0-9990-11e8-acc8-b9f54a8f1661","dashboard_url":"https://power-iaas.cloud.ibm.com/authenticate","last_operation":{"type":"create","state":"succeeded","async":true,"description":"service
+        instance IBM_CLOUD_POWERVS_INSTANCE_ID was provisioned successfully for account
+        1fdf5effc3f945688c021cd0a8b45c4d in region mon01","cancelable":false,"poll":false},"resource_aliases_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_aliases","resource_bindings_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_bindings","resource_keys_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_keys","plan_history":[{"resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","start_date":"2022-01-04T19:19:27.00879531Z","requestor_id":"IBMid-2700063YVN"}],"migrated":false,"controlled_by":"","locked":false}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:02 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/system-pools
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"e980":{"capacity":{"cores":88,"memory":12564,"totalCores":null,"totalMemory":null},"coreMemoryRatio":64,"maxAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"maxCoresAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"maxMemoryAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"sharedCoreRatio":{"default":0.25,"max":1,"min":0.05},"systems":[{"cores":59.5,"id":1,"memory":11779,"totalCores":null,"totalMemory":null}],"type":"e980"},"s922":{"capacity":{"cores":15,"memory":935,"totalCores":null,"totalMemory":null},"coreMemoryRatio":64,"maxAvailable":{"cores":14.25,"memory":902,"totalCores":null,"totalMemory":null},"maxCoresAvailable":{"cores":14.25,"memory":897,"totalCores":null,"totalMemory":null},"maxMemoryAvailable":{"cores":6,"memory":902,"totalCores":null,"totalMemory":null},"sharedCoreRatio":{"default":0.25,"max":1,"min":0.05},"systems":[{"cores":14.25,"id":14,"memory":897,"totalCores":null,"totalMemory":null},{"cores":12.3,"id":25,"memory":895,"totalCores":null,"totalMemory":null},{"cores":11.75,"id":18,"memory":884,"totalCores":null,"totalMemory":null},{"cores":10.25,"id":12,"memory":849,"totalCores":null,"totalMemory":null},{"cores":9.5,"id":11,"memory":874,"totalCores":null,"totalMemory":null},{"cores":9,"id":15,"memory":880,"totalCores":null,"totalMemory":null},{"cores":8.25,"id":9,"memory":681,"totalCores":null,"totalMemory":null},{"cores":7.5,"id":8,"memory":843,"totalCores":null,"totalMemory":null},{"cores":6,"id":17,"memory":902,"totalCores":null,"totalMemory":null},{"cores":5.75,"id":23,"memory":598,"totalCores":null,"totalMemory":null},{"cores":4.5,"id":21,"memory":738,"totalCores":null,"totalMemory":null},{"cores":4.5,"id":5,"memory":728,"totalCores":null,"totalMemory":null},{"cores":4,"id":13,"memory":822,"totalCores":null,"totalMemory":null},{"cores":3.5,"id":10,"memory":624,"totalCores":null,"totalMemory":null},{"cores":1.5,"id":20,"memory":855,"totalCores":null,"totalMemory":null},{"cores":0.26,"id":19,"memory":397,"totalCores":null,"totalMemory":null},{"cores":0.26,"id":16,"memory":485,"totalCores":null,"totalMemory":null},{"cores":0.25,"id":24,"memory":519,"totalCores":null,"totalMemory":null},{"cores":0.01,"id":6,"memory":556,"totalCores":null,"totalMemory":null},{"cores":0,"id":22,"memory":455,"totalCores":null,"totalMemory":null},{"cores":0,"id":4,"memory":533,"totalCores":null,"totalMemory":null},{"cores":0,"id":7,"memory":320,"totalCores":null,"totalMemory":null}],"type":"s922"}}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:03 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '752'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"capabilities":["cloud-connections","direct-link-transit-gateway","ibmi-software-licenses","linux","pinning","rhel-sap","sap","snapshots","volume-clone","vpn-connections","shared-processor-pools"],"cloudInstanceID":"c8d0ac7c30c944f0ac3288eb8bb74aaa","enabled":true,"initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"IBM_CLOUD_POWERVS_INSTANCE_ID","openstackID":"07389ca7-2266-4303-afd3-5babc1cebe20","pvmInstances":[],"region":"mon01","tenantID":"1fdf5effc3f945688c021cd0a8b45c4d","usage":{"instances":0,"memory":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0,"storageStandard":0}}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:03 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/sap
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"profiles":[{"certified":true,"cores":16,"memory":1600,"profileID":"bh1-16x1600","type":"balanced"},{"certified":true,"cores":20,"memory":2000,"profileID":"bh1-20x2000","type":"balanced"},{"certified":true,"cores":22,"memory":2200,"profileID":"bh1-22x2200","type":"balanced"},{"certified":true,"cores":25,"memory":2500,"profileID":"bh1-25x2500","type":"balanced"},{"certified":true,"cores":30,"memory":3000,"profileID":"bh1-30x3000","type":"balanced"},{"certified":true,"cores":35,"memory":3500,"profileID":"bh1-35x3500","type":"balanced"},{"certified":true,"cores":40,"memory":4000,"profileID":"bh1-40x4000","type":"balanced"},{"certified":true,"cores":50,"memory":5000,"profileID":"bh1-50x5000","type":"balanced"},{"certified":true,"cores":60,"memory":6000,"profileID":"bh1-60x6000","type":"balanced"},{"certified":true,"cores":70,"memory":7000,"profileID":"bh1-70x7000","type":"balanced"},{"certified":true,"cores":80,"memory":8000,"profileID":"bh1-80x8000","type":"balanced"},{"certified":true,"cores":100,"memory":10000,"profileID":"bh1-100x10000","type":"balanced"},{"certified":true,"cores":120,"memory":12000,"profileID":"bh1-120x12000","type":"balanced"},{"certified":true,"cores":140,"memory":14000,"profileID":"bh1-140x14000","type":"balanced"},{"certified":true,"cores":60,"memory":3000,"profileID":"ch1-60x3000","type":"compute"},{"certified":true,"cores":70,"memory":3500,"profileID":"ch1-70x3500","type":"compute"},{"certified":true,"cores":80,"memory":4000,"profileID":"ch1-80x4000","type":"compute"},{"certified":true,"cores":100,"memory":5000,"profileID":"ch1-100x5000","type":"compute"},{"certified":true,"cores":120,"memory":6000,"profileID":"ch1-120x6000","type":"compute"},{"certified":true,"cores":140,"memory":7000,"profileID":"ch1-140x7000","type":"compute"},{"certified":true,"cores":8,"memory":1440,"profileID":"mh1-8x1440","type":"memory"},{"certified":true,"cores":10,"memory":1800,"profileID":"mh1-10x1800","type":"memory"},{"certified":true,"cores":12,"memory":2160,"profileID":"mh1-12x2160","type":"memory"},{"certified":true,"cores":16,"memory":2880,"profileID":"mh1-16x2880","type":"memory"},{"certified":true,"cores":20,"memory":3600,"profileID":"mh1-20x3600","type":"memory"},{"certified":true,"cores":22,"memory":3960,"profileID":"mh1-22x3960","type":"memory"},{"certified":true,"cores":25,"memory":4500,"profileID":"mh1-25x4500","type":"memory"},{"certified":true,"cores":30,"memory":5400,"profileID":"mh1-30x5400","type":"memory"},{"certified":true,"cores":35,"memory":6300,"profileID":"mh1-35x6300","type":"memory"},{"certified":true,"cores":40,"memory":7200,"profileID":"mh1-40x7200","type":"memory"},{"certified":true,"cores":50,"memory":9000,"profileID":"mh1-50x9000","type":"memory"},{"certified":true,"cores":60,"memory":10800,"profileID":"mh1-60x10800","type":"memory"},{"certified":true,"cores":70,"memory":12600,"profileID":"mh1-70x12600","type":"memory"},{"certified":true,"cores":80,"memory":14400,"profileID":"mh1-80x14400","type":"memory"},{"certified":true,"cores":90,"memory":16200,"profileID":"mh1-90x16200","type":"memory"},{"certified":true,"cores":100,"memory":18000,"profileID":"mh1-100x18000","type":"memory"},{"certified":true,"cores":4,"memory":128,"profileID":"ush1-4x128","type":"small"},{"certified":true,"cores":4,"memory":256,"profileID":"ush1-4x256","type":"small"},{"certified":true,"cores":4,"memory":384,"profileID":"ush1-4x384","type":"small"},{"certified":true,"cores":4,"memory":512,"profileID":"ush1-4x512","type":"small"},{"certified":true,"cores":4,"memory":768,"profileID":"ush1-4x768","type":"small"},{"certified":true,"cores":4,"memory":960,"profileID":"umh-4x960","type":"ultra-memory"},{"certified":true,"cores":6,"memory":1440,"profileID":"umh-6x1440","type":"ultra-memory"},{"certified":true,"cores":8,"memory":1920,"profileID":"umh-8x1920","type":"ultra-memory"},{"certified":true,"cores":10,"memory":2400,"profileID":"umh-10x2400","type":"ultra-memory"},{"certified":true,"cores":12,"memory":2880,"profileID":"umh-12x2880","type":"ultra-memory"},{"certified":true,"cores":16,"memory":3840,"profileID":"umh-16x3840","type":"ultra-memory"},{"certified":true,"cores":20,"memory":4800,"profileID":"umh-20x4800","type":"ultra-memory"},{"certified":true,"cores":22,"memory":5280,"profileID":"umh-22x5280","type":"ultra-memory"},{"certified":true,"cores":25,"memory":6000,"profileID":"umh-25x6000","type":"ultra-memory"},{"certified":true,"cores":30,"memory":7200,"profileID":"umh-30x7200","type":"ultra-memory"},{"certified":true,"cores":35,"memory":8400,"profileID":"umh-35x8400","type":"ultra-memory"},{"certified":true,"cores":40,"memory":9600,"profileID":"umh-40x9600","type":"ultra-memory"},{"certified":true,"cores":50,"memory":12000,"profileID":"umh-50x12000","type":"ultra-memory"},{"certified":true,"cores":60,"memory":14400,"profileID":"umh-60x14400","type":"ultra-memory"},{"certified":false,"cores":1,"memory":128,"profileID":"np1-1x128","type":"non-production"}]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:03 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/storage-capacity/storage-types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"any"},"storageTypesCapacity":[{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier1"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092}],"storageType":"tier1"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier3"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092}],"storageType":"tier3"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier5k"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092}],"storageType":"tier5k"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier0"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092}],"storageType":"tier0"}]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:04 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"consoleLanguage":{"code":"037","language":"037
+        English"},"creationDate":"2024-01-18T18:43:09.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:31:05.494688","status":"OK"},"hostID":7,"imageID":"ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2","maxmem":16,"maxproc":2,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["925c13aa-9579-43a3-86e1-150131906835"],"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"V7R5M0
+        410 2","osType":"ibmi","pinPolicy":"none","placementGroup":"8334ba79-bd98-47af-ad25-6eb8a1c4c817","procType":"capped","processors":0.25,"pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a","serverName":"test-instance-ibmi-s922-capped-tier1","softwareLicenses":{"ibmiCSS":false,"ibmiDBQ":false,"ibmiPHA":false,"ibmiRDS":false},"srcs":[[{"src":"A6005008","timestamp":"2024-01-18T18:51:32Z"},{"src":"03B00061","timestamp":"2024-01-18T18:51:32Z"},{"src":"FFFF0000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"50070404","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"}]],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2024-01-18T18:43:09.000Z","virtualCores":{"assigned":1,"max":4,"min":1},"volumeIDs":["ed84f79b-b8d1-48c3-8766-2a92ff6a879b"]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:08 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"images":[{"creationDate":"2022-11-15T22:45:40.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/8de97d73-95c0-46e9-a509-0b10be36eded","imageID":"8de97d73-95c0-46e9-a509-0b10be36eded","lastUpdateDate":"2023-06-07T01:38:14.000Z","name":"7300-00-01","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"aix"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-15T22:45:06.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/7da758c0-949b-4b11-a306-dc7dfc33919e","imageID":"7da758c0-949b-4b11-a306-dc7dfc33919e","lastUpdateDate":"2023-06-07T01:38:15.000Z","name":"CentOS-Stream-8","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2024-01-18T18:41:35.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/9eebf535-9b78-450e-bffd-e7cb4d3c9e94","imageID":"9eebf535-9b78-450e-bffd-e7cb4d3c9e94","lastUpdateDate":"2024-01-18T18:41:35.000Z","name":"IBMi-75-02-2984-1","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-15T22:42:20.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/10d7c4a5-32a7-44a9-b9e1-9a428a4da5d9","imageID":"10d7c4a5-32a7-44a9-b9e1-9a428a4da5d9","lastUpdateDate":"2023-06-07T01:38:17.000Z","name":"RHEL8-SP6","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-12T11:36:56.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/a0198511-c877-4f6f-b1c3-64312fcdb92c","imageID":"a0198511-c877-4f6f-b1c3-64312fcdb92c","lastUpdateDate":"2023-06-07T01:38:19.000Z","name":"SLES15-SP4","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"sles"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-01-28T22:32:39.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/032d72bf-89f2-44a9-bbc4-ab898dd93309","imageID":"032d72bf-89f2-44a9-bbc4-ab898dd93309","lastUpdateDate":"2023-12-14T21:46:24.000Z","name":"rhcos-4.8","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"import","operatingSystem":"rhel"},"state":"active","storagePool":"General-Flash-81","storageType":"tier3"}]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:09 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '433'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"creationDate":"2023-12-12T23:02:27.000Z","imageID":"ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2","lastUpdateDate":"2023-12-12T23:15:20.000Z","name":"IBMi-75-02-2984-1","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"","storageType":"","volumes":[]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:10 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"volumes":[{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T19:02:29.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/7d6f53e6-4adf-4792-8b5f-07cc618dff78","ioThrottleRate":"360
+        iops","lastUpdateDate":"2024-01-18T19:13:21.000Z","name":"test-instance-d6a661a8-00030ebf-boot-0","pvmInstanceIDs":["d6a661a8-fed1-4a52-9d50-24fc9f9956b8"],"shareable":false,"size":120,"state":"in-use","volumeID":"7d6f53e6-4adf-4792-8b5f-07cc618dff78","volumePool":"General-Flash-81","volumeType":"Tier3-General-Flash-81","wwn":"60050768108002DAC800000000004AF4"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:49:45.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/ba26d663-1e76-4457-8732-9d9235df8019","ioThrottleRate":"300
+        iops","lastUpdateDate":"2024-01-18T19:00:43.000Z","name":"test-instance-54e1f646-00030ebe-boot-0","pvmInstanceIDs":["54e1f646-8ce4-4ee5-9355-e5d34166c4fd"],"shareable":false,"size":100,"state":"in-use","volumeID":"ba26d663-1e76-4457-8732-9d9235df8019","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C4"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:47:54.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/984498df-5554-4685-a109-821d5e39b27b","ioThrottleRate":"300
+        iops","lastUpdateDate":"2024-01-18T18:48:16.000Z","name":"test-instance-b9370d8d-00030ebb-boot-0","pvmInstanceIDs":["b9370d8d-8d73-4f0e-ad84-34f7fd52eb84"],"shareable":false,"size":100,"state":"in-use","volumeID":"984498df-5554-4685-a109-821d5e39b27b","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C3"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:45:07.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/cdfebbb2-d64e-41e1-9834-4f6b5d249489","ioThrottleRate":"360
+        iops","lastUpdateDate":"2024-01-18T18:45:34.000Z","name":"test-instance-1ea38460-00030eb6-boot-0","pvmInstanceIDs":["1ea38460-b3ff-4abd-802b-0289983be590"],"shareable":false,"size":120,"state":"in-use","volumeID":"cdfebbb2-d64e-41e1-9834-4f6b5d249489","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C2"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:43:15.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/ed84f79b-b8d1-48c3-8766-2a92ff6a879b","ioThrottleRate":"1000
+        iops","lastUpdateDate":"2024-01-18T18:43:38.000Z","name":"test-instance-e8cf72cf-00030eb4-boot-0","pvmInstanceIDs":["e8cf72cf-7685-4bfb-a386-66422f71820a"],"shareable":false,"size":100,"state":"in-use","volumeID":"ed84f79b-b8d1-48c3-8766-2a92ff6a879b","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274C1"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T17:24:51.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/2e653913-14fe-4b3a-a4f3-c7396bed0862","ioThrottleRate":"250
+        iops","lastUpdateDate":"2024-01-18T17:25:13.000Z","name":"test-instance-502106d8-00030ea7-boot-0","pvmInstanceIDs":["502106d8-d969-49df-9103-184c3ab97508"],"shareable":false,"size":25,"state":"in-use","volumeID":"2e653913-14fe-4b3a-a4f3-c7396bed0862","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274BB"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:13.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/21f2d430-44fd-4f5e-af43-66076e6e9af7","ioThrottleRate":"150
+        iops","lastUpdateDate":"2024-01-18T17:24:14.000Z","name":"test-volume-15GB-tier1-notsharable","pvmInstanceIDs":[],"shareable":false,"size":15,"state":"available","volumeID":"21f2d430-44fd-4f5e-af43-66076e6e9af7","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274BA"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:07.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/5bb66445-1de3-4817-8590-42b35f21f9d8","ioThrottleRate":"30
+        iops","lastUpdateDate":"2024-01-18T17:24:08.000Z","name":"test-volume-3GB-tier1-notsharable","pvmInstanceIDs":[],"shareable":false,"size":3,"state":"available","volumeID":"5bb66445-1de3-4817-8590-42b35f21f9d8","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274B9"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:03.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/f302fbf6-c2f7-4df2-b80c-c3c2e8055d77","ioThrottleRate":"30
+        iops","lastUpdateDate":"2024-01-18T17:24:04.000Z","name":"test-volume-10GB-tier3-sharable","pvmInstanceIDs":[],"shareable":true,"size":10,"state":"available","volumeID":"f302fbf6-c2f7-4df2-b80c-c3c2e8055d77","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274B8"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:23:57.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/46eef916-ea40-4aee-9e0c-df840da65867","ioThrottleRate":"3
+        iops","lastUpdateDate":"2024-01-18T17:23:58.000Z","name":"test-volume-1GB-tier3-sharable","pvmInstanceIDs":[],"shareable":true,"size":1,"state":"available","volumeID":"46eef916-ea40-4aee-9e0c-df840da65867","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274B7"}]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:10 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/placement-groups
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '344'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"placementGroups":[{"id":"8334ba79-bd98-47af-ad25-6eb8a1c4c817","members":["e8cf72cf-7685-4bfb-a386-66422f71820a"],"name":"test-placement-group-affinity","policy":"affinity"},{"id":"f99c2fc5-73ba-4387-9736-61dc51f53471","members":["d6a661a8-fed1-4a52-9d50-24fc9f9956b8"],"name":"test-placement-group-anti-affinity","policy":"anti-affinity"}]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:10 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/snapshots
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"snapshots":[{"action":"snapshot","creationDate":"2024-01-18T19:14:39.000Z","description":"server
+        name: test-instance-ibmi-s922-capped-tier1","lastUpdateDate":"2024-01-18T19:14:49.000Z","name":"test-instance-ibmi-s922-capped-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a","snapshotID":"0e536300-ad93-40f3-92f9-f5153785d2ac","status":"available","volumeSnapshots":{"ed84f79b-b8d1-48c3-8766-2a92ff6a879b":"2ad97524-7d8e-48dc-ace4-f66c544e2775"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:53.000Z","description":"server
+        name: test-instance-sles-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:15:02.000Z","name":"test-instance-sles-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd","snapshotID":"2d3fa834-5212-4ea4-ac2a-d28a244041c2","status":"available","volumeSnapshots":{"ba26d663-1e76-4457-8732-9d9235df8019":"5c7be867-f103-4a83-87af-53ffa26b07be"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:57.000Z","description":"server
+        name: test-instance-rhcos-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:15:05.000Z","name":"test-instance-rhcos-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8","snapshotID":"9c6127c6-b71d-417d-8238-e4642cf3df83","status":"available","volumeSnapshots":{"7d6f53e6-4adf-4792-8b5f-07cc618dff78":"7fabb55d-38e4-40c0-bd0c-ba44e706135e"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:44.000Z","description":"server
+        name: test-instance-centos-e980-dedicated-tier3","lastUpdateDate":"2024-01-18T19:14:53.000Z","name":"test-instance-centos-e980-dedicated-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"1ea38460-b3ff-4abd-802b-0289983be590","snapshotID":"9f192329-1470-4532-b609-16b56914fad0","status":"available","volumeSnapshots":{"cdfebbb2-d64e-41e1-9834-4f6b5d249489":"563ac449-f811-4ff7-bd91-adb026c82562"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:48.000Z","description":"server
+        name: test-instance-rhel-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:14:58.000Z","name":"test-instance-rhel-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","snapshotID":"d5332d55-9d8f-4745-b26e-203387b59d55","status":"available","volumeSnapshots":{"984498df-5554-4685-a109-821d5e39b27b":"ccc567e7-63db-4441-ab3c-a206e41ff9b3"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:35.000Z","description":"server
+        name: test-instance-aix-s922-shared-tier1","lastUpdateDate":"2024-01-18T19:14:44.000Z","name":"test-instance-aix-s922-shared-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"502106d8-d969-49df-9103-184c3ab97508","snapshotID":"e47f1ab4-22eb-4262-9b8c-b670afcbf6ef","status":"available","volumeSnapshots":{"2e653913-14fe-4b3a-a4f3-c7396bed0862":"0d6df030-deb6-4fe4-8247-42a61d7c4cad"}}]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:11 GMT
+- request:
+    method: get
+    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/shared-processor-pools
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/2.1.1/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '384'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: UTF-8
+      string: '{"sharedProcessorPools":[{"allocatedCores":0.5,"availableCores":0.5,"hostGroup":"s922","hostID":6,"id":"85029156-8753-4d06-9a56-d13e3bd4c27d","name":"test_pool","reservedCores":1,"sharedProcessorPoolPlacementGroups":[{"id":"bb252e11-c5f9-43fb-9801-2218058fe030","name":"test_spppg","policy":"affinity"}],"status":"active","statusDetail":"shared
+        processor pool test_pool is active"}]}
+
+        '
+  recorded_at: Thu, 18 Jan 2024 19:31:12 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
I noticed duplicate entries in the `advanced_settings` table on an internal MIQ instance. @agrare suggested I add some targeted refresh specs to see if it caught the issue. Looks like there is an issue with duplicate snapshots.