### PR TITLE
drop use of unsupported_reason_add an supports_feature

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/container_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/container_manager.rb
@@ -6,7 +6,7 @@ class ManageIQ::Providers::IbmCloud::ContainerManager < ManageIQ::Providers::Kub
   METRICS_ROLES = %w[prometheus].freeze
 
   supports :metrics do
-    unsupported_reason_add(:metrics, _("No metrics endpoint has been added")) unless metrics_endpoint_exists?
+    _("No metrics endpoint has been added") unless metrics_endpoint_exists?
   end
 
   def metrics_endpoint_exists?

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/template.rb
@@ -5,9 +5,9 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Template
 
   supports :provisioning do
     if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
+      ext_management_system.unsupported_reason(:provisioning)
     else
-      unsupported_reason_add(:provisioning, _('not connected to ems'))
+      _('not connected to ems')
     end
   end
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -4,15 +4,15 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
   supports :capture
   supports :terminate
   supports :reboot_guest do
-    unsupported_reason_add(:reboot_guest, _("The VM is not powered on")) unless current_state == "on"
+    _("The VM is not powered on") unless current_state == "on"
   end
   supports :reset do
-    unsupported_reason_add(:reset, _("The VM is not powered on")) unless current_state == "on"
+    _("The VM is not powered on") unless current_state == "on"
   end
   supports :snapshots
   supports :snapshot_create
   supports :revert_to_snapshot do
-    unsupported_reason_add(:revert_to_snapshot, _("Cannot revert to snapshot while VM is running")) unless current_state == "off"
+    _("Cannot revert to snapshot while VM is running") unless current_state == "off"
   end
   supports :remove_snapshot
   supports :remove_all_snapshots
@@ -20,30 +20,28 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
   supports_not :suspend
 
   supports :publish do
-    reason   = _("Publish not supported because VM is blank")    if blank?
-    reason ||= _("Publish not supported because VM is orphaned") if orphaned?
-    reason ||= _("Publish not supported because VM is archived") if archived?
-    unsupported_reason_add(:publish, reason) if reason
+    return _("Publish not supported because VM is blank")    if blank?
+    return _("Publish not supported because VM is orphaned") if orphaned?
+    return _("Publish not supported because VM is archived") if archived?
   end
 
+  # TODO: converge these all into console and use unsupported_reason(:console) for all
   supports :html5_console do
-    reason   = _("VM Console not supported because VM is not powered on") unless current_state == "on"
-    reason ||= _("VM Console not supported because VM is orphaned")       if orphaned?
-    reason ||= _("VM Console not supported because VM is archived")       if archived?
-    unsupported_reason_add(:html5_console, reason) if reason
+    return _("VM Console not supported because VM is not powered on") unless current_state == "on"
+    return _("VM Console not supported because VM is orphaned")       if orphaned?
+    return _("VM Console not supported because VM is archived")       if archived?
   end
   supports :launch_html5_console
 
   supports :native_console do
-    reason ||= _("VM Console not supported because VM is orphaned") if orphaned?
-    reason ||= _("VM Console not supported because VM is archived") if archived?
-    unsupported_reason_add(:native_console, reason) if reason
+    return _("VM Console not supported because VM is orphaned") if orphaned?
+    return _("VM Console not supported because VM is archived") if archived?
   end
 
   supports :resize do
-    unsupported_reason_add(:resize, _('The VM is not powered off')) unless current_state == "off"
-    unsupported_reason_add(:resize, _('The VM is not connected to a provider')) unless ext_management_system
-    unsupported_reason_add(:resize, _('SAP VM resize not supported')) if flavor.kind_of?(ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SAPProfile)
+    return _('The VM is not powered off') unless current_state == "off"
+    return _('The VM is not connected to a provider') unless ext_management_system
+    return _('SAP VM resize not supported') if flavor.kind_of?(ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SAPProfile)
   end
 
   def cloud_instance_id

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager/cloud_subnet.rb
@@ -1,9 +1,7 @@
 class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager::CloudSubnet < ::CloudSubnet
   supports :create
   supports :delete do
-    if number_of(:vms) > 0
-      unsupported_reason_add(:delete, _("The Network has active VMIs related to it"))
-    end
+    _("The Network has active VMIs related to it") if number_of(:vms) > 0
   end
 
   def self.params_for_create(_ems)

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
@@ -2,18 +2,18 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
   supports :create
   supports :clone
   supports :delete do
