### PR TITLE
[WIP] Fix duplicate advanced settings entries

### DIFF
--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -94,6 +94,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
       expect(OperatingSystem.count).to eq(12)
       expect(PlacementGroup.count).to eq(2)
       expect(Vm.count).to eq(6)
+      expect(AdvancedSetting.count).to eq(18)
     end
 
     def assert_ems_counts


### PR DESCRIPTION
Each PowerVS VM should have 3 corresponding advanced settings entries (entitled proc count, proc type and pin policy). The current refresher VCR cassette has 6 VMs so we should expect to see 18 advanced settings records.

Refreshing either the PowerVS NetworkManager or StorageManager directly adds duplicate advanced settings entries. Once the duplicate entries are in place, refreshing the CloudManager will attempt to destroy them but since we set `:read_only => true` they remain in place (even though logs say they were destroyed! See ManageIQ/inventory_refresh#120).

TODO: Figure out where the `NetworkManager` and `StorageManager` refresh scope is wrong.