### PR TITLE
Add schedule tab with "Time until Retirement"

### DIFF
--- a/content/miq_dialogs/miq_provision_ibm_vpc_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_vpc_dialogs_template.yaml
@@ -14,8 +14,61 @@
 
     :schedule:
       :description: Schedule
-      :fields: {}
-      :display: :hide
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :vm_auto_start:
+          :values:
+            false: 0
+            true: 1
+          :description: Power on virtual machines after creation
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+        :retirement:
+          :values:
+            0: Indefinite
+            1.month: 1 Month
+            3.months: 3 Months
+            6.months: 6 Months
+          :description: Time until Retirement
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
+                1.week: 1 Week
+                2.weeks: 2 Weeks
+                30.days: 30 Days
+              :include_equals: false
+              :field: :retirement
+            :method: :values_less_then
+          :description: Retirement Warning
+          :required: true
+          :display: :edit
+          :default: 1.week
+          :data_type: :integer
+      :display: :show
 
     :purpose:
       :description: Purpose


### PR DESCRIPTION
This was missing and thus wasn't easy to set a time to retire the instance

![image](https://github.com/user-attachments/assets/228833cb-0d45-4410-af53-dba02442d4d5)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