-    unsupported_reason_add(:delete, _("the volume is not connected to an active Provider")) unless ext_management_system
-    unsupported_reason_add(:delete, _("cannot delete volume that is in use.")) if status == "in-use"
+    return _("the volume is not connected to an active Provider") unless ext_management_system
+    return _("cannot delete volume that is in use.") if status == "in-use"
   end
   supports_not :snapshot_create
   supports_not :update
   supports :attach do
-    unsupported_reason_add(:attach, _("the volume is not connected to an active Provider")) unless ext_management_system
-    unsupported_reason_add(:attach, _("cannot attach non-shareable volume that is in use.")) if status == "in-use" && !multi_attachment
+    return _("the volume is not connected to an active Provider") unless ext_management_system
+    return _("cannot attach non-shareable volume that is in use.") if status == "in-use" && !multi_attachment
   end
   supports :detach do
-    unsupported_reason_add(:detach, _("the volume is not connected to an active Provider")) unless ext_management_system
-    unsupported_reason_add(:detach, _("the volume status is '%{status}' but should be 'in-use'") % {:status => status}) unless status == "in-use"
+    return _("the volume is not connected to an active Provider") unless ext_management_system
+    return _("the volume status is '%{status}' but should be 'in-use'") % {:status => status} unless status == "in-use"
   end
 
   def available_vms

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/template.rb
@@ -6,9 +6,9 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Template < ManageIQ::Pro
 
   supports :provisioning do
     if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports_provisioning?
+      ext_management_system.unsupported_reason(:provisioning)
     else
-      unsupported_reason_add(:provisioning, _('not connected to ems'))
+      _('not connected to ems')
     end
   end
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
@@ -70,7 +70,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
 
   # Show reboot in the instance menu when on.
   supports :reboot_guest do
-    unsupported_reason_add(:reboot_guest, _('The VM is not powered on')) unless current_state == 'on'
+    _('The VM is not powered on') unless current_state == 'on'
   end
 
   # Gracefully reboot the quest.
@@ -92,7 +92,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
 
   # Tell UI to show reset in UI only when VM is on.
   supports :reset do
-    unsupported_reason_add(:reset, _('The VM is not powered on')) unless current_state == "on"
+    _('The VM is not powered on') unless current_state == "on"
   end
 
   # Force the the VM to restart.
@@ -101,7 +101,7 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
   end
 
   supports :terminate do
-    unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports_control?
+    unsupported_reason(:control)
   end
 
   def raw_destroy
@@ -112,8 +112,8 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
   end
 
   supports :resize do
-    unsupported_reason_add(:resize, _('The VM is not powered off')) unless current_state == "off"
-    unsupported_reason_add(:resize, _('The VM is not connected to a provider')) unless ext_management_system
+    return _('The VM is not powered off') unless current_state == "off"
+    return _('The VM is not connected to a provider') unless ext_management_system
   end
 
   def raw_resize(options)

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_network.rb
@@ -4,9 +4,9 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudNetwork < ::Cloud
   supports :create
   supports :delete do
     if ext_management_system.nil?
-      unsupported_reason_add(:delete_cloud_network, _("The Cloud Network is not connected to an active %{table}") % {
+      _("The Cloud Network is not connected to an active %{table}") % {
         :table => ui_lookup(:table => "ext_management_systems")
-      })
+      }
     end
   end
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager/cloud_subnet.rb
@@ -4,14 +4,13 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager::CloudSubnet < ::CloudS
   supports :create
   supports :delete do
     if ext_management_system.nil?
-      unsupported_reason_add(:delete, _("The subnet is not connected to an active %{table}") % {
+      _("The subnet is not connected to an active %{table}") % {
         :table => ui_lookup(:table => "ext_management_systems")
-      })
-    end
-    if number_of(:vms) > 0
-      unsupported_reason_add(:delete, _("The subnet has an active %{table}") % {
+      }
+    elsif number_of(:vms) > 0
+      _("The subnet has an active %{table}") % {
         :table => ui_lookup(:table => "vm_cloud")
-      })
+      }
     end
   end
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager/cloud_volume.rb
@@ -2,9 +2,9 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager::CloudVolume < ::CloudV
   supports :create
   supports :delete do
     if ext_management_system.nil?
-      unsupported_reason_add(:delete_volume, _("The Cloud Volume is not connected to an active %{table}") % {
+      _("The Cloud Volume is not connected to an active %{table}") % {
         :table => ui_lookup(:table => "ext_management_systems")
-      })
+      }
     end
   end
 


### PR DESCRIPTION
part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Dropping use of supports_feature?. Using `supports?(feature)` instead
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
