### PR TITLE
Remove return from supports block

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -20,28 +20,43 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
   supports_not :suspend
 
   supports :publish do
-    return _("Publish not supported because VM is blank")    if blank?
-    return _("Publish not supported because VM is orphaned") if orphaned?
-    return _("Publish not supported because VM is archived") if archived?
+    if blank?
+      _("Publish not supported because VM is blank")
+    elsif orphaned?
+      _("Publish not supported because VM is orphaned")
+    elsif archived?
+      _("Publish not supported because VM is archived")
+    end
   end
 
   # TODO: converge these all into console and use unsupported_reason(:console) for all
   supports :html5_console do
-    return _("VM Console not supported because VM is not powered on") unless current_state == "on"
-    return _("VM Console not supported because VM is orphaned")       if orphaned?
-    return _("VM Console not supported because VM is archived")       if archived?
+    if current_state != "on"
+      _("VM Console not supported because VM is not powered on")
+    elsif orphaned?
+      _("VM Console not supported because VM is orphaned")
+    elsif archived?
+      _("VM Console not supported because VM is archived")
+    end
   end
   supports :launch_html5_console
 
   supports :native_console do
-    return _("VM Console not supported because VM is orphaned") if orphaned?
-    return _("VM Console not supported because VM is archived") if archived?
+    if orphaned?
+      _("VM Console not supported because VM is orphaned")
+    elsif archived?
+      _("VM Console not supported because VM is archived")
+    end
   end
 
   supports :resize do
-    return _('The VM is not powered off') unless current_state == "off"
-    return _('The VM is not connected to a provider') unless ext_management_system
-    return _('SAP VM resize not supported') if flavor.kind_of?(ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SAPProfile)
+    if current_state != "off"
+      _('The VM is not powered off')
+    elsif ext_management_system.nil?
+      _('The VM is not connected to a provider')
+    elsif flavor.kind_of?(ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SAPProfile)
+      _('SAP VM resize not supported')
+    end
   end
 
   def cloud_instance_id

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager/cloud_volume.rb
@@ -2,18 +2,27 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager::CloudV
   supports :create
   supports :clone
   supports :delete do
-    return _("the volume is not connected to an active Provider") unless ext_management_system
-    return _("cannot delete volume that is in use.") if status == "in-use"
+    if ext_management_system.nil?
+      _("the volume is not connected to an active Provider")
+    elsif status == "in-use"
+      _("cannot delete volume that is in use.")
+    end
   end
   supports_not :snapshot_create
   supports_not :update
   supports :attach do
-    return _("the volume is not connected to an active Provider") unless ext_management_system
-    return _("cannot attach non-shareable volume that is in use.") if status == "in-use" && !multi_attachment
+    if ext_management_system.nil?
+      _("the volume is not connected to an active Provider")
+    elsif status == "in-use" && !multi_attachment
+      _("cannot attach non-shareable volume that is in use.")
+    end
   end
   supports :detach do
-    return _("the volume is not connected to an active Provider") unless ext_management_system
-    return _("the volume status is '%{status}' but should be 'in-use'") % {:status => status} unless status == "in-use"
+    if ext_management_system.nil?
+      _("the volume is not connected to an active Provider")
+    elsif status != "in-use"
+      _("the volume status is '%{status}' but should be 'in-use'") % {:status => status}
+    end
   end
 
   def available_vms

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/vm.rb
@@ -112,8 +112,11 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::Vm < ManageIQ::Providers
   end
 
   supports :resize do
-    return _('The VM is not powered off') unless current_state == "off"
-    return _('The VM is not connected to a provider') unless ext_management_system
+    if current_state != "off"
+      _('The VM is not powered off')
+    elsif ext_management_system.nil?
+      _('The VM is not connected to a provider')
+    end
   end
 
   def raw_resize(options)


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/22898 (as a followup)

Introduced by https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/486

you can not have a return in a block. It causes a LongJump error Besides, it tries to return from inside the calling block - not what we want.
