### PR TITLE
Fix PowerVS Regions ems_type method

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/regions.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/regions.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::Regions < ManageIQ::Pr
     private
 
     def ems_type
-      :ibm_cloud_power_virtual_servers
+      :ems_ibm_cloud_power_virtual_servers
     end
 
     def regions_yml

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,7 @@
 :ems:
   :ems_ibm_cloud_power_virtual_servers:
+    :additional_regions: {}
+    :disabled_regions: []
     :event_handling:
       :event_groups:
         :addition:

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/regions_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/regions_spec.rb
@@ -1,0 +1,95 @@
+RSpec.describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::Regions do
+  let(:ems_settings_name) { :ems_ibm_cloud_power_virtual_servers }
+  let(:additional_regions) { {:mars => {:name => :mars, :description => "The Red Planet", :hostname => "mars.power-iaas.cloud.ibm.com"}} }
+  let(:disabled_regions) { ["dal"] }
+
+  describe ".regions" do
+    it "returns regions" do
+      expect(described_class.regions.count).not_to be_zero
+    end
+
+    context "with additional_regions" do
+      before do
+        stub_settings_merge(
+          :ems => {ems_settings_name => {:additional_regions => additional_regions}}
+        )
+      end
+
+      it "includes the additional region" do
+        expect(described_class.regions).to include("mars" => {:name => :mars, :description => "The Red Planet", :hostname => "mars.power-iaas.cloud.ibm.com"})
+      end
+    end
+
+    context "with disabled_regions" do
+      before do
+        stub_settings_merge(
+          :ems => {ems_settings_name => {:disabled_regions => disabled_regions}}
+        )
+      end
+
+      it "excluded the additional region" do
+        expect(described_class.regions).not_to include("dal")
+      end
+    end
+  end
+
+  describe ".all" do
+    it "returns regions" do
+      expect(described_class.all.count).not_to be_zero
+    end
+
+    context "with additional_regions" do
+      before do
+        stub_settings_merge(
+          :ems => {ems_settings_name => {:additional_regions => additional_regions}}
+        )
+      end
+
+      it "includes the additional region" do
+        expect(described_class.all).to include({:name => :mars, :description => "The Red Planet", :hostname => "mars.power-iaas.cloud.ibm.com"})
+      end
+    end
+
+    context "with disabled_regions" do
+      before do
+        stub_settings_merge(
+          :ems => {ems_settings_name => {:disabled_regions => disabled_regions}}
+        )
+      end
+
+      it "excluded the additional region" do
+        expect(described_class.regions).not_to include("dal")
+      end
+    end
+  end
+
+  describe ".names" do
+    it "returns regions" do
+      expect(described_class.names.count).not_to be_zero
+    end
+
+    context "with additional_regions" do
+      before do
+        stub_settings_merge(
+          :ems => {ems_settings_name => {:additional_regions => additional_regions}}
+        )
+      end
+
+      it "includes the additional region" do
+        expect(described_class.names).to include("mars")
+      end
+    end
+
+    context "with disabled_regions" do
+      before do
+        stub_settings_merge(
+          :ems => {ems_settings_name => {:disabled_regions => disabled_regions}}
+        )
+      end
+
+      it "excluded the additional region" do
+        expect(described_class.regions).not_to include("dal")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The Regions ems_type value needs to be prefixed with `ems_`. The incorrect value prevents `additional_regions` and `disabled_regions` from functioning properly.