### PR TITLE
Use virtual_has_many for virtual relations

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/storage_manager.rb
@@ -20,8 +20,8 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::StorageManager < Manag
            :to        => :parent_manager,
            :allow_nil => true
 
-  virtual_delegate :cloud_tenants, :to => :parent_manager, :allow_nil => true
-  virtual_delegate :volume_availability_zones, :to => :parent_manager, :allow_nil => true
+  virtual_has_many :cloud_tenants
+  virtual_has_many :volume_availability_zones
 
   supports :cloud_volume
   supports :cloud_volume_create


### PR DESCRIPTION
part of:
- [ ] https://github.com/ManageIQ/manageiq/pull/23486

virtual_delegate is only valid for column delegations not relations
Using a `vitual_has_many` instead

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
