### PR TITLE
Force bundler to the latest version on Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ matrix.ruby-version }}"
+        bundler: "${{ matrix.ruby-version == '3.1' && 'latest' || 'default' }}"
         bundler-cache: true
       timeout-minutes: 30
     - name: Prepare tests


### PR DESCRIPTION
We noticed that our cache sizes were growing enormously, namely in the git repositories, where the git directory is not git gc'd. The bundler shipped with Ruby 3.1, bundler 2.3.27, exhibits the problem, whereas newer bundlers > 2.4.0 seem to have mitigated the problem because of the underlying change to how git respositories are shallow clones.

@agrare Please review.