### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/container_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager.rb
@@ -1,20 +1,6 @@
 ManageIQ::Providers::Kubernetes::ContainerManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmCloud::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
-  require_nested :Container
-  require_nested :ContainerGroup
-  require_nested :ContainerNode
-  require_nested :ContainerTemplate
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :ServiceInstance
-  require_nested :ServiceOffering
-  require_nested :ServiceParametersSet
-
   supports :create
 
   METRICS_ROLES = %w[prometheus].freeze

--- a/app/models/manageiq/providers/ibm_cloud/container_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::ContainerManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_ibm_cloud_iks
   end

--- a/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_capture.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCapture < ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture
-  require_nested :PrometheusCaptureContext
-
   def prometheus_capture_context(target, start_time, end_time)
     ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCapture::PrometheusCaptureContext.new(target, start_time, end_time, INTERVAL)
   end

--- a/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::ContainerManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "iks"
 
   def friendly_name

--- a/app/models/manageiq/providers/ibm_cloud/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager/refresh_worker.rb
@@ -1,7 +1,4 @@
 class ManageIQ::Providers::IbmCloud::ContainerManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-  require_nested :WatchThread
-
   def self.settings_name
     :ems_refresh_worker_ibm_cloud_iks
   end

--- a/app/models/manageiq/providers/ibm_cloud/inventory.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::IbmCloud::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   def self.parsed_manager_name(ems, target)
     case target
     when InventoryRefresh::TargetCollection

--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector.rb
@@ -1,6 +1,2 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :ContainerManager
-  require_nested :ObjectStorage
-  require_nested :PowerVirtualServers
-  require_nested :VPC
 end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/object_storage.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/object_storage.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Collector::ObjectStorage < ManageIQ::Providers::IbmCloud::Inventory::Collector
-  require_nested :StorageManager
-
   BUCKET_TAB_LIMIT = 1000
 
   def buckets

--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers < ManageIQ::Providers::IbmCloud::Inventory::Collector
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :StorageManager
-  require_nested :TargetCollection
-
   def collect
     connection
   end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/vpc.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Collector::VPC < ManageIQ::Providers::IbmCloud::Inventory::Collector
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :StorageManager
-  require_nested :TargetCollection
-
   def connection
     @connection ||= manager.connect
   end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser.rb
@@ -1,6 +1,2 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :ContainerManager
-  require_nested :ObjectStorage
-  require_nested :PowerVirtualServers
-  require_nested :VPC
 end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Parser::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/object_storage.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/object_storage.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Parser::ObjectStorage < ManageIQ::Providers::IbmCloud::Inventory::Parser
-  require_nested :StorageManager
-
   BUCKET_TAB_LIMIT = 1000
 
   def parse

