### PR TITLE
Delegate refresh_ems class method to parent cloud manager

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/network_manager.rb
@@ -22,6 +22,10 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::NetworkManager < Manag
            :to        => :parent_manager,
            :allow_nil => true
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager
+  end
+
   def image_name
     "ibm_power_vs"
   end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
@@ -26,6 +26,10 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager < Manag
   supports :cloud_volume
   supports :cloud_volume_create
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager
+  end
+
   def image_name
     "ibm_power_vs"
   end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/network_manager.rb
@@ -23,6 +23,10 @@ class ManageIQ::Providers::IbmCloud::VPC::NetworkManager < ManageIQ::Providers::
            :to        => :parent_manager,
            :allow_nil => true
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::IbmCloud::VPC::CloudManager
+  end
+
   def image_name
     "ibm_cloud"
   end

--- a/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/storage_manager.rb
@@ -24,6 +24,10 @@ class ManageIQ::Providers::IbmCloud::VPC::StorageManager < ManageIQ::Providers::
   supports :cloud_volume
   supports :cloud_volume_create
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::IbmCloud::VPC::CloudManager
+  end
+
   def image_name
     "ibm_cloud"
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -77,6 +77,10 @@
   :ibm_cloud_power_virtual_servers:
     :refresh_interval: 15.minutes
     :allow_targeted_refresh: true
+  :ibm_cloud_power_virtual_servers_network:
+    :refresh_interval: 0
+  :ibm_cloud_power_virtual_servers_storage:
+    :refresh_interval: 0
   :iks:
     :refresh_interval: 15.minutes
     :streaming_refresh: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -68,6 +68,10 @@
   :ibm_vpc:
     :refresh_interval: 15.minutes
     :allow_targeted_refresh: true
+  :ibm_cloud_vpc_network:
+    :refresh_interval: 0
+  :ibm_cloud_vpc_storage:
+    :refresh_interval: 0
   :ibm_cloud_object_storage:
     :refresh_interval: 15.minutes
   :ibm_cloud_power_virtual_servers:


### PR DESCRIPTION
Reasoning here: https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

@miq-bot assign @agrare
@miq-bot add_label bug
@miq-bot add_reviewer @agrare