### PR TITLE
Fix uninitialized constant IBMCloudSdkCore

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/ibm_cloud/vpc/cloud_manager/metrics_capture.rb
@@ -136,7 +136,10 @@ class ManageIQ::Providers::IbmCloud::VPC::CloudManager::MetricsCapture < ManageI
   end
 
   def iam_access_token
-    @iam_access_token ||= IBMCloudSdkCore::IAMTokenManager.new(:apikey => ext_management_system.authentication_key("default")).access_token
+    @iam_access_token ||= begin
+      require 'ibm_cloud_sdk_core'
+      IBMCloudSdkCore::IAMTokenManager.new(:apikey => ext_management_system.authentication_key("default")).access_token
+    end
   end
 
   def store_datapoints_with_interpolation!(end_time, timestamps, datapoints, counter_key, counter_values_by_mor)


### PR DESCRIPTION
Fix `uninitialized constant IBMCloudSdkCore` in VPC Metrics Capture

Fixes https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/525

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