--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < ManageIQ::Providers::IbmCloud::Inventory::Parser
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :StorageManager
-  require_nested :TargetCollection
-
   attr_reader :subnet_to_ext_ports
 
   OS_MIQ_NAMES_MAP = {

--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/vpc.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Parser::VPC < ManageIQ::Providers::IbmCloud::Inventory::Parser
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :StorageManager
-  require_nested :TargetCollection
-
   def parse
     floating_ips
     cloud_databases

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister.rb
@@ -1,6 +1,2 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :ContainerManager
-  require_nested :ObjectStorage
-  require_nested :PowerVirtualServers
-  require_nested :VPC
 end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/container_manager.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
-  require_nested :WatchNotice
 end

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/object_storage.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/object_storage.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Persister::ObjectStorage < ManageIQ::Providers::IbmCloud::Inventory::Persister
-  require_nested :StorageManager
-
   def initialize_inventory_collections
     add_collection(storage, :cloud_object_store_objects) do |builder|
       builder.add_properties(:model_class => ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager::CloudObjectStoreObject)

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/power_virtual_servers.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Persister::PowerVirtualServers < ManageIQ::Providers::IbmCloud::Inventory::Persister
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :StorageManager
-  require_nested :TargetCollection
-
   def initialize_inventory_collections
     initialize_cloud_inventory_collections
     initialize_network_inventory_collections

--- a/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/persister/vpc.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::IbmCloud::Inventory::Persister::VPC < ManageIQ::Providers::IbmCloud::Inventory::Persister
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :StorageManager
-  require_nested :TargetCollection
-
   def self.provider_module
     "ManageIQ::Providers::IbmCloud::VPC"
   end

--- a/app/models/manageiq/providers/ibm_cloud/object_storage/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/object_storage/storage_manager.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager < ManageIQ::Providers::StorageManager
-  require_nested :CloudObjectStoreContainer
-  require_nested :CloudObjectStoreObject
-  require_nested :Refresher
-  require_nested :RefreshWorker
-
   supports :create
   supports :update
 

--- a/app/models/manageiq/providers/ibm_cloud/object_storage/storage_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ibm_cloud/object_storage/storage_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::ObjectStorage::StorageManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_ibm_cloud_object_storage
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager.rb
@@ -1,19 +1,4 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager < ManageIQ::Providers::CloudManager
-  require_nested :AuthKeyPair
-  require_nested :AvailabilityZone
-  require_nested :EventCatcher
-  require_nested :Flavor
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :PlacementGroup
-  require_nested :Provision
-  require_nested :ProvisionWorkflow
-  require_nested :SAPProfile
-  require_nested :Snapshot
-  require_nested :Template
-  require_nested :Vm
-  require_nested :ResourcePool
-
   include ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
 
   delegate :cloud_volumes,

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_ibm_cloud_power_virtual_servers
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provision < ::MiqProvisionCloud
-  include_concern 'Cloning'
-  include_concern 'StateMachine'
-  include_concern 'OptionsHelper'
+  include Cloning
+  include StateMachine
+  include OptionsHelper
 
   def destination_type
     case request_type

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_ibm_cloud_power_virtual_servers
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
-  include_concern 'Operations'
+  include Operations
 
   supports :capture
   supports :terminate

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
@@ -1,12 +1,4 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager < ManageIQ::Providers::NetworkManager
-  require_nested :Refresher
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :LoadBalancer
-  require_nested :NetworkPort
-  require_nested :NetworkRouter
-  require_nested :SecurityGroup
-
   include ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
 
   supports :cloud_subnet_create

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager < ManageIQ::Providers::StorageManager
-  require_nested :CloudVolume
-  require_nested :CloudVolumeType
-  require_nested :Refresher
-
   include ManageIQ::Providers::IbmCloud::PowerVirtualServers::ManagerMixin
   include ManageIQ::Providers::StorageManager::BlockMixin
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -1,20 +1,4 @@
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::CloudManager
-  require_nested :AuthKeyPair
-  require_nested :AvailabilityZone
-  require_nested :CloudDatabase
-  require_nested :CloudDatabaseFlavor
-  require_nested :EventCatcher
-  require_nested :Flavor
-  require_nested :LoggingMixin
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :Provision
-  require_nested :ProvisionWorkflow
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :Template
-  require_nested :Vm
-
   supports :create
   supports :metrics
   supports :catalog

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   def self.all_valid_ems_in_zone
     super.select do |ems|
       ems.authentication_key("events").present? && ems.authentication_status_ok?(:events)

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "ibm_cloud_vpc"
 
   def friendly_name

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision.rb
@@ -3,8 +3,7 @@
 # Opts into CloudManager provisioning. Custom logic is separated into module mixins.
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Provision < ::MiqProvisionCloud
   include ManageIQ::Providers::IbmCloud::VPC::CloudManager::LoggingMixin # Standardise the logging.
-
-  include_concern 'Cloning'       # Actual provision to cloud.
-  include_concern 'Payload'       # Create json payload.
-  include_concern 'StateMachine'  # Pre-provision tasks.
+  include Cloning       # Actual provision to cloud.
+  include Payload       # Create json payload.
+  include StateMachine  # Pre-provision tasks.
 end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/provision_workflow.rb
@@ -3,12 +3,11 @@
 # Class contains all logic used to populate the UI.
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager::ProvisionWorkflow < ::MiqProvisionCloudWorkflow
   include ManageIQ::Providers::IbmCloud::VPC::CloudManager::LoggingMixin # Standardise the logging.
-
-  include_concern 'Common'  # Provides common functionality.
-  include_concern 'General' # Used for general options.
-  include_concern 'Network' # Used for network options.
-  include_concern 'Volumes' # Used for volume options.
-  include_concern 'Fields'  # Used for manipulating field hashes.
+  include Common  # Provides common functionality.
+  include General # Used for general options.
+  include Network # Used for network options.
+  include Volumes # Used for volume options.
+  include Fields  # Used for manipulating field hashes.
 
   # Class methods. Do not move to sub module.
   class << self

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_ibm_cloud_vpc
   end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/template.rb
@@ -2,7 +2,7 @@
 
 # Provide CloudManager support for IBM CLoud VPC templates.
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template < ManageIQ::Providers::CloudManager::Template
-  include_concern 'ManageIQ::Providers::IbmCloud::VPC::CloudManager::VmOrTemplateShared'
+  include ManageIQ::Providers::IbmCloud::VPC::CloudManager::VmOrTemplateShared
 
   supports :provisioning do
     if ext_management_system

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
@@ -1,17 +1,4 @@
 class ManageIQ::Providers::IbmCloud::VPC::NetworkManager < ManageIQ::Providers::NetworkManager
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :FloatingIp
-  require_nested :LoadBalancer
-  require_nested :LoadBalancerHealthCheck
-  require_nested :LoadBalancerListener
-  require_nested :LoadBalancerPool
-  require_nested :LoadBalancerPoolMember
-  require_nested :NetworkPort
-  require_nested :NetworkRouter
-  require_nested :Refresher
-  require_nested :SecurityGroup
-
   include ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
 
   supports :cloud_subnet_create

--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
@@ -2,10 +2,6 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager < ManageIQ::Providers::
   include ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
   include ManageIQ::Providers::StorageManager::BlockMixin
 
-  require_nested :CloudVolume
-  require_nested :CloudVolumeType
-  require_nested :Refresher
-
   delegate :authentication_check,
            :authentication_status,
            :authentication_status_ok?,


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854