### PR TITLE
Fix metrics endpoint DDF Form

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::CloudManager
   supports :create
-  supports :metrics
+  supports :metrics do
+    _("No metrics endpoint has been added") if metrics_endpoint.nil?
+  end
   supports :catalog
   supports :provisioning
   supports :storage_manager
@@ -52,6 +54,10 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager < ManageIQ::Providers::Cl
 
   def authentications_to_validate
     authentication_for_providers.collect(&:authentication_type)
+  end
+
+  def metrics_endpoint
+    endpoints.find_by(:role => "metrics")
   end
 
   def self.hostname_required?

--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_capture.rb
@@ -55,8 +55,8 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::MetricsCapture < ManageI
     counters_by_mor = {target.ems_ref => VIM_STYLE_COUNTERS}
     counter_values_by_mor = {target.ems_ref => {}}
 
-    metrics_endpoint = ext_management_system.endpoints.find_by(:role => "metrics")
-    raise _("Missing monitoring instance id") if metrics_endpoint.nil?
+    metrics_endpoint = ext_management_system.metrics_endpoint
+    raise _("No metrics endpoint has been added") if metrics_endpoint.nil?
 
     instance_id = metrics_endpoint.options["monitoring_instance_id"]
 

--- a/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/manager_mixin.rb
@@ -108,19 +108,21 @@ module ManageIQ::Providers::IbmCloud::VPC::ManagerMixin
                         {
                           :label => _('Enabled'),
                           :value => 'enable_metrics',
+                          :pivot => 'endpoints.metrics.options.monitoring_instance_id'
                         },
                       ],
                     },
                     {
-                      :component  => 'password-field',
-                      :id         => 'endpoints.metrics.options.monitoring_instance_id',
-                      :name       => 'endpoints.metrics.options.monitoring_instance_id',
-                      :label      => _('IBM Cloud Monitoring Instance GUID'),
-                      :isRequired => true,
-                      :condition  => {
+                      :component              => 'password-field',
+                      :id                     => 'endpoints.metrics.options.monitoring_instance_id',
+                      :name                   => 'endpoints.metrics.options.monitoring_instance_id',
+                      :label                  => _('IBM Cloud Monitoring Instance GUID'),
+                      :validationDependencies => %w[type zone_id metrics_selection],
+                      :isRequired             => true,
+                      :condition              => {
                         :when => "metrics_selection",
                         :is   => 'enable_metrics',
-                      },
+                      }
                     },
                   ]
                 },


### PR DESCRIPTION
With this PR, editing the provider with an existing metrics endpoint shows up as "Enabled" properly:

![image](https://github.com/user-attachments/assets/404fe634-1ef4-4ec4-b27c-d24638c8522d)


Fixes https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/522
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
