### PR TITLE
Replace PowerVS System Pools API with Datacenters API

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/collector/power_virtual_servers.rb
@@ -113,8 +113,8 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers <
     @sshkeys ||= tenants_api.pcloud_tenants_get(pcloud_tenant_id).ssh_keys
   end
 
-  def system_pools
-    @system_pools ||= system_pools_api.pcloud_systempools_get(cloud_instance_id)
+  def datacenter
+    @datacenter ||= datacenters_api.v1_datacenters_get(pcloud_location)
   end
 
   def storage_types
@@ -163,6 +163,10 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers <
     cloud_manager.pcloud_tenant_id(connection)
   end
 
+  def pcloud_location
+    cloud_manager.pcloud_location(connection)
+  end
+
   def placement_groups_api
     @placement_groups_api ||= IbmCloudPower::PCloudPlacementGroupsApi.new(connection)
   end
@@ -187,8 +191,8 @@ class ManageIQ::Providers::IbmCloud::Inventory::Collector::PowerVirtualServers <
     @storage_capacity_api ||= IbmCloudPower::PCloudStorageCapacityApi.new(connection)
   end
 
-  def system_pools_api
-    @system_pools_api ||= IbmCloudPower::PCloudSystemPoolsApi.new(connection)
+  def datacenters_api
+    @datacenters_api ||= IbmCloudPower::DatacentersApi.new(connection)
   end
 
   def tenants_api

--- a/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
+++ b/app/models/manageiq/providers/ibm_cloud/inventory/parser/power_virtual_servers.rb
@@ -267,11 +267,11 @@ class ManageIQ::Providers::IbmCloud::Inventory::Parser::PowerVirtualServers < Ma
   end
 
   def flavors
-    collector.system_pools.each_value do |value|
+    collector.datacenter.capabilities_details.supported_systems.general.each do |system_type|
       persister.flavors.build(
         :type    => "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::SystemType",
-        :ems_ref => value.type,
-        :name    => value.type
+        :ems_ref => system_type,
+        :name    => system_type
       )
     end
     if collector.cloud_instance.capabilities.include?('sap')

--- a/lib/tasks_private/power_virtual_servers.rake
+++ b/lib/tasks_private/power_virtual_servers.rake
@@ -99,7 +99,7 @@ namespace :vcr do
       :instances => [
         IbmCloudPower::PVMInstanceCreate.new(
           "server_name"   => "test-instance-aix-s922-shared-tier1",
-          "image_id"      => "7300-00-01",
+          "image_id"      => "7300-03-00",
           "sys_type"      => "s922",
           "proc_type"     => "shared",
           "storage_type"  => "tier1",
@@ -115,7 +115,7 @@ namespace :vcr do
         ),
         IbmCloudPower::PVMInstanceCreate.new(
           "server_name"     => "test-instance-ibmi-s922-capped-tier1",
-          "image_id"        => "IBMi-75-02-2984-1",
+          "image_id"        => "IBMi-75-05-2984-1",
           "sys_type"        => "s922",
           "proc_type"       => "capped",
           "storage_type"    => "tier1",
@@ -132,7 +132,7 @@ namespace :vcr do
         ),
         IbmCloudPower::PVMInstanceCreate.new(
           "server_name"     => "test-instance-centos-e980-dedicated-tier3",
-          "image_id"        => "CentOS-Stream-8",
+          "image_id"        => "CentOS-Stream-9",
           "sys_type"        => "e980",
           "proc_type"       => "dedicated",
           "storage_type"    => "tier3",
@@ -148,7 +148,7 @@ namespace :vcr do
         ),
         IbmCloudPower::PVMInstanceCreate.new(
           "server_name"           => "test-instance-rhel-s922-shared-tier3",
-          "image_id"              => "RHEL8-SP6",
+          "image_id"              => "RHEL9-SP4-BYOL",
           "sys_type"              => "s922",
           "proc_type"             => "shared",
           "storage_type"          => "tier3",
@@ -165,7 +165,7 @@ namespace :vcr do
         ),
         IbmCloudPower::PVMInstanceCreate.new(
           "server_name"     => "test-instance-sles-s922-shared-tier3",
-          "image_id"        => "SLES15-SP4",
+          "image_id"        => "SLES15-SP6-BYOL",
           "sys_type"        => "s922",
           "proc_type"       => "shared",
           "storage_type"    => "tier3",
@@ -184,7 +184,7 @@ namespace :vcr do
         ),
         IbmCloudPower::PVMInstanceCreate.new(
           "server_name"     => "test-instance-rhcos-s922-shared-tier3",
-          "image_id"        => "rhcos-4.8",
+          "image_id"        => "rhcos-416",
           "sys_type"        => "s922",
           "proc_type"       => "shared",
           "storage_type"    => "tier3",

--- a/lib/tasks_private/power_virtual_servers.rake
+++ b/lib/tasks_private/power_virtual_servers.rake
@@ -426,6 +426,7 @@ namespace :vcr do
             instance
           )[0]
 
+          sleep(60)
           pvm_instance_id = created_instance.pvm_instance_id
           until created_instance.status == "ACTIVE"
             created_instance = pvm_instances_api.pcloud_pvminstances_get(

--- a/manageiq-providers-ibm_cloud.gemspec
+++ b/manageiq-providers-ibm_cloud.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ibm_cloud_iam", "~> 1.0"
-  spec.add_dependency "ibm_cloud_power", "~> 2.1"
+  spec.add_dependency "ibm_cloud_power", "~> 3.0"
   spec.add_dependency "ibm_cloud_resource_controller", "~> 2.0", ">= 2.0.2"
   spec.add_dependency "ibm-cloud-sdk", "~> 0.1"
   spec.add_dependency "ibm_cloud_activity_tracker", "~> 0.1", ">= 0.1.2"

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -238,7 +238,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
     end
 
     def assert_specific_template
-      template_name = "7300-00-01"
+      template_name = "7300-03-00"
       template = ems.miq_templates.find_by(:name => template_name)
       expect(template).to have_attributes(
         :name             => template_name,

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher_spec.rb
@@ -142,8 +142,8 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
       expect(CloudVolume.count).to eq(10)
       expect(CloudNetwork.count).to eq(4)
       expect(CloudSubnet.count).to eq(4)
-      expect(CloudSubnetNetworkPort.count).to eq(8)
-      expect(Flavor.count).to eq(58)
+      expect(CloudSubnetNetworkPort.count).to eq(12)
+      expect(Flavor.count).to eq(130)
       expect(MiqTemplate.count).to eq(6)
       expect(ManageIQ::Providers::CloudManager::AuthKeyPair.count).to be > 1
       expect(NetworkPort.count).to eq(8)
@@ -168,7 +168,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
 
     def assert_cloud_manager
       expect(ems).to have_attributes(
-        :provider_region => "mon01"
+        :provider_region => "dal10"
       )
     end
 
@@ -221,7 +221,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
       )
 
       expect(vm.advanced_settings.find { |setting| setting['name'] == 'pin_policy' }).to have_attributes(
-        :value        => "none"
+        :value        => "soft"
       )
 
       expect(vm.snapshots.first).to have_attributes(
@@ -292,7 +292,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Refre
         :device_type => "VmOrTemplate"
       )
 
-      expect(network_port.cloud_subnets.count).to eq(1)
+      expect(network_port.cloud_subnets.count).to eq(2)
     end
 
     def assert_specific_cloud_volume

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ end
 # Replace the contents of the token before writing to file.
 def replace_token_contents(interaction)
   data = JSON.parse(interaction.response.body, :symbolize_names => true)
-  data.merge!({:refresh_token => 'REFRESH_TOKEN', :ims_user_id => '22222', :expiration => Date.new(2100, 1, 1).to_time.to_i})
+  data.merge!({:access_token => 'ACCESS_TOKEN', :refresh_token => 'REFRESH_TOKEN', :ims_user_id => '22222', :expiration => Date.new(2100, 1, 1).to_time.to_i})
   interaction.response.body = data.to_json.force_encoding('ASCII-8BIT')
 
   transient_headers = %w[].freeze

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,8 +69,8 @@ VCR.configure do |config|
   config.cassette_library_dir = File.join(ManageIQ::Providers::IbmCloud::Engine.root, 'spec/vcr_cassettes')
 
   config.before_record do |i|
-    replace_token_contents(i) if i.request.uri == "https://iam.cloud.ibm.com/identity/token"
-    vpc_sanitizer(i) if i.request.uri.match?('iaas.cloud.ibm') || i.request.uri.match?('tags.global-search-tagging')
+    replace_token_contents(i) if i.request.uri.start_with?("https://iam.cloud.ibm.com/identity/token")
+    vpc_sanitizer(i) if i.request.uri.match?('cloud.ibm') || i.request.uri.match?('tags.global-search-tagging')
   end
 
   secrets = Rails.application.secrets

--- a/spec/vcr_cassettes/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher.yml
@@ -22,12 +22,10 @@ http_interactions:
     headers:
       X-Content-Type-Options:
       - nosniff
-      Transaction-Id:
-      - d3Y2MnA-8a0f73483ffc482e85fc4ad3d0eddd95
-      X-Request-Id:
-      - 9b4c989f-0a8e-4939-89a9-b4946f2a2cde
+      Ibm-Cloud-Service-Name:
+      - iam-identity
       X-Correlation-Id:
-      - d3Y2MnA-8a0f73483ffc482e85fc4ad3d0eddd95
+      - YnNzOGw-5a3b6067b977457795be3debcfda6740
       Cache-Control:
       - no-cache, no-store, must-revalidate
       Expires:
@@ -39,22 +37,20 @@ http_interactions:
       Content-Language:
       - en-US
       Content-Length:
-      - '1532'
+      - '1635'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 18 Jan 2024 19:27:07 GMT
       Connection:
       - keep-alive
       Akamai-Grn:
-      - 0.4df47568.1705606027.b675149a
+      - 0.cb17dd17.1750863186.c79fb207
       X-Proxy-Upstream-Service-Time:
-      - '159'
+      - '239'
     body:
       encoding: ASCII-8BIT
-      string: '{"access_token":"IAMBEARERTOKEN","refresh_token":"not_supported","ims_user_id":7771420,"token_type":"Bearer","expires_in":3600,"expiration":1705609624,"scope":"ibm
+      string: '{"access_token":"ACCESS_TOKEN","refresh_token":"REFRESH_TOKEN","ims_user_id":"22222","token_type":"Bearer","expires_in":3600,"expiration":4102466400,"scope":"ibm
         openid"}'
-  recorded_at: Thu, 18 Jan 2024 19:27:07 GMT
+  recorded_at: Wed, 25 Jun 2025 14:53:06 GMT
 - request:
     method: get
     uri: https://resource-controller.cloud.ibm.com/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID
@@ -63,34 +59,31 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - ibm_cloud_resource_controller-ruby-sdk-2.0.2 x86_64-pc-linux-gnu ruby-3.1.4
+      - ibm_cloud_resource_controller-ruby-sdk-2.0.3 x86_64-pc-linux ruby-3.3.8
       X-Ibmcloud-Sdk-Analytics:
       - service_name=resource_controller;service_version=V2;operation_id=get_resource_instance
       Accept:
       - application/json
-      Authorization:
-      - Bearer IAMBEARERTOKEN
+      Authorization: Bearer xxxxxx
       Connection:
       - close
   response:
     status:
       code: 200
-      message: OK
+      message:
     headers:
       Content-Type:
       - application/json
       Request-Id:
-      - 3c46bfcb-5acf-4fd7-848d-789288361c90
+      - 626c-090a123882a43ab7
       Retry-After:
       - '0'
       Strict-Transport-Security:
       - max-age=31536000;includeSubDomains
-      Transaction-Id:
-      - bss-e9adacd3b34aa054
       X-Content-Type-Options:
       - nosniff
-      X-Global-Transaction-Id:
-      - bss-e9adacd3b34aa054
+      X-Correlation-Id:
+      - 626c-6cb7c8ec7df16d7e
       X-Op-Completion-Time:
       - ''
       X-Ratelimit-Limit:
@@ -99,47 +92,37 @@ http_interactions:
       - '99'
       X-Ratelimit-Reset:
       - '0'
-      X-Request-Id:
-      - 3c46bfcb-5acf-4fd7-848d-789288361c90
-      X-Transaction-Id:
-      - bss-e9adacd3b34aa054
-      X-Envoy-Upstream-Service-Time:
-      - '381'
-      Server:
-      - istio-envoy
       Content-Length:
-      - '2116'
+      - '2115'
       Expires:
-      - Thu, 18 Jan 2024 19:27:07 GMT
+      - Wed, 25 Jun 2025 14:53:07 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
-      Date:
-      - Thu, 18 Jan 2024 19:27:07 GMT
       Connection:
       - close
     body:
       encoding: UTF-8
-      string: '{"id":"crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","guid":"IBM_CLOUD_POWERVS_INSTANCE_ID","url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID","created_at":"2022-01-04T19:19:27.00879531Z","updated_at":"2022-05-28T10:58:12.563242645Z","deleted_at":null,"created_by":"IBMid-2700063YVN","updated_by":"IBMid-2700063YVN","deleted_by":"","scheduled_reclaim_at":null,"restored_at":null,"scheduled_reclaim_by":"","restored_by":"","name":"rdr-power.control.plane.test-hcm-mon01-miq-specs","region_id":"mon01","account_id":"1fdf5effc3f945688c021cd0a8b45c4d","reseller_channel_id":"","resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","resource_group_id":"2f9167fcfa9c4e2a951c5d8fa22bd01f","resource_group_crn":"crn:v1:bluemix:public:resource-controller::a/1fdf5effc3f945688c021cd0a8b45c4d::resource-group:2f9167fcfa9c4e2a951c5d8fa22bd01f","target_crn":"crn:v1:bluemix:public:globalcatalog::::deployment:f165dd34-3a40-423b-9d95-e90a23f724dd%3Amon0159210","allow_cleanup":false,"crn":"crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","state":"active","type":"service_instance","resource_id":"abd259f0-9990-11e8-acc8-b9f54a8f1661","dashboard_url":"https://power-iaas.cloud.ibm.com/authenticate","last_operation":{"type":"create","state":"succeeded","async":true,"description":"service
+      string: '{"id":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","guid":"IBM_CLOUD_POWERVS_INSTANCE_ID","url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID","created_at":"2025-05-22T13:44:28.57250562Z","updated_at":"2025-05-22T13:45:11.597828983Z","deleted_at":null,"created_by":"IBMid-2700063YVN","updated_by":"","deleted_by":"","scheduled_reclaim_at":null,"restored_at":null,"scheduled_reclaim_by":"","restored_by":"","name":"rdr-power.control.plane.test-hcm-miq-specs","region_id":"us-east10","account_id":"1fdf5effc3f945688c021cd0a8b45c4d","reseller_channel_id":"","resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","resource_group_id":"2f9167fcfa9c4e2a951c5d8fa22bd01f","resource_group_crn":"crn:v1:bluemix:public:resource-controller::a/1fdf5effc3f945688c021cd0a8b45c4d::resource-group:2f9167fcfa9c4e2a951c5d8fa22bd01f","target_crn":"crn:v1:bluemix:public:globalcatalog::::deployment:f165dd34-3a40-423b-9d95-e90a23f724dd%3Aus-east1084023","allow_cleanup":false,"crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","state":"active","type":"composite_instance","resource_id":"abd259f0-9990-11e8-acc8-b9f54a8f1661","dashboard_url":null,"last_operation":{"type":"create","state":"succeeded","async":true,"description":"service
         instance IBM_CLOUD_POWERVS_INSTANCE_ID was provisioned successfully for account
-        1fdf5effc3f945688c021cd0a8b45c4d in region mon01","cancelable":false,"poll":false},"resource_aliases_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_aliases","resource_bindings_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_bindings","resource_keys_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_keys","plan_history":[{"resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","start_date":"2022-01-04T19:19:27.00879531Z","requestor_id":"IBMid-2700063YVN"}],"migrated":false,"controlled_by":"","locked":false}
+        1fdf5effc3f945688c021cd0a8b45c4d in region us-east10","cancelable":false,"poll":true},"resource_aliases_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_aliases","resource_bindings_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_bindings","resource_keys_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_keys","plan_history":[{"resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","start_date":"2025-05-22T13:44:28.57250562Z","requestor_id":"IBMid-2700063YVN"}],"migrated":false,"extensions":{"resourceCRNs":true},"controlled_by":"","locked":false,"onetime_credentials":false}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:27:07 GMT
+  recorded_at: Wed, 25 Jun 2025 14:53:07 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -152,64 +135,38 @@ http_interactions:
     headers:
       Content-Type:
       - application/json
+      X-Correlation-Id:
+      - a3669c5f-9610-4fc4-afb0-f0d8593ab8de
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"images":[{"creationDate":"2022-11-15T22:45:40.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/8de97d73-95c0-46e9-a509-0b10be36eded","imageID":"8de97d73-95c0-46e9-a509-0b10be36eded","lastUpdateDate":"2023-06-07T01:38:14.000Z","name":"7300-00-01","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"aix"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-15T22:45:06.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/7da758c0-949b-4b11-a306-dc7dfc33919e","imageID":"7da758c0-949b-4b11-a306-dc7dfc33919e","lastUpdateDate":"2023-06-07T01:38:15.000Z","name":"CentOS-Stream-8","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2024-01-18T18:41:35.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/9eebf535-9b78-450e-bffd-e7cb4d3c9e94","imageID":"9eebf535-9b78-450e-bffd-e7cb4d3c9e94","lastUpdateDate":"2024-01-18T18:41:35.000Z","name":"IBMi-75-02-2984-1","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-15T22:42:20.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/10d7c4a5-32a7-44a9-b9e1-9a428a4da5d9","imageID":"10d7c4a5-32a7-44a9-b9e1-9a428a4da5d9","lastUpdateDate":"2023-06-07T01:38:17.000Z","name":"RHEL8-SP6","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-12T11:36:56.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/a0198511-c877-4f6f-b1c3-64312fcdb92c","imageID":"a0198511-c877-4f6f-b1c3-64312fcdb92c","lastUpdateDate":"2023-06-07T01:38:19.000Z","name":"SLES15-SP4","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"sles"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-01-28T22:32:39.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/032d72bf-89f2-44a9-bbc4-ab898dd93309","imageID":"032d72bf-89f2-44a9-bbc4-ab898dd93309","lastUpdateDate":"2023-12-14T21:46:24.000Z","name":"rhcos-4.8","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"import","operatingSystem":"rhel"},"state":"active","storagePool":"General-Flash-81","storageType":"tier3"}]}
+      encoding: ASCII-8BIT
+      string: '{"images":[{"creationDate":"2025-06-12T13:30:49.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:05e43ffe-bf8e-4f4a-8dd8-2ebc747e9b33","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/05e43ffe-bf8e-4f4a-8dd8-2ebc747e9b33","imageID":"05e43ffe-bf8e-4f4a-8dd8-2ebc747e9b33","lastUpdateDate":"2025-06-12T13:30:49.000Z","name":"7300-03-00","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"aix"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2025-06-12T13:34:00.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:be0864af-8dda-465f-80e0-695715fb40f0","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/be0864af-8dda-465f-80e0-695715fb40f0","imageID":"be0864af-8dda-465f-80e0-695715fb40f0","lastUpdateDate":"2025-06-12T13:34:00.000Z","name":"CentOS-Stream-9","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2025-06-12T13:32:01.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:198a2763-0f16-4026-bc5d-77a3f6b8b5bc","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/198a2763-0f16-4026-bc5d-77a3f6b8b5bc","imageID":"198a2763-0f16-4026-bc5d-77a3f6b8b5bc","lastUpdateDate":"2025-06-12T13:32:01.000Z","name":"IBMi-75-05-2984-1","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2025-06-12T13:36:54.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:4c7f350e-218b-42c3-b11f-2e6eca8599d2","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/4c7f350e-218b-42c3-b11f-2e6eca8599d2","imageID":"4c7f350e-218b-42c3-b11f-2e6eca8599d2","lastUpdateDate":"2025-06-12T13:36:54.000Z","name":"RHEL9-SP4-BYOL","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2025-06-12T13:38:02.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:e3c7a731-aa96-493c-8390-1911269de574","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/e3c7a731-aa96-493c-8390-1911269de574","imageID":"e3c7a731-aa96-493c-8390-1911269de574","lastUpdateDate":"2025-06-12T13:38:02.000Z","name":"SLES15-SP6-BYOL","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"sles"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2025-06-12T19:27:42.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:e6b94e6c-8c6a-4a05-9718-afef367b4af9","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/e6b94e6c-8c6a-4a05-9718-afef367b4af9","imageID":"e6b94e6c-8c6a-4a05-9718-afef367b4af9","lastUpdateDate":"2025-06-12T19:29:23.000Z","name":"rhcos-416","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"import","operatingSystem":"rhel"},"state":"active","storagePool":"General-Flash-53","storageType":"tier1"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:27:09 GMT
+  recorded_at: Wed, 25 Jun 2025 14:57:44 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/system-pools
+    uri: https://us-east.power-iaas.cloud.ibm.com/v1/datacenters/us-east10
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"e980":{"capacity":{"cores":88,"memory":12564,"totalCores":null,"totalMemory":null},"coreMemoryRatio":64,"maxAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"maxCoresAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"maxMemoryAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"sharedCoreRatio":{"default":0.25,"max":1,"min":0.05},"systems":[{"cores":59.5,"id":1,"memory":11779,"totalCores":null,"totalMemory":null}],"type":"e980"},"s922":{"capacity":{"cores":15,"memory":935,"totalCores":null,"totalMemory":null},"coreMemoryRatio":64,"maxAvailable":{"cores":14.25,"memory":902,"totalCores":null,"totalMemory":null},"maxCoresAvailable":{"cores":14.25,"memory":897,"totalCores":null,"totalMemory":null},"maxMemoryAvailable":{"cores":6,"memory":902,"totalCores":null,"totalMemory":null},"sharedCoreRatio":{"default":0.25,"max":1,"min":0.05},"systems":[{"cores":14.25,"id":14,"memory":897,"totalCores":null,"totalMemory":null},{"cores":12.3,"id":25,"memory":895,"totalCores":null,"totalMemory":null},{"cores":11.75,"id":18,"memory":884,"totalCores":null,"totalMemory":null},{"cores":10.25,"id":12,"memory":849,"totalCores":null,"totalMemory":null},{"cores":9.5,"id":11,"memory":874,"totalCores":null,"totalMemory":null},{"cores":9,"id":15,"memory":880,"totalCores":null,"totalMemory":null},{"cores":8.25,"id":9,"memory":681,"totalCores":null,"totalMemory":null},{"cores":7.5,"id":8,"memory":843,"totalCores":null,"totalMemory":null},{"cores":6,"id":17,"memory":902,"totalCores":null,"totalMemory":null},{"cores":5.5,"id":23,"memory":598,"totalCores":null,"totalMemory":null},{"cores":4.5,"id":5,"memory":728,"totalCores":null,"totalMemory":null},{"cores":4.5,"id":21,"memory":738,"totalCores":null,"totalMemory":null},{"cores":4,"id":13,"memory":822,"totalCores":null,"totalMemory":null},{"cores":3.5,"id":10,"memory":624,"totalCores":null,"totalMemory":null},{"cores":1.5,"id":20,"memory":855,"totalCores":null,"totalMemory":null},{"cores":0.5,"id":24,"memory":519,"totalCores":null,"totalMemory":null},{"cores":0.26,"id":19,"memory":397,"totalCores":null,"totalMemory":null},{"cores":0.26,"id":16,"memory":485,"totalCores":null,"totalMemory":null},{"cores":0.01,"id":6,"memory":556,"totalCores":null,"totalMemory":null},{"cores":0,"id":4,"memory":533,"totalCores":null,"totalMemory":null},{"cores":0,"id":22,"memory":455,"totalCores":null,"totalMemory":null},{"cores":0,"id":7,"memory":320,"totalCores":null,"totalMemory":null}],"type":"s922"}}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:27:09 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -223,257 +180,40 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '752'
+      - '609'
+      X-Correlation-Id:
+      - fc1a66d4-3838-41f9-b21b-13bb19142737
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"capabilities":["cloud-connections","direct-link-transit-gateway","ibmi-software-licenses","linux","pinning","rhel-sap","sap","snapshots","volume-clone","vpn-connections","shared-processor-pools"],"cloudInstanceID":"c8d0ac7c30c944f0ac3288eb8bb74aaa","enabled":true,"initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"IBM_CLOUD_POWERVS_INSTANCE_ID","openstackID":"07389ca7-2266-4303-afd3-5babc1cebe20","pvmInstances":[],"region":"mon01","tenantID":"1fdf5effc3f945688c021cd0a8b45c4d","usage":{"instances":0,"memory":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0,"storageStandard":0}}
+      encoding: ASCII-8BIT
+      string: '{"capabilities":{"cloud-connections":false,"dedicated-hosts":true,"disaster-recovery-site":true,"metrics":true,"network-security-groups":true,"power-edge-router":true,"power-vpn-connections":false},"capabilitiesDetails":{"disasterRecovery":{"asynchronousReplication":{"enabled":true,"targetLocations":[{"region":"wdc07","status":"active"}]}},"supportedSystems":{"dedicated":["s1022","s922"],"general":["e1080","s1022","e980","s922"]}},"location":{"region":"us-east10","regionDisplayName":"Dallas
+        10","type":"data-center","url":"https://us-south.power-iaas.cloud.ibm.com"},"status":"active","type":"off-premises"}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:27:10 GMT
+  recorded_at: Wed, 25 Jun 2025 14:57:45 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/sap
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"profiles":[{"certified":true,"cores":16,"memory":1600,"profileID":"bh1-16x1600","type":"balanced"},{"certified":true,"cores":20,"memory":2000,"profileID":"bh1-20x2000","type":"balanced"},{"certified":true,"cores":22,"memory":2200,"profileID":"bh1-22x2200","type":"balanced"},{"certified":true,"cores":25,"memory":2500,"profileID":"bh1-25x2500","type":"balanced"},{"certified":true,"cores":30,"memory":3000,"profileID":"bh1-30x3000","type":"balanced"},{"certified":true,"cores":35,"memory":3500,"profileID":"bh1-35x3500","type":"balanced"},{"certified":true,"cores":40,"memory":4000,"profileID":"bh1-40x4000","type":"balanced"},{"certified":true,"cores":50,"memory":5000,"profileID":"bh1-50x5000","type":"balanced"},{"certified":true,"cores":60,"memory":6000,"profileID":"bh1-60x6000","type":"balanced"},{"certified":true,"cores":70,"memory":7000,"profileID":"bh1-70x7000","type":"balanced"},{"certified":true,"cores":80,"memory":8000,"profileID":"bh1-80x8000","type":"balanced"},{"certified":true,"cores":100,"memory":10000,"profileID":"bh1-100x10000","type":"balanced"},{"certified":true,"cores":120,"memory":12000,"profileID":"bh1-120x12000","type":"balanced"},{"certified":true,"cores":140,"memory":14000,"profileID":"bh1-140x14000","type":"balanced"},{"certified":true,"cores":60,"memory":3000,"profileID":"ch1-60x3000","type":"compute"},{"certified":true,"cores":70,"memory":3500,"profileID":"ch1-70x3500","type":"compute"},{"certified":true,"cores":80,"memory":4000,"profileID":"ch1-80x4000","type":"compute"},{"certified":true,"cores":100,"memory":5000,"profileID":"ch1-100x5000","type":"compute"},{"certified":true,"cores":120,"memory":6000,"profileID":"ch1-120x6000","type":"compute"},{"certified":true,"cores":140,"memory":7000,"profileID":"ch1-140x7000","type":"compute"},{"certified":true,"cores":8,"memory":1440,"profileID":"mh1-8x1440","type":"memory"},{"certified":true,"cores":10,"memory":1800,"profileID":"mh1-10x1800","type":"memory"},{"certified":true,"cores":12,"memory":2160,"profileID":"mh1-12x2160","type":"memory"},{"certified":true,"cores":16,"memory":2880,"profileID":"mh1-16x2880","type":"memory"},{"certified":true,"cores":20,"memory":3600,"profileID":"mh1-20x3600","type":"memory"},{"certified":true,"cores":22,"memory":3960,"profileID":"mh1-22x3960","type":"memory"},{"certified":true,"cores":25,"memory":4500,"profileID":"mh1-25x4500","type":"memory"},{"certified":true,"cores":30,"memory":5400,"profileID":"mh1-30x5400","type":"memory"},{"certified":true,"cores":35,"memory":6300,"profileID":"mh1-35x6300","type":"memory"},{"certified":true,"cores":40,"memory":7200,"profileID":"mh1-40x7200","type":"memory"},{"certified":true,"cores":50,"memory":9000,"profileID":"mh1-50x9000","type":"memory"},{"certified":true,"cores":60,"memory":10800,"profileID":"mh1-60x10800","type":"memory"},{"certified":true,"cores":70,"memory":12600,"profileID":"mh1-70x12600","type":"memory"},{"certified":true,"cores":80,"memory":14400,"profileID":"mh1-80x14400","type":"memory"},{"certified":true,"cores":90,"memory":16200,"profileID":"mh1-90x16200","type":"memory"},{"certified":true,"cores":100,"memory":18000,"profileID":"mh1-100x18000","type":"memory"},{"certified":true,"cores":4,"memory":128,"profileID":"ush1-4x128","type":"small"},{"certified":true,"cores":4,"memory":256,"profileID":"ush1-4x256","type":"small"},{"certified":true,"cores":4,"memory":384,"profileID":"ush1-4x384","type":"small"},{"certified":true,"cores":4,"memory":512,"profileID":"ush1-4x512","type":"small"},{"certified":true,"cores":4,"memory":768,"profileID":"ush1-4x768","type":"small"},{"certified":true,"cores":4,"memory":960,"profileID":"umh-4x960","type":"ultra-memory"},{"certified":true,"cores":6,"memory":1440,"profileID":"umh-6x1440","type":"ultra-memory"},{"certified":true,"cores":8,"memory":1920,"profileID":"umh-8x1920","type":"ultra-memory"},{"certified":true,"cores":10,"memory":2400,"profileID":"umh-10x2400","type":"ultra-memory"},{"certified":true,"cores":12,"memory":2880,"profileID":"umh-12x2880","type":"ultra-memory"},{"certified":true,"cores":16,"memory":3840,"profileID":"umh-16x3840","type":"ultra-memory"},{"certified":true,"cores":20,"memory":4800,"profileID":"umh-20x4800","type":"ultra-memory"},{"certified":true,"cores":22,"memory":5280,"profileID":"umh-22x5280","type":"ultra-memory"},{"certified":true,"cores":25,"memory":6000,"profileID":"umh-25x6000","type":"ultra-memory"},{"certified":true,"cores":30,"memory":7200,"profileID":"umh-30x7200","type":"ultra-memory"},{"certified":true,"cores":35,"memory":8400,"profileID":"umh-35x8400","type":"ultra-memory"},{"certified":true,"cores":40,"memory":9600,"profileID":"umh-40x9600","type":"ultra-memory"},{"certified":true,"cores":50,"memory":12000,"profileID":"umh-50x12000","type":"ultra-memory"},{"certified":true,"cores":60,"memory":14400,"profileID":"umh-60x14400","type":"ultra-memory"},{"certified":false,"cores":1,"memory":128,"profileID":"np1-1x128","type":"non-production"}]}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:27:10 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/storage-capacity/storage-types
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"any"},"storageTypesCapacity":[{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier0"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092}],"storageType":"tier0"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier1"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092}],"storageType":"tier1"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier3"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092}],"storageType":"tier3"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier5k"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092}],"storageType":"tier5k"}]}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:27:12 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"volumes":[{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T19:02:29.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/7d6f53e6-4adf-4792-8b5f-07cc618dff78","ioThrottleRate":"360
-        iops","lastUpdateDate":"2024-01-18T19:13:21.000Z","name":"test-instance-d6a661a8-00030ebf-boot-0","pvmInstanceIDs":["d6a661a8-fed1-4a52-9d50-24fc9f9956b8"],"shareable":false,"size":120,"state":"in-use","volumeID":"7d6f53e6-4adf-4792-8b5f-07cc618dff78","volumePool":"General-Flash-81","volumeType":"Tier3-General-Flash-81","wwn":"60050768108002DAC800000000004AF4"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:49:45.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/ba26d663-1e76-4457-8732-9d9235df8019","ioThrottleRate":"300
-        iops","lastUpdateDate":"2024-01-18T19:00:43.000Z","name":"test-instance-54e1f646-00030ebe-boot-0","pvmInstanceIDs":["54e1f646-8ce4-4ee5-9355-e5d34166c4fd"],"shareable":false,"size":100,"state":"in-use","volumeID":"ba26d663-1e76-4457-8732-9d9235df8019","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C4"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:47:54.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/984498df-5554-4685-a109-821d5e39b27b","ioThrottleRate":"300
-        iops","lastUpdateDate":"2024-01-18T18:48:16.000Z","name":"test-instance-b9370d8d-00030ebb-boot-0","pvmInstanceIDs":["b9370d8d-8d73-4f0e-ad84-34f7fd52eb84"],"shareable":false,"size":100,"state":"in-use","volumeID":"984498df-5554-4685-a109-821d5e39b27b","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C3"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:45:07.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/cdfebbb2-d64e-41e1-9834-4f6b5d249489","ioThrottleRate":"360
-        iops","lastUpdateDate":"2024-01-18T18:45:34.000Z","name":"test-instance-1ea38460-00030eb6-boot-0","pvmInstanceIDs":["1ea38460-b3ff-4abd-802b-0289983be590"],"shareable":false,"size":120,"state":"in-use","volumeID":"cdfebbb2-d64e-41e1-9834-4f6b5d249489","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C2"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:43:15.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/ed84f79b-b8d1-48c3-8766-2a92ff6a879b","ioThrottleRate":"1000
-        iops","lastUpdateDate":"2024-01-18T18:43:38.000Z","name":"test-instance-e8cf72cf-00030eb4-boot-0","pvmInstanceIDs":["e8cf72cf-7685-4bfb-a386-66422f71820a"],"shareable":false,"size":100,"state":"in-use","volumeID":"ed84f79b-b8d1-48c3-8766-2a92ff6a879b","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274C1"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T17:24:51.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/2e653913-14fe-4b3a-a4f3-c7396bed0862","ioThrottleRate":"250
-        iops","lastUpdateDate":"2024-01-18T17:25:13.000Z","name":"test-instance-502106d8-00030ea7-boot-0","pvmInstanceIDs":["502106d8-d969-49df-9103-184c3ab97508"],"shareable":false,"size":25,"state":"in-use","volumeID":"2e653913-14fe-4b3a-a4f3-c7396bed0862","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274BB"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:13.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/21f2d430-44fd-4f5e-af43-66076e6e9af7","ioThrottleRate":"150
-        iops","lastUpdateDate":"2024-01-18T17:24:14.000Z","name":"test-volume-15GB-tier1-notsharable","pvmInstanceIDs":[],"shareable":false,"size":15,"state":"available","volumeID":"21f2d430-44fd-4f5e-af43-66076e6e9af7","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274BA"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:07.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/5bb66445-1de3-4817-8590-42b35f21f9d8","ioThrottleRate":"30
-        iops","lastUpdateDate":"2024-01-18T17:24:08.000Z","name":"test-volume-3GB-tier1-notsharable","pvmInstanceIDs":[],"shareable":false,"size":3,"state":"available","volumeID":"5bb66445-1de3-4817-8590-42b35f21f9d8","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274B9"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:03.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/f302fbf6-c2f7-4df2-b80c-c3c2e8055d77","ioThrottleRate":"30
-        iops","lastUpdateDate":"2024-01-18T17:24:04.000Z","name":"test-volume-10GB-tier3-sharable","pvmInstanceIDs":[],"shareable":true,"size":10,"state":"available","volumeID":"f302fbf6-c2f7-4df2-b80c-c3c2e8055d77","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274B8"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:23:57.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/46eef916-ea40-4aee-9e0c-df840da65867","ioThrottleRate":"3
-        iops","lastUpdateDate":"2024-01-18T17:23:58.000Z","name":"test-volume-1GB-tier3-sharable","pvmInstanceIDs":[],"shareable":true,"size":1,"state":"available","volumeID":"46eef916-ea40-4aee-9e0c-df840da65867","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274B7"}]}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:27:12 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"pvmInstances":[{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/test-network-pub-vlan-dns","ip":"127.0.0.122","ipAddress":"127.0.0.122","macAddress":"fa:7f:f8:6b:9e:21","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/test-network-vlan-jumbo","ip":"127.0.0.10","ipAddress":"127.0.0.10","macAddress":"fa:7f:f8:6b:9e:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"creationDate":"2024-01-18T19:02:24.000Z","diskSize":120,"health":{"lastUpdate":"2024-01-18T19:27:12.850166","status":"WARNING"},"hostID":19,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8","imageID":"032d72bf-89f2-44a9-bbc4-ab898dd93309","maxmem":48,"maxproc":10,"memory":6,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/test-network-pub-vlan-dns","ip":"127.0.0.122","ipAddress":"127.0.0.122","macAddress":"fa:7f:f8:6b:9e:21","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/test-network-vlan-jumbo","ip":"127.0.0.10","ipAddress":"127.0.0.10","macAddress":"fa:7f:f8:6b:9e:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"127.0.0.0.0.0","osType":"rhel","pinPolicy":"none","placementGroup":"f99c2fc5-73ba-4387-9736-61dc51f53471","procType":"shared","processors":1.25,"pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8","serverName":"test-instance-rhcos-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-81","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T19:02:24.000Z","virtualCores":{"assigned":2,"max":16,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/test-network-pub-vlan","ip":"127.0.0.46","ipAddress":"127.0.0.46","macAddress":"fa:1a:90:7c:8a:21","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/test-network-vlan","ip":"127.0.0.208","ipAddress":"127.0.0.208","macAddress":"fa:1a:90:7c:8a:20","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T18:49:40.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:27:12.850195","status":"OK"},"hostID":19,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd","imageID":"38cac9ad-d422-46d7-acda-9024dd17c034","maxmem":32,"maxproc":6,"memory":4,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/test-network-pub-vlan","ip":"127.0.0.46","ipAddress":"127.0.0.46","macAddress":"fa:1a:90:7c:8a:21","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/test-network-vlan","ip":"127.0.0.208","ipAddress":"127.0.0.208","macAddress":"fa:1a:90:7c:8a:20","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/SLES
-        5.14.21-150400.24.11-defa15-SP4, 15-SP4","osType":"sles","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.75,"pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd","serverName":"test-instance-sles-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T18:49:40.000Z","virtualCores":{"assigned":1,"max":8,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84/networks/test-network-pub-vlan-dns","ip":"127.0.0.124","ipAddress":"127.0.0.124","macAddress":"fa:a0:0e:97:fe:20","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"creationDate":"2024-01-18T18:47:48.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:27:12.850216","status":"OK"},"hostID":6,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","imageID":"62ae0e80-e11b-45cd-a955-90fc08d7191c","maxmem":16,"maxproc":1,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84/networks/test-network-pub-vlan-dns","ip":"127.0.0.124","ipAddress":"127.0.0.124","macAddress":"fa:a0:0e:97:fe:20","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"operatingSystem":"Linux/Red
-        Hat Enterprise Linux 4.18.0-127.0.0.el8.ppc64l8.6 (Ootpa), 8.6 (Ootpa)","osType":"rhel","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.5,"pvmInstanceID":"b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","serverName":"test-instance-rhel-s922-shared-tier3","sharedProcessorPool":"test_pool","sharedProcessorPoolID":"85029156-8753-4d06-9a56-d13e3bd4c27d","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T18:47:48.000Z","virtualCores":{"assigned":1,"max":8,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590/networks/test-network-pub-vlan","ip":"127.0.0.45","ipAddress":"127.0.0.45","macAddress":"fa:50:f2:44:d6:20","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T18:45:03.000Z","diskSize":120,"health":{"lastUpdate":"2024-01-18T19:27:12.850236","status":"OK"},"hostID":1,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590","imageID":"69992304-1da0-4e66-a957-b95a58fb7d5c","maxmem":32,"maxproc":8,"memory":4,"minmem":2,"minproc":1,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590/networks/test-network-pub-vlan","ip":"127.0.0.45","ipAddress":"127.0.0.45","macAddress":"fa:50:f2:44:d6:20","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/CentOS
-        Stream 4.18.0-497.el8.ppc64le, 8","osType":"rhel","pinPolicy":"hard","placementGroup":"none","procType":"dedicated","processors":1,"pvmInstanceID":"1ea38460-b3ff-4abd-802b-0289983be590","serverName":"test-instance-centos-e980-dedicated-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"e980","updatedDate":"2024-01-18T18:45:03.000Z","virtualCores":{"assigned":1,"max":8,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/test-network-vlan-jumbo","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"consoleLanguage":{"code":"037","language":"037
-        English"},"creationDate":"2024-01-18T18:43:09.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:27:12.850256","status":"OK"},"hostID":7,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a","imageID":"ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2","maxmem":16,"maxproc":2,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/test-network-vlan-jumbo","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"V7R5M0
-        410 2","osType":"ibmi","pinPolicy":"none","placementGroup":"8334ba79-bd98-47af-ad25-6eb8a1c4c817","procType":"capped","processors":0.25,"pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a","serverName":"test-instance-ibmi-s922-capped-tier1","softwareLicenses":{"ibmiCSS":false,"ibmiDBQ":false,"ibmiPHA":false,"ibmiRDS":false},"srcs":[[{"src":"A6005008","timestamp":"2024-01-18T18:51:32Z"},{"src":"03B00061","timestamp":"2024-01-18T18:51:32Z"},{"src":"FFFF0000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"50070404","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"}]],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2024-01-18T18:43:09.000Z","virtualCores":{"assigned":1,"max":4,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508/networks/test-network-vlan","ip":"127.0.0.186","ipAddress":"127.0.0.186","macAddress":"fa:46:3d:6b:a1:20","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T17:24:40.000Z","diskSize":25,"health":{"lastUpdate":"2024-01-18T19:27:12.850275","status":"OK"},"hostID":4,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508","imageID":"45afea97-e991-41f4-8ef9-44d5e893ff45","maxmem":16,"maxproc":2,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508/networks/test-network-vlan","ip":"127.0.0.186","ipAddress":"127.0.0.186","macAddress":"fa:46:3d:6b:a1:20","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"AIX
-        7.3, 7300-00-01-2148","osType":"aix","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.25,"pvmInstanceID":"502106d8-d969-49df-9103-184c3ab97508","serverName":"test-instance-aix-s922-shared-tier1","srcs":[[{"src":"00000000","timestamp":"2024-01-18T17:27:40Z"}]],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2024-01-18T17:24:40.000Z","virtualCores":{"assigned":1,"max":5,"min":1}}]}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:27:15 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"addresses":[{"externalIP":"127.0.0.122","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b","ip":"127.0.0.122","ipAddress":"127.0.0.122","macAddress":"fa:7f:f8:6b:9e:21","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.10","ipAddress":"127.0.0.10","macAddress":"fa:7f:f8:6b:9e:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"creationDate":"2024-01-18T19:02:24.000Z","diskSize":120,"health":{"lastUpdate":"2024-01-18T19:27:16.580231","status":"WARNING"},"hostID":19,"imageID":"032d72bf-89f2-44a9-bbc4-ab898dd93309","maxmem":48,"maxproc":10,"memory":6,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["3e0c10e1-7cca-44b4-865d-ebd369169a1b","925c13aa-9579-43a3-86e1-150131906835"],"networks":[{"externalIP":"127.0.0.122","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b","ip":"127.0.0.122","ipAddress":"127.0.0.122","macAddress":"fa:7f:f8:6b:9e:21","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.10","ipAddress":"127.0.0.10","macAddress":"fa:7f:f8:6b:9e:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"127.0.0.0.0.0","osType":"rhel","pinPolicy":"none","placementGroup":"f99c2fc5-73ba-4387-9736-61dc51f53471","procType":"shared","processors":1.25,"pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8","serverName":"test-instance-rhcos-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-81","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T19:02:24.000Z","virtualCores":{"assigned":2,"max":16,"min":1},"volumeIDs":["7d6f53e6-4adf-4792-8b5f-07cc618dff78"]}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:27:17 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"addresses":[{"externalIP":"127.0.0.46","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5","ip":"127.0.0.46","ipAddress":"127.0.0.46","macAddress":"fa:1a:90:7c:8a:21","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/3de2f865-8726-43a3-8ee8-a385aa851adf","ip":"127.0.0.208","ipAddress":"127.0.0.208","macAddress":"fa:1a:90:7c:8a:20","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T18:49:40.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:27:18.089259","status":"OK"},"hostID":19,"imageID":"38cac9ad-d422-46d7-acda-9024dd17c034","maxmem":32,"maxproc":6,"memory":4,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["11896394-64c5-4d6d-8a2f-a9ad829348c5","3de2f865-8726-43a3-8ee8-a385aa851adf"],"networks":[{"externalIP":"127.0.0.46","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5","ip":"127.0.0.46","ipAddress":"127.0.0.46","macAddress":"fa:1a:90:7c:8a:21","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd/networks/3de2f865-8726-43a3-8ee8-a385aa851adf","ip":"127.0.0.208","ipAddress":"127.0.0.208","macAddress":"fa:1a:90:7c:8a:20","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/SLES
-        5.14.21-150400.24.11-defa15-SP4, 15-SP4","osType":"sles","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.75,"pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd","serverName":"test-instance-sles-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T18:49:40.000Z","virtualCores":{"assigned":1,"max":8,"min":1},"volumeIDs":["ba26d663-1e76-4457-8732-9d9235df8019"]}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:27:18 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/38cac9ad-d422-46d7-acda-9024dd17c034
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -487,30 +227,367 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '433'
+      - '680'
+      X-Correlation-Id:
+      - f51ff3a9-534f-4abb-8ac2-4ab426c375d0
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"creationDate":"2023-12-13T02:27:06.000Z","imageID":"38cac9ad-d422-46d7-acda-9024dd17c034","lastUpdateDate":"2023-12-13T02:41:10.000Z","name":"SLES15-SP4","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"sles"},"state":"active","storagePool":"","storageType":"","volumes":[]}
+      encoding: ASCII-8BIT
+      string: '{"capabilities":["ibmi-software-licenses","linux","pinning","rhel-sap","sap","snapshots","volume-clone","shared-processor-pools"],"cloudInstanceID":"9089686c4d6143a4bdcc72b197c7655d","enabled":true,"initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"IBM_CLOUD_POWERVS_INSTANCE_ID","openstackID":"d4c477222576b7395a58a51fbee2937a","pvmInstances":[],"region":"us-east10","tenantID":"1fdf5effc3f945688c021cd0a8b45c4d","usage":{"instances":0,"memory":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0,"storageStandard":0}}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:27:20 GMT
+  recorded_at: Wed, 25 Jun 2025 14:57:45 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/sap
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Correlation-Id:
+      - 9c197f0a-f72d-42e4-8bfc-dd8a896ec6be
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"profiles":[{"certified":true,"cores":16,"defaultSystem":"e980","fullSystemProfile":false,"memory":1600,"profileID":"bh1-16x1600","saps":96000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":20,"defaultSystem":"e980","fullSystemProfile":false,"memory":2000,"profileID":"bh1-20x2000","saps":120000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":22,"defaultSystem":"e980","fullSystemProfile":false,"memory":2200,"profileID":"bh1-22x2200","saps":132000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":25,"defaultSystem":"e980","fullSystemProfile":false,"memory":2500,"profileID":"bh1-25x2500","saps":150000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":30,"defaultSystem":"e980","fullSystemProfile":false,"memory":3000,"profileID":"bh1-30x3000","saps":180000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":35,"defaultSystem":"e1050","fullSystemProfile":false,"memory":3000,"profileID":"bh2-35x3000","saps":266000,"smtMode":8,"supportedSystems":["e1050"],"type":"balanced","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":35,"defaultSystem":"e980","fullSystemProfile":false,"memory":3500,"profileID":"bh1-35x3500","saps":210000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":35,"defaultSystem":"e1050","fullSystemProfile":false,"memory":3900,"profileID":"bh2-35x3900","saps":266000,"smtMode":8,"supportedSystems":["e1050"],"type":"balanced","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":40,"defaultSystem":"e980","fullSystemProfile":false,"memory":4000,"profileID":"bh1-40x4000","saps":240000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":50,"defaultSystem":"e980","fullSystemProfile":false,"memory":5000,"profileID":"bh1-50x5000","saps":300000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":60,"defaultSystem":"e980","fullSystemProfile":false,"memory":6000,"profileID":"bh1-60x6000","saps":360000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":70,"defaultSystem":"e980","fullSystemProfile":false,"memory":7000,"profileID":"bh1-70x7000","saps":420000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":80,"defaultSystem":"e980","fullSystemProfile":false,"memory":8000,"profileID":"bh1-80x8000","saps":480000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":100,"defaultSystem":"e980","fullSystemProfile":false,"memory":10000,"profileID":"bh1-100x10000","saps":600000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":120,"defaultSystem":"e980","fullSystemProfile":false,"memory":12000,"profileID":"bh1-120x12000","saps":720000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":140,"defaultSystem":"e980","fullSystemProfile":false,"memory":14000,"profileID":"bh1-140x14000","saps":840000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":150,"defaultSystem":"e980","fullSystemProfile":false,"memory":15000,"profileID":"bh1-150x15000","saps":0,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":[""]},{"certified":true,"cores":60,"defaultSystem":"e980","fullSystemProfile":false,"memory":3000,"profileID":"ch1-60x3000","saps":360000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":70,"defaultSystem":"e980","fullSystemProfile":false,"memory":3500,"profileID":"ch1-70x3500","saps":420000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":80,"defaultSystem":"e980","fullSystemProfile":false,"memory":4000,"profileID":"ch1-80x4000","saps":480000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":80,"defaultSystem":"e1050","fullSystemProfile":true,"memory":6144,"profileID":"ch2-80x6144","saps":608000,"smtMode":8,"supportedSystems":["e1050"],"type":"compute","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":6000,"profileID":"ch2-87x6000","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"compute","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":7000,"profileID":"ch2-87x7000","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"compute","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":7600,"profileID":"ch2-87x7600","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"compute","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":100,"defaultSystem":"e980","fullSystemProfile":false,"memory":5000,"profileID":"ch1-100x5000","saps":600000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":120,"defaultSystem":"e980","fullSystemProfile":false,"memory":6000,"profileID":"ch1-120x6000","saps":720000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":140,"defaultSystem":"e980","fullSystemProfile":false,"memory":7000,"profileID":"ch1-140x7000","saps":840000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":150,"defaultSystem":"e980","fullSystemProfile":false,"memory":7500,"profileID":"ch1-150x7500","saps":0,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":[""]},{"certified":true,"cores":8,"defaultSystem":"e980","fullSystemProfile":false,"memory":1440,"profileID":"mh1-8x1440","saps":48000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":10,"defaultSystem":"e980","fullSystemProfile":false,"memory":1800,"profileID":"mh1-10x1800","saps":60000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":12,"defaultSystem":"e980","fullSystemProfile":false,"memory":2160,"profileID":"mh1-12x2160","saps":72000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":16,"defaultSystem":"e980","fullSystemProfile":false,"memory":2880,"profileID":"mh1-16x2880","saps":96000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":20,"defaultSystem":"e980","fullSystemProfile":false,"memory":3600,"profileID":"mh1-20x3600","saps":120000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":22,"defaultSystem":"e980","fullSystemProfile":false,"memory":3960,"profileID":"mh1-22x3960","saps":132000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":25,"defaultSystem":"e980","fullSystemProfile":false,"memory":4500,"profileID":"mh1-25x4500","saps":150000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":30,"defaultSystem":"e980","fullSystemProfile":false,"memory":5400,"profileID":"mh1-30x5400","saps":180000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":35,"defaultSystem":"e980","fullSystemProfile":false,"memory":6300,"profileID":"mh1-35x6300","saps":210000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":40,"defaultSystem":"e980","fullSystemProfile":false,"memory":7200,"profileID":"mh1-40x7200","saps":240000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":50,"defaultSystem":"e980","fullSystemProfile":false,"memory":9000,"profileID":"mh1-50x9000","saps":300000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":60,"defaultSystem":"e980","fullSystemProfile":false,"memory":10800,"profileID":"mh1-60x10800","saps":360000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":70,"defaultSystem":"e980","fullSystemProfile":false,"memory":12600,"profileID":"mh1-70x12600","saps":420000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":80,"defaultSystem":"e980","fullSystemProfile":false,"memory":14400,"profileID":"mh1-80x14400","saps":480000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":90,"defaultSystem":"e980","fullSystemProfile":false,"memory":16200,"profileID":"mh1-90x16200","saps":0,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":[""]},{"certified":true,"cores":100,"defaultSystem":"e980","fullSystemProfile":false,"memory":18000,"profileID":"mh1-100x18000","saps":0,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":[""]},{"certified":true,"cores":125,"defaultSystem":"e980","fullSystemProfile":false,"memory":22500,"profileID":"mh1-125x22500","saps":0,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":[""]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sr2-7x256","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":384,"profileID":"sr2-7x384","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":950,"profileID":"sr2-12x950","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1450,"profileID":"sr2-12x1450","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":14,"defaultSystem":"s1022","fullSystemProfile":false,"memory":512,"profileID":"sr2-14x512","saps":84000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLTP"]},{"certified":true,"cores":14,"defaultSystem":"s1022","fullSystemProfile":false,"memory":740,"profileID":"sr2-14x740","saps":84000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":22,"defaultSystem":"e1080","fullSystemProfile":false,"memory":2950,"profileID":"sr2-22x2950","saps":132000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":24,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1024,"profileID":"sr2-24x1024","saps":144000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":24,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1536,"profileID":"sr2-24x1536","saps":144000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":25,"defaultSystem":"s1022","fullSystemProfile":true,"memory":1900,"profileID":"sr2-25x1900","saps":190000,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":35,"defaultSystem":"e1050","fullSystemProfile":false,"memory":3000,"profileID":"sr2-35x3000","saps":266000,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":35,"defaultSystem":"e1050","fullSystemProfile":false,"memory":3900,"profileID":"sr2-35x3900","saps":266000,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":35,"defaultSystem":"e1080","fullSystemProfile":false,"memory":4450,"profileID":"sr2-35x4450","saps":210000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":40,"defaultSystem":"e1080","fullSystemProfile":false,"memory":3072,"profileID":"sr2-40x3072","saps":240000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":64,"defaultSystem":"e1080","fullSystemProfile":false,"memory":6144,"profileID":"sr2-64x6144","saps":384000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":80,"defaultSystem":"e1050","fullSystemProfile":true,"memory":6144,"profileID":"sr2-80x6144","saps":608000,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":80,"defaultSystem":"e1080","fullSystemProfile":false,"memory":9216,"profileID":"sr2-80x9216","saps":480000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":80,"defaultSystem":"e1080","fullSystemProfile":false,"memory":12288,"profileID":"sr2-80x12288","saps":480000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":80,"defaultSystem":"e1080","fullSystemProfile":false,"memory":14400,"profileID":"sr2-80x14400","saps":480000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":6000,"profileID":"sr2-87x6000","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":7000,"profileID":"sr2-87x7000","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":7600,"profileID":"sr2-87x7600","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":128,"defaultSystem":"e1080","fullSystemProfile":false,"memory":16000,"profileID":"sr2-128x16000","saps":768000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":128,"defaultSystem":"e1080","fullSystemProfile":false,"memory":18000,"profileID":"sr2-128x18000","saps":768000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":128,"defaultSystem":"e1080","fullSystemProfile":false,"memory":20000,"profileID":"sr2-128x20000","saps":768000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":165,"defaultSystem":"e1080","fullSystemProfile":true,"memory":22000,"profileID":"sr2-165x22000","saps":1254000,"smtMode":8,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":165,"defaultSystem":"e1080","fullSystemProfile":true,"memory":24000,"profileID":"sr2-165x24000","saps":1254000,"smtMode":8,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":165,"defaultSystem":"e1080","fullSystemProfile":true,"memory":26000,"profileID":"sr2-165x26000","saps":1254000,"smtMode":8,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":165,"defaultSystem":"e1080","fullSystemProfile":true,"memory":28000,"profileID":"sr2-165x28000","saps":1254000,"smtMode":8,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":165,"defaultSystem":"e1080","fullSystemProfile":true,"memory":30500,"profileID":"sr2-165x30500","saps":1254000,"smtMode":8,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":2,"defaultSystem":"s1022","fullSystemProfile":false,"memory":32,"profileID":"sr2-2x32","saps":15200,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":3,"defaultSystem":"s1022","fullSystemProfile":false,"memory":64,"profileID":"sr2-3x64","saps":22800,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":64,"profileID":"sr2-4x64","saps":30400,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":6,"defaultSystem":"s1022","fullSystemProfile":false,"memory":128,"profileID":"sr2-6x128","saps":45600,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":8,"defaultSystem":"s1022","fullSystemProfile":false,"memory":128,"profileID":"sr2-8x128","saps":60800,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sr2-12x256","saps":91200,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":16,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sr2-16x256","saps":121600,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":128,"profileID":"ush1-4x128","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sh2-4x256","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":256,"profileID":"ush1-4x256","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":384,"profileID":"sh2-4x384","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":384,"profileID":"ush1-4x384","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":512,"profileID":"sh2-4x512","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":512,"profileID":"ush1-4x512","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":768,"profileID":"sh2-4x768","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":768,"profileID":"ush1-4x768","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1000,"profileID":"sh2-4x1000","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1500,"profileID":"sh2-4x1500","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sh2-7x256","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":384,"profileID":"sh2-7x384","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":512,"profileID":"sh2-7x512","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":768,"profileID":"sh2-7x768","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1000,"profileID":"sh2-7x1000","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1500,"profileID":"sh2-7x1500","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":8,"defaultSystem":"s1022","fullSystemProfile":true,"memory":1900,"profileID":"sh2-8x1900","saps":60800,"smtMode":8,"supportedSystems":["s1022"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sh2-12x256","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":384,"profileID":"sh2-12x384","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":512,"profileID":"sh2-12x512","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":768,"profileID":"sh2-12x768","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1000,"profileID":"sh2-12x1000","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1500,"profileID":"sh2-12x1500","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":16,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1000,"profileID":"sh2-16x1000","saps":96000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":16,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1500,"profileID":"sh2-16x1500","saps":96000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":16,"defaultSystem":"s1022","fullSystemProfile":true,"memory":1900,"profileID":"sh2-16x1900","saps":121600,"smtMode":8,"supportedSystems":["s1022"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":25,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1000,"profileID":"sh2-25x1000","saps":150000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":25,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1500,"profileID":"sh2-25x1500","saps":150000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":33,"defaultSystem":"s1022","fullSystemProfile":true,"memory":1900,"profileID":"sh2-33x1900","saps":250800,"smtMode":8,"supportedSystems":["s1022"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":960,"profileID":"umh-4x960","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":6,"defaultSystem":"e980","fullSystemProfile":false,"memory":1440,"profileID":"umh-6x1440","saps":36000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":8,"defaultSystem":"e980","fullSystemProfile":false,"memory":1920,"profileID":"umh-8x1920","saps":48000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":10,"defaultSystem":"e980","fullSystemProfile":false,"memory":2400,"profileID":"umh-10x2400","saps":60000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":12,"defaultSystem":"e980","fullSystemProfile":false,"memory":2880,"profileID":"umh-12x2880","saps":72000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":16,"defaultSystem":"e980","fullSystemProfile":false,"memory":3840,"profileID":"umh-16x3840","saps":96000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":20,"defaultSystem":"e980","fullSystemProfile":false,"memory":4800,"profileID":"umh-20x4800","saps":120000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":22,"defaultSystem":"e980","fullSystemProfile":false,"memory":5280,"profileID":"umh-22x5280","saps":132000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":25,"defaultSystem":"e980","fullSystemProfile":false,"memory":6000,"profileID":"umh-25x6000","saps":150000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":30,"defaultSystem":"e980","fullSystemProfile":false,"memory":7200,"profileID":"umh-30x7200","saps":180000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":35,"defaultSystem":"e980","fullSystemProfile":false,"memory":8400,"profileID":"umh-35x8400","saps":210000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":40,"defaultSystem":"e980","fullSystemProfile":false,"memory":9600,"profileID":"umh-40x9600","saps":240000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":50,"defaultSystem":"e980","fullSystemProfile":false,"memory":12000,"profileID":"umh-50x12000","saps":300000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":60,"defaultSystem":"e980","fullSystemProfile":false,"memory":14400,"profileID":"umh-60x14400","saps":360000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]}]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:57:45 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/storage-capacity/storage-types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Correlation-Id:
+      - 8d9ca5df-f827-4876-8f5f-ff1752752dca
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"maximumStorageAllocation":{"maxAllocationSize":184740,"storagePool":"General-Flash-53","storageType":"any"},"storageTypesCapacity":[{"maximumStorageAllocation":{"maxAllocationSize":184740,"storagePool":"General-Flash-53","storageType":"tier0"},"storagePoolsCapacity":[{"maxAllocationSize":184740,"poolName":"General-Flash-53","replicationEnabled":true,"storageHost":"ius-east10_tier3_1","storageType":"tier0","totalCapacity":512000},{"maxAllocationSize":150354,"poolName":"General-Flash-59","replicationEnabled":true,"storageHost":"ius-east10_tier3_2","storageType":"tier0","totalCapacity":512000},{"maxAllocationSize":148173,"poolName":"General-Flash-56","replicationEnabled":true,"storageHost":"ius-east10_tier1_2","storageType":"tier0","totalCapacity":512000},{"maxAllocationSize":106374,"poolName":"General-Flash-50","replicationEnabled":true,"storageHost":"ius-east10_tier1_1","storageType":"tier0","totalCapacity":512000}],"storageType":"tier0"},{"maximumStorageAllocation":{"maxAllocationSize":184740,"storagePool":"General-Flash-53","storageType":"tier1"},"storagePoolsCapacity":[{"maxAllocationSize":184740,"poolName":"General-Flash-53","replicationEnabled":true,"storageHost":"ius-east10_tier3_1","storageType":"tier1","totalCapacity":512000},{"maxAllocationSize":150354,"poolName":"General-Flash-59","replicationEnabled":true,"storageHost":"ius-east10_tier3_2","storageType":"tier1","totalCapacity":512000},{"maxAllocationSize":106374,"poolName":"General-Flash-50","replicationEnabled":true,"storageHost":"ius-east10_tier1_1","storageType":"tier1","totalCapacity":512000},{"maxAllocationSize":148173,"poolName":"General-Flash-56","replicationEnabled":true,"storageHost":"ius-east10_tier1_2","storageType":"tier1","totalCapacity":512000}],"storageType":"tier1"},{"maximumStorageAllocation":{"maxAllocationSize":184740,"storagePool":"General-Flash-53","storageType":"tier3"},"storagePoolsCapacity":[{"maxAllocationSize":148173,"poolName":"General-Flash-56","replicationEnabled":true,"storageHost":"ius-east10_tier1_2","storageType":"tier3","totalCapacity":512000},{"maxAllocationSize":106374,"poolName":"General-Flash-50","replicationEnabled":true,"storageHost":"ius-east10_tier1_1","storageType":"tier3","totalCapacity":512000},{"maxAllocationSize":150354,"poolName":"General-Flash-59","replicationEnabled":true,"storageHost":"ius-east10_tier3_2","storageType":"tier3","totalCapacity":512000},{"maxAllocationSize":184740,"poolName":"General-Flash-53","replicationEnabled":true,"storageHost":"ius-east10_tier3_1","storageType":"tier3","totalCapacity":512000}],"storageType":"tier3"},{"maximumStorageAllocation":{"maxAllocationSize":184740,"storagePool":"General-Flash-53","storageType":"tier5k"},"storagePoolsCapacity":[{"maxAllocationSize":184740,"poolName":"General-Flash-53","replicationEnabled":true,"storageHost":"ius-east10_tier3_1","storageType":"tier5k","totalCapacity":512000},{"maxAllocationSize":150354,"poolName":"General-Flash-59","replicationEnabled":true,"storageHost":"ius-east10_tier3_2","storageType":"tier5k","totalCapacity":512000},{"maxAllocationSize":148173,"poolName":"General-Flash-56","replicationEnabled":true,"storageHost":"ius-east10_tier1_2","storageType":"tier5k","totalCapacity":512000},{"maxAllocationSize":106374,"poolName":"General-Flash-50","replicationEnabled":true,"storageHost":"ius-east10_tier1_1","storageType":"tier5k","totalCapacity":512000}],"storageType":"tier5k"}]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:57:46 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Correlation-Id:
+      - 8d737787-a21d-4d5a-9277-b52b66f7d9a1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumes":[{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:44:07.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:55eeb86d-80d4-4ef2-9267-0075bac0378d","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/55eeb86d-80d4-4ef2-9267-0075bac0378d","ioThrottleRate":"360
+        iops","lastUpdateDate":"2025-06-25T14:44:25.000Z","name":"test-instance-9317b826-0002edc3-boot-0","pvmInstanceIDs":["9317b826-3660-4cf9-aa93-6d42a4643ba9"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":120,"state":"in-use","volumeID":"55eeb86d-80d4-4ef2-9267-0075bac0378d","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9C4"},{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:41:27.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:2b3477a2-5e5c-46fc-8906-bc2ef9166c37","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/2b3477a2-5e5c-46fc-8906-bc2ef9166c37","ioThrottleRate":"300
+        iops","lastUpdateDate":"2025-06-25T14:42:00.000Z","name":"test-instance-c717671d-0002edc0-boot-0","pvmInstanceIDs":["c717671d-baae-4955-879f-0588ef5171bb"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":100,"state":"in-use","volumeID":"2b3477a2-5e5c-46fc-8906-bc2ef9166c37","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9C3"},{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:39:01.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:ab68a4b6-921e-4149-a6d3-70c281349fcf","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/ab68a4b6-921e-4149-a6d3-70c281349fcf","ioThrottleRate":"300
+        iops","lastUpdateDate":"2025-06-25T14:39:25.000Z","name":"test-instance-43a0b59a-0002edba-boot-0","pvmInstanceIDs":["43a0b59a-f4d7-4150-8fb8-72b4e5452d02"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":100,"state":"in-use","volumeID":"ab68a4b6-921e-4149-a6d3-70c281349fcf","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9BE"},{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:36:25.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:4fdf9382-aa4c-435e-9352-de392a6ef278","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/4fdf9382-aa4c-435e-9352-de392a6ef278","ioThrottleRate":"360
+        iops","lastUpdateDate":"2025-06-25T14:36:57.000Z","name":"test-instance-c19f7546-0002edb7-boot-0","pvmInstanceIDs":["c19f7546-323e-4e0b-bf97-5ad8668f0529"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":120,"state":"in-use","volumeID":"4fdf9382-aa4c-435e-9352-de392a6ef278","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9BC"},{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:33:58.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:b6a90aec-fce5-4640-9a99-140e8af2b103","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/b6a90aec-fce5-4640-9a99-140e8af2b103","ioThrottleRate":"1000
+        iops","lastUpdateDate":"2025-06-25T14:34:24.000Z","name":"test-instance-04c9a30d-0002edb4-boot-0","pvmInstanceIDs":["04c9a30d-c8d5-46cb-849b-0f7fa5004b70"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":100,"state":"in-use","volumeID":"b6a90aec-fce5-4640-9a99-140e8af2b103","volumePool":"General-Flash-53","volumeType":"Tier1-General-Flash-53","wwn":"6005076813810212980000000000A9BB"},{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:29:52.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:1f455cf4-c82c-4e1b-b84b-f1e86082aadf","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/1f455cf4-c82c-4e1b-b84b-f1e86082aadf","ioThrottleRate":"200
+        iops","lastUpdateDate":"2025-06-25T14:30:23.000Z","name":"test-instance-5d8393c6-0002edb1-boot-0","pvmInstanceIDs":["5d8393c6-b50c-4de4-98f0-a04222e9fbdc"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":20,"state":"in-use","volumeID":"1f455cf4-c82c-4e1b-b84b-f1e86082aadf","volumePool":"General-Flash-53","volumeType":"Tier1-General-Flash-53","wwn":"6005076813810212980000000000A9BA"},{"auxiliary":false,"bootable":false,"creationDate":"2025-06-25T14:27:46.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:b5da6f68-de2e-4594-a615-4f3625f33e3c","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/b5da6f68-de2e-4594-a615-4f3625f33e3c","ioThrottleRate":"150
+        iops","lastUpdateDate":"2025-06-25T14:27:51.000Z","name":"test-volume-15GB-tier1-notsharable","pvmInstanceIDs":[],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":15,"state":"available","volumeID":"b5da6f68-de2e-4594-a615-4f3625f33e3c","volumePool":"General-Flash-53","volumeType":"Tier1-General-Flash-53","wwn":"6005076813810212980000000000A9B8"},{"auxiliary":false,"bootable":false,"creationDate":"2025-06-25T14:27:39.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:1e279407-e554-491d-8ed3-a5094ce86ac0","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/1e279407-e554-491d-8ed3-a5094ce86ac0","ioThrottleRate":"30
+        iops","lastUpdateDate":"2025-06-25T14:27:42.000Z","name":"test-volume-3GB-tier1-notsharable","pvmInstanceIDs":[],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":3,"state":"available","volumeID":"1e279407-e554-491d-8ed3-a5094ce86ac0","volumePool":"General-Flash-53","volumeType":"Tier1-General-Flash-53","wwn":"6005076813810212980000000000A9B7"},{"auxiliary":false,"bootable":false,"creationDate":"2025-06-25T14:27:32.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:5d1d628d-95ab-4513-81e0-b95b784a7062","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/5d1d628d-95ab-4513-81e0-b95b784a7062","ioThrottleRate":"30
+        iops","lastUpdateDate":"2025-06-25T14:27:34.000Z","name":"test-volume-10GB-tier3-sharable","pvmInstanceIDs":[],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":true,"size":10,"state":"available","volumeID":"5d1d628d-95ab-4513-81e0-b95b784a7062","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9B6"},{"auxiliary":false,"bootable":false,"creationDate":"2025-06-25T14:27:24.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:2ce11d4a-2c94-4742-bff4-0e802cf348f8","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/2ce11d4a-2c94-4742-bff4-0e802cf348f8","ioThrottleRate":"3
+        iops","lastUpdateDate":"2025-06-25T14:27:26.000Z","name":"test-volume-1GB-tier3-sharable","pvmInstanceIDs":[],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":true,"size":1,"state":"available","volumeID":"2ce11d4a-2c94-4742-bff4-0e802cf348f8","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9B5"}]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:57:48 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Correlation-Id:
+      - a1b88bf4-6fa4-4bdf-8c67-745c5cef8006
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"pvmInstances":[{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9/networks/test-network-pub-vlan-dns","ip":"127.0.0.171","ipAddress":"127.0.0.171","macAddress":"fa:16:3e:fd:c2:38","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9/networks/test-network-vlan-jumbo","ip":"127.0.0.8","ipAddress":"127.0.0.8","macAddress":"fa:16:3e:c9:9f:58","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"creationDate":"2025-06-25T14:43:52.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:9317b826-3660-4cf9-aa93-6d42a4643ba9","diskSize":120,"health":{"lastUpdate":"2025-06-25T14:57:50.080306","reason":"rmc_state
+        - inactive","status":"WARNING"},"hostID":22,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9","imageID":"e6b94e6c-8c6a-4a05-9718-afef367b4af9","maxmem":48,"maxproc":10,"memory":6,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9/networks/test-network-pub-vlan-dns","ip":"127.0.0.171","ipAddress":"127.0.0.171","macAddress":"fa:16:3e:fd:c2:38","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9/networks/test-network-vlan-jumbo","ip":"127.0.0.8","ipAddress":"127.0.0.8","macAddress":"fa:16:3e:c9:9f:58","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"Unknown","osType":"rhel","pinPolicy":"none","placementGroup":"b52c11cb-b6bf-45a0-a376-242f4217ca6f","procType":"shared","processors":1.25,"pvmInstanceID":"9317b826-3660-4cf9-aa93-6d42a4643ba9","serverName":"test-instance-rhcos-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"s922","updatedDate":"2025-06-25T14:43:52.000Z","virtualCores":{"assigned":2,"max":16,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb/networks/test-network-pub-vlan","ip":"127.0.0.51","ipAddress":"127.0.0.51","macAddress":"fa:16:3e:54:22:62","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb/networks/test-network-vlan","ip":"127.0.0.222","ipAddress":"127.0.0.222","macAddress":"fa:16:3e:18:d9:fc","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2025-06-25T14:41:09.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:c717671d-baae-4955-879f-0588ef5171bb","diskSize":100,"health":{"lastUpdate":"2025-06-25T14:57:50.080335","status":"OK"},"hostID":82,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb","imageID":"52ff78a6-d303-42e3-9704-9c0693aed0b0","maxmem":32,"maxproc":6,"memory":4,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb/networks/test-network-pub-vlan","ip":"127.0.0.51","ipAddress":"127.0.0.51","macAddress":"fa:16:3e:54:22:62","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb/networks/test-network-vlan","ip":"127.0.0.222","ipAddress":"127.0.0.222","macAddress":"fa:16:3e:18:d9:fc","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"null,","osType":"sles","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.75,"pvmInstanceID":"c717671d-baae-4955-879f-0588ef5171bb","serverName":"test-instance-sles-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"s922","updatedDate":"2025-06-25T14:41:09.000Z","virtualCores":{"assigned":1,"max":8,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/43a0b59a-f4d7-4150-8fb8-72b4e5452d02/networks/test-network-pub-vlan-dns","ip":"127.0.0.173","ipAddress":"127.0.0.173","macAddress":"fa:16:3e:1a:fb:62","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"creationDate":"2025-06-25T14:38:49.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:43a0b59a-f4d7-4150-8fb8-72b4e5452d02","diskSize":100,"health":{"lastUpdate":"2025-06-25T14:57:50.080352","status":"OK"},"hostID":58,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/43a0b59a-f4d7-4150-8fb8-72b4e5452d02","imageID":"810ec288-de37-49da-8c60-163a36704d30","maxmem":16,"maxproc":1,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/43a0b59a-f4d7-4150-8fb8-72b4e5452d02/networks/test-network-pub-vlan-dns","ip":"127.0.0.173","ipAddress":"127.0.0.173","macAddress":"fa:16:3e:1a:fb:62","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"operatingSystem":"Linux/Red
+        Hat Enterprise Linux 5.14.0-127.0.0.el9_4.ppc9.4 (Plow), 9.4 (Plow)","osType":"rhel","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.5,"pvmInstanceID":"43a0b59a-f4d7-4150-8fb8-72b4e5452d02","serverName":"test-instance-rhel-s922-shared-tier3","sharedProcessorPool":"test_pool","sharedProcessorPoolID":"85ba15e6-bbc0-469b-90b7-697876167cfc","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"s922","updatedDate":"2025-06-25T14:38:49.000Z","virtualCores":{"assigned":1,"max":2,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c19f7546-323e-4e0b-bf97-5ad8668f0529/networks/test-network-pub-vlan","ip":"127.0.0.52","ipAddress":"127.0.0.52","macAddress":"fa:16:3e:81:10:5d","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"creationDate":"2025-06-25T14:36:12.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:c19f7546-323e-4e0b-bf97-5ad8668f0529","diskSize":120,"health":{"lastUpdate":"2025-06-25T14:57:50.080367","status":"OK"},"hostID":124,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c19f7546-323e-4e0b-bf97-5ad8668f0529","imageID":"8237f6bc-3347-47ec-b11c-8ab47683be5f","maxmem":32,"maxproc":8,"memory":4,"minmem":2,"minproc":1,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c19f7546-323e-4e0b-bf97-5ad8668f0529/networks/test-network-pub-vlan","ip":"127.0.0.52","ipAddress":"127.0.0.52","macAddress":"fa:16:3e:81:10:5d","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/CentOS
+        Stream 5.14.0-554.el9.ppc64le, 9","osType":"rhel","pinPolicy":"hard","placementGroup":"none","procType":"dedicated","processors":1,"pvmInstanceID":"c19f7546-323e-4e0b-bf97-5ad8668f0529","serverName":"test-instance-centos-e980-dedicated-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"e980","updatedDate":"2025-06-25T14:36:12.000Z","virtualCores":{"assigned":1,"max":8,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/04c9a30d-c8d5-46cb-849b-0f7fa5004b70/networks/test-network-vlan-jumbo","ip":"127.0.0.1","ipAddress":"127.0.0.1","macAddress":"fa:16:3e:a1:4d:23","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"consoleLanguage":{"code":"037","language":"037
+        English"},"creationDate":"2025-06-25T14:33:31.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:04c9a30d-c8d5-46cb-849b-0f7fa5004b70","diskSize":100,"health":{"lastUpdate":"2025-06-25T14:57:50.080382","status":"OK"},"hostID":79,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/04c9a30d-c8d5-46cb-849b-0f7fa5004b70","imageID":"0e09362f-08dd-4fff-ae7b-c389b81ab7bd","maxmem":16,"maxproc":2,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/04c9a30d-c8d5-46cb-849b-0f7fa5004b70/networks/test-network-vlan-jumbo","ip":"127.0.0.1","ipAddress":"127.0.0.1","macAddress":"fa:16:3e:a1:4d:23","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"V7R5M0
+        410 5","osType":"ibmi","pinPolicy":"soft","placementGroup":"69ac6b47-912e-4346-8804-da768f4aa789","procType":"capped","processors":0.25,"pvmInstanceID":"04c9a30d-c8d5-46cb-849b-0f7fa5004b70","serverName":"test-instance-ibmi-s922-capped-tier1","softwareLicenses":{"ibmiCSS":false,"ibmiDBQ":false,"ibmiPHA":false,"ibmiRDS":false},"srcs":[[{"src":"A6005008","timestamp":"2025-06-25T15:25:10Z"},{"src":"03B00061","timestamp":"2025-06-25T15:25:10Z"},{"src":"FFFF0000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"50070404","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"}]],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"s922","updatedDate":"2025-06-25T14:33:31.000Z","virtualCores":{"assigned":1,"max":4,"min":1}},{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/5d8393c6-b50c-4de4-98f0-a04222e9fbdc/networks/test-network-vlan","ip":"127.0.0.168","ipAddress":"127.0.0.168","macAddress":"fa:16:3e:30:7b:3b","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2025-06-25T14:29:29.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:5d8393c6-b50c-4de4-98f0-a04222e9fbdc","diskSize":20,"health":{"lastUpdate":"2025-06-25T14:57:50.080396","status":"OK"},"hostID":79,"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/5d8393c6-b50c-4de4-98f0-a04222e9fbdc","imageID":"e8891477-f9ce-4785-b1e5-7c374701b12b","maxmem":16,"maxproc":2,"memory":2,"minmem":2,"minproc":0.25,"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/5d8393c6-b50c-4de4-98f0-a04222e9fbdc/networks/test-network-vlan","ip":"127.0.0.168","ipAddress":"127.0.0.168","macAddress":"fa:16:3e:30:7b:3b","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"AIX
+        7.3, 7300-03-00-2446","osType":"aix","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.25,"pvmInstanceID":"5d8393c6-b50c-4de4-98f0-a04222e9fbdc","serverName":"test-instance-aix-s922-shared-tier1","srcs":[[{"src":"00000000","timestamp":"2025-06-25T15:15:40Z"}]],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"s922","updatedDate":"2025-06-25T14:29:29.000Z","virtualCores":{"assigned":1,"max":5,"min":1}}]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:57:52 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Correlation-Id:
+      - 0cf9a007-8b2c-42ad-af40-d87f19708bd7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"addresses":[{"externalIP":"127.0.0.203","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9/networks/fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","ip":"127.0.0.171","ipAddress":"127.0.0.171","macAddress":"fa:16:3e:fd:c2:38","networkID":"fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","networkInterfaceID":"ef882de7-3959-4217-89c4-89db3edb6eff","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9/networks/75a55a9f-1038-4495-9c3f-f7c113670c2e","ip":"127.0.0.8","ipAddress":"127.0.0.8","macAddress":"fa:16:3e:c9:9f:58","networkID":"75a55a9f-1038-4495-9c3f-f7c113670c2e","networkInterfaceID":"1c3e5c91-3c61-49f2-a55f-082958467a67","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"creationDate":"2025-06-25T14:43:52.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:9317b826-3660-4cf9-aa93-6d42a4643ba9","diskSize":120,"health":{"lastUpdate":"2025-06-25T14:57:54.903478","reason":"rmc_state
+        - inactive","status":"WARNING"},"hostID":22,"imageID":"e6b94e6c-8c6a-4a05-9718-afef367b4af9","maxmem":48,"maxproc":10,"memory":6,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","75a55a9f-1038-4495-9c3f-f7c113670c2e"],"networks":[{"externalIP":"127.0.0.203","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9/networks/fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","ip":"127.0.0.171","ipAddress":"127.0.0.171","macAddress":"fa:16:3e:fd:c2:38","networkID":"fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","networkInterfaceID":"ef882de7-3959-4217-89c4-89db3edb6eff","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9/networks/75a55a9f-1038-4495-9c3f-f7c113670c2e","ip":"127.0.0.8","ipAddress":"127.0.0.8","macAddress":"fa:16:3e:c9:9f:58","networkID":"75a55a9f-1038-4495-9c3f-f7c113670c2e","networkInterfaceID":"1c3e5c91-3c61-49f2-a55f-082958467a67","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"Unknown","osType":"rhel","pinPolicy":"none","placementGroup":"b52c11cb-b6bf-45a0-a376-242f4217ca6f","procType":"shared","processors":1.25,"pvmInstanceID":"9317b826-3660-4cf9-aa93-6d42a4643ba9","serverName":"test-instance-rhcos-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"s922","updatedDate":"2025-06-25T14:43:52.000Z","virtualCores":{"assigned":2,"max":16,"min":1},"volumeIDs":["55eeb86d-80d4-4ef2-9267-0075bac0378d"]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:57:56 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Correlation-Id:
+      - f3ade293-b0e2-4495-8a4d-59298b2c0e30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"addresses":[{"externalIP":"127.0.0.83","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb/networks/33d7228f-c6c8-40ea-a99f-351e042b0b4b","ip":"127.0.0.51","ipAddress":"127.0.0.51","macAddress":"fa:16:3e:54:22:62","networkID":"33d7228f-c6c8-40ea-a99f-351e042b0b4b","networkInterfaceID":"7c25445c-c769-44b7-aa83-2a8cd322e9b4","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb/networks/ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","ip":"127.0.0.222","ipAddress":"127.0.0.222","macAddress":"fa:16:3e:18:d9:fc","networkID":"ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","networkInterfaceID":"7428c137-e911-4a3e-b0b8-dcd9add53283","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2025-06-25T14:41:09.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:c717671d-baae-4955-879f-0588ef5171bb","diskSize":100,"health":{"lastUpdate":"2025-06-25T14:57:58.171503","status":"OK"},"hostID":82,"imageID":"52ff78a6-d303-42e3-9704-9c0693aed0b0","maxmem":32,"maxproc":6,"memory":4,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["33d7228f-c6c8-40ea-a99f-351e042b0b4b","ff2f5ffc-0ced-4a10-83ac-79d8edfa8796"],"networks":[{"externalIP":"127.0.0.83","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb/networks/33d7228f-c6c8-40ea-a99f-351e042b0b4b","ip":"127.0.0.51","ipAddress":"127.0.0.51","macAddress":"fa:16:3e:54:22:62","networkID":"33d7228f-c6c8-40ea-a99f-351e042b0b4b","networkInterfaceID":"7c25445c-c769-44b7-aa83-2a8cd322e9b4","networkName":"test-network-pub-vlan","type":"fixed","version":4},{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb/networks/ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","ip":"127.0.0.222","ipAddress":"127.0.0.222","macAddress":"fa:16:3e:18:d9:fc","networkID":"ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","networkInterfaceID":"7428c137-e911-4a3e-b0b8-dcd9add53283","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"null,","osType":"sles","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.75,"pvmInstanceID":"c717671d-baae-4955-879f-0588ef5171bb","serverName":"test-instance-sles-s922-shared-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"s922","updatedDate":"2025-06-25T14:41:09.000Z","virtualCores":{"assigned":1,"max":8,"min":1},"volumeIDs":["2b3477a2-5e5c-46fc-8906-bc2ef9166c37"]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:57:59 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/52ff78a6-d303-42e3-9704-9c0693aed0b0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '107'
+      X-Correlation-Id:
+      - 1338055b-7dc2-4031-ba02-8486d6aca5d5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"description":"image does not exist. ID: 52ff78a6-d303-42e3-9704-9c0693aed0b0","error":"image
+        not found"}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:58:02 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/stock-images/52ff78a6-d303-42e3-9704-9c0693aed0b0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -524,31 +601,132 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1829'
+      - '589'
+      X-Correlation-Id:
+      - 3a348478-3752-4c4c-8df7-9a58a48cb944
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"addresses":[{"externalIP":"127.0.0.124","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b","ip":"127.0.0.124","ipAddress":"127.0.0.124","macAddress":"fa:a0:0e:97:fe:20","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"creationDate":"2024-01-18T18:47:48.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:27:20.611855","status":"OK"},"hostID":6,"imageID":"62ae0e80-e11b-45cd-a955-90fc08d7191c","maxmem":16,"maxproc":1,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["3e0c10e1-7cca-44b4-865d-ebd369169a1b"],"networks":[{"externalIP":"127.0.0.124","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b","ip":"127.0.0.124","ipAddress":"127.0.0.124","macAddress":"fa:a0:0e:97:fe:20","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"operatingSystem":"Linux/Red
-        Hat Enterprise Linux 4.18.0-127.0.0.el8.ppc64l8.6 (Ootpa), 8.6 (Ootpa)","osType":"rhel","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.5,"pvmInstanceID":"b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","serverName":"test-instance-rhel-s922-shared-tier3","sharedProcessorPool":"test_pool","sharedProcessorPoolID":"85029156-8753-4d06-9a56-d13e3bd4c27d","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"s922","updatedDate":"2024-01-18T18:47:48.000Z","virtualCores":{"assigned":1,"max":8,"min":1},"volumeIDs":["984498df-5554-4685-a109-821d5e39b27b"]}
+      encoding: ASCII-8BIT
+      string: '{"creationDate":"2024-12-05T01:08:52.000Z","imageID":"52ff78a6-d303-42e3-9704-9c0693aed0b0","lastUpdateDate":"2025-06-18T17:05:49.000Z","maxImageVolumeSize":100,"name":"SLES15-SP6-BYOL","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"sles"},"state":"active","storagePool":"General-Flash-53","storageType":"tier3","volumes":[{"bootable":true,"name":"Imported
+        image volume","size":100,"volumeID":"08717c07-f68c-4473-9dc4-69cb5dd5933d"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:27:21 GMT
+  recorded_at: Wed, 25 Jun 2025 14:58:13 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/62ae0e80-e11b-45cd-a955-90fc08d7191c
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/43a0b59a-f4d7-4150-8fb8-72b4e5452d02
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Correlation-Id:
+      - b167f610-020d-42db-93f7-e8f47ca10eef
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"addresses":[{"externalIP":"127.0.0.205","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/43a0b59a-f4d7-4150-8fb8-72b4e5452d02/networks/fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","ip":"127.0.0.173","ipAddress":"127.0.0.173","macAddress":"fa:16:3e:1a:fb:62","networkID":"fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","networkInterfaceID":"d29bdd12-2853-4adf-bead-ac95ef4eaed5","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"creationDate":"2025-06-25T14:38:49.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:43a0b59a-f4d7-4150-8fb8-72b4e5452d02","diskSize":100,"health":{"lastUpdate":"2025-06-25T14:58:15.725466","status":"OK"},"hostID":58,"imageID":"810ec288-de37-49da-8c60-163a36704d30","maxmem":16,"maxproc":1,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7"],"networks":[{"externalIP":"127.0.0.205","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/43a0b59a-f4d7-4150-8fb8-72b4e5452d02/networks/fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","ip":"127.0.0.173","ipAddress":"127.0.0.173","macAddress":"fa:16:3e:1a:fb:62","networkID":"fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","networkInterfaceID":"d29bdd12-2853-4adf-bead-ac95ef4eaed5","networkName":"test-network-pub-vlan-dns","type":"fixed","version":4}],"operatingSystem":"Linux/Red
+        Hat Enterprise Linux 5.14.0-127.0.0.el9_4.ppc9.4 (Plow), 9.4 (Plow)","osType":"rhel","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.5,"pvmInstanceID":"43a0b59a-f4d7-4150-8fb8-72b4e5452d02","serverName":"test-instance-rhel-s922-shared-tier3","sharedProcessorPool":"test_pool","sharedProcessorPoolID":"85ba15e6-bbc0-469b-90b7-697876167cfc","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"s922","updatedDate":"2025-06-25T14:38:49.000Z","virtualCores":{"assigned":1,"max":2,"min":1},"volumeIDs":["ab68a4b6-921e-4149-a6d3-70c281349fcf"]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:58:16 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/810ec288-de37-49da-8c60-163a36704d30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '107'
+      X-Correlation-Id:
+      - 838412cf-1e5e-4b1c-a282-3285014b1f66
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"description":"image does not exist. ID: 810ec288-de37-49da-8c60-163a36704d30","error":"image
+        not found"}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:58:20 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/stock-images/810ec288-de37-49da-8c60-163a36704d30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -562,30 +740,40 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '432'
+      - '588'
+      X-Correlation-Id:
+      - 1a53504f-2d26-4b42-ac4c-b4e00c18dc20
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"creationDate":"2023-12-13T01:38:31.000Z","imageID":"62ae0e80-e11b-45cd-a955-90fc08d7191c","lastUpdateDate":"2023-12-13T02:22:36.000Z","name":"RHEL8-SP6","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":"","volumes":[]}
+      encoding: ASCII-8BIT
+      string: '{"creationDate":"2025-05-07T11:50:15.000Z","imageID":"810ec288-de37-49da-8c60-163a36704d30","lastUpdateDate":"2025-06-18T17:06:04.000Z","maxImageVolumeSize":100,"name":"RHEL9-SP4-BYOL","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"General-Flash-53","storageType":"tier3","volumes":[{"bootable":true,"name":"Imported
+        image volume","size":100,"volumeID":"ae4c3e8e-e5d7-4feb-84ee-05b7edf3742c"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:11 GMT
+  recorded_at: Wed, 25 Jun 2025 14:58:31 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c19f7546-323e-4e0b-bf97-5ad8668f0529
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -599,31 +787,87 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1686'
+      - '1975'
+      X-Correlation-Id:
+      - 0d97e0ba-ae13-4c4c-a50d-dc4b731140b5
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"addresses":[{"externalIP":"127.0.0.45","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5","ip":"127.0.0.45","ipAddress":"127.0.0.45","macAddress":"fa:50:f2:44:d6:20","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T18:45:03.000Z","diskSize":120,"health":{"lastUpdate":"2024-01-18T19:28:12.186103","status":"OK"},"hostID":1,"imageID":"69992304-1da0-4e66-a957-b95a58fb7d5c","maxmem":32,"maxproc":8,"memory":4,"migratable":false,"minmem":2,"minproc":1,"networkIDs":["11896394-64c5-4d6d-8a2f-a9ad829348c5"],"networks":[{"externalIP":"127.0.0.45","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5","ip":"127.0.0.45","ipAddress":"127.0.0.45","macAddress":"fa:50:f2:44:d6:20","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/CentOS
-        Stream 4.18.0-497.el8.ppc64le, 8","osType":"rhel","pinPolicy":"hard","placementGroup":"none","procType":"dedicated","processors":1,"pvmInstanceID":"1ea38460-b3ff-4abd-802b-0289983be590","serverName":"test-instance-centos-e980-dedicated-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier3","sysType":"e980","updatedDate":"2024-01-18T18:45:03.000Z","virtualCores":{"assigned":1,"max":8,"min":1},"volumeIDs":["cdfebbb2-d64e-41e1-9834-4f6b5d249489"]}
+      encoding: ASCII-8BIT
+      string: '{"addresses":[{"externalIP":"127.0.0.84","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c19f7546-323e-4e0b-bf97-5ad8668f0529/networks/33d7228f-c6c8-40ea-a99f-351e042b0b4b","ip":"127.0.0.52","ipAddress":"127.0.0.52","macAddress":"fa:16:3e:81:10:5d","networkID":"33d7228f-c6c8-40ea-a99f-351e042b0b4b","networkInterfaceID":"9506a5f9-b9d7-43b2-b17f-1808bdae10c7","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"creationDate":"2025-06-25T14:36:12.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:c19f7546-323e-4e0b-bf97-5ad8668f0529","diskSize":120,"health":{"lastUpdate":"2025-06-25T14:58:33.148581","status":"OK"},"hostID":124,"imageID":"8237f6bc-3347-47ec-b11c-8ab47683be5f","maxmem":32,"maxproc":8,"memory":4,"migratable":false,"minmem":2,"minproc":1,"networkIDs":["33d7228f-c6c8-40ea-a99f-351e042b0b4b"],"networks":[{"externalIP":"127.0.0.84","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/c19f7546-323e-4e0b-bf97-5ad8668f0529/networks/33d7228f-c6c8-40ea-a99f-351e042b0b4b","ip":"127.0.0.52","ipAddress":"127.0.0.52","macAddress":"fa:16:3e:81:10:5d","networkID":"33d7228f-c6c8-40ea-a99f-351e042b0b4b","networkInterfaceID":"9506a5f9-b9d7-43b2-b17f-1808bdae10c7","networkName":"test-network-pub-vlan","type":"fixed","version":4}],"operatingSystem":"Linux/CentOS
+        Stream 5.14.0-554.el9.ppc64le, 9","osType":"rhel","pinPolicy":"hard","placementGroup":"none","procType":"dedicated","processors":1,"pvmInstanceID":"c19f7546-323e-4e0b-bf97-5ad8668f0529","serverName":"test-instance-centos-e980-dedicated-tier3","srcs":[],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"e980","updatedDate":"2025-06-25T14:36:12.000Z","virtualCores":{"assigned":1,"max":8,"min":1},"volumeIDs":["4fdf9382-aa4c-435e-9352-de392a6ef278"]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:12 GMT
+  recorded_at: Wed, 25 Jun 2025 14:58:34 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/69992304-1da0-4e66-a957-b95a58fb7d5c
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/8237f6bc-3347-47ec-b11c-8ab47683be5f
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '107'
+      X-Correlation-Id:
+      - a9a8bc5a-b74d-45ad-bafa-f845511f98c6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"description":"image does not exist. ID: 8237f6bc-3347-47ec-b11c-8ab47683be5f","error":"image
+        not found"}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:58:37 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/stock-images/8237f6bc-3347-47ec-b11c-8ab47683be5f
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -637,30 +881,40 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '434'
+      - '589'
+      X-Correlation-Id:
+      - ccb47379-5604-4f99-a602-17a20cdb9d49
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"creationDate":"2023-12-12T20:38:09.000Z","imageID":"69992304-1da0-4e66-a957-b95a58fb7d5c","lastUpdateDate":"2023-12-12T20:55:40.000Z","name":"CentOS-Stream-8","servers":[],"size":120,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":"","volumes":[]}
+      encoding: ASCII-8BIT
+      string: '{"creationDate":"2025-05-29T21:31:51.000Z","imageID":"8237f6bc-3347-47ec-b11c-8ab47683be5f","lastUpdateDate":"2025-06-02T08:08:35.000Z","maxImageVolumeSize":120,"name":"CentOS-Stream-9","servers":[],"size":120,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"General-Flash-53","storageType":"tier3","volumes":[{"bootable":true,"name":"Imported
+        image volume","size":120,"volumeID":"f2ea7865-cedc-49f2-9d3a-43dcf1063199"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:13 GMT
+  recorded_at: Wed, 25 Jun 2025 14:58:48 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/04c9a30d-c8d5-46cb-849b-0f7fa5004b70
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -673,31 +927,87 @@ http_interactions:
     headers:
       Content-Type:
       - application/json
+      X-Correlation-Id:
+      - a44450a3-c2e5-4d81-856d-7d5acca27556
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"consoleLanguage":{"code":"037","language":"037
-        English"},"creationDate":"2024-01-18T18:43:09.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:28:14.516887","status":"OK"},"hostID":7,"imageID":"ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2","maxmem":16,"maxproc":2,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["925c13aa-9579-43a3-86e1-150131906835"],"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"V7R5M0
-        410 2","osType":"ibmi","pinPolicy":"none","placementGroup":"8334ba79-bd98-47af-ad25-6eb8a1c4c817","procType":"capped","processors":0.25,"pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a","serverName":"test-instance-ibmi-s922-capped-tier1","softwareLicenses":{"ibmiCSS":false,"ibmiDBQ":false,"ibmiPHA":false,"ibmiRDS":false},"srcs":[[{"src":"A6005008","timestamp":"2024-01-18T18:51:32Z"},{"src":"03B00061","timestamp":"2024-01-18T18:51:32Z"},{"src":"FFFF0000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"50070404","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"}]],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2024-01-18T18:43:09.000Z","virtualCores":{"assigned":1,"max":4,"min":1},"volumeIDs":["ed84f79b-b8d1-48c3-8766-2a92ff6a879b"]}
+      encoding: ASCII-8BIT
+      string: '{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/04c9a30d-c8d5-46cb-849b-0f7fa5004b70/networks/75a55a9f-1038-4495-9c3f-f7c113670c2e","ip":"127.0.0.1","ipAddress":"127.0.0.1","macAddress":"fa:16:3e:a1:4d:23","networkID":"75a55a9f-1038-4495-9c3f-f7c113670c2e","networkInterfaceID":"3ba26bdf-adea-4fae-a99b-4dfbfadac1f1","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"consoleLanguage":{"code":"037","language":"037
+        English"},"creationDate":"2025-06-25T14:33:31.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:04c9a30d-c8d5-46cb-849b-0f7fa5004b70","diskSize":100,"health":{"lastUpdate":"2025-06-25T14:58:49.785616","status":"OK"},"hostID":79,"imageID":"0e09362f-08dd-4fff-ae7b-c389b81ab7bd","maxmem":16,"maxproc":2,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["75a55a9f-1038-4495-9c3f-f7c113670c2e"],"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/04c9a30d-c8d5-46cb-849b-0f7fa5004b70/networks/75a55a9f-1038-4495-9c3f-f7c113670c2e","ip":"127.0.0.1","ipAddress":"127.0.0.1","macAddress":"fa:16:3e:a1:4d:23","networkID":"75a55a9f-1038-4495-9c3f-f7c113670c2e","networkInterfaceID":"3ba26bdf-adea-4fae-a99b-4dfbfadac1f1","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"V7R5M0
+        410 5","osType":"ibmi","pinPolicy":"soft","placementGroup":"69ac6b47-912e-4346-8804-da768f4aa789","procType":"capped","processors":0.25,"pvmInstanceID":"04c9a30d-c8d5-46cb-849b-0f7fa5004b70","serverName":"test-instance-ibmi-s922-capped-tier1","softwareLicenses":{"ibmiCSS":false,"ibmiDBQ":false,"ibmiPHA":false,"ibmiRDS":false},"srcs":[[{"src":"A6005008","timestamp":"2025-06-25T15:25:10Z"},{"src":"03B00061","timestamp":"2025-06-25T15:25:10Z"},{"src":"FFFF0000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"50070404","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"}]],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"s922","updatedDate":"2025-06-25T14:33:31.000Z","virtualCores":{"assigned":1,"max":4,"min":1},"volumeIDs":["b6a90aec-fce5-4640-9a99-140e8af2b103"]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:16 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:00 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/0e09362f-08dd-4fff-ae7b-c389b81ab7bd
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '107'
+      X-Correlation-Id:
+      - ace16d3c-7e2b-4709-9778-dc7e1a30dc73
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"description":"image does not exist. ID: 0e09362f-08dd-4fff-ae7b-c389b81ab7bd","error":"image
+        not found"}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:59:03 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/stock-images/0e09362f-08dd-4fff-ae7b-c389b81ab7bd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -711,30 +1021,40 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '433'
+      - '588'
+      X-Correlation-Id:
+      - 870962d1-95e2-4b8d-b06d-7cf395086a20
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"creationDate":"2023-12-12T23:02:27.000Z","imageID":"ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2","lastUpdateDate":"2023-12-12T23:15:20.000Z","name":"IBMi-75-02-2984-1","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"","storageType":"","volumes":[]}
+      encoding: ASCII-8BIT
+      string: '{"creationDate":"2025-03-21T00:49:56.000Z","imageID":"0e09362f-08dd-4fff-ae7b-c389b81ab7bd","lastUpdateDate":"2025-04-18T21:42:07.000Z","maxImageVolumeSize":100,"name":"IBMi-75-05-2984-1","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"General-Flash-53","storageType":"tier3","volumes":[{"bootable":true,"name":"Imported
+        image volume","size":100,"volumeID":"9e260cc3-9425-4f9e-b1a8-08181d96d604"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:17 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:14 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/5d8393c6-b50c-4de4-98f0-a04222e9fbdc
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -748,31 +1068,87 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1635'
+      - '1923'
+      X-Correlation-Id:
+      - 80beb31b-351e-4220-9f8b-6f1bb541f07e
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508/networks/3de2f865-8726-43a3-8ee8-a385aa851adf","ip":"127.0.0.186","ipAddress":"127.0.0.186","macAddress":"fa:46:3d:6b:a1:20","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2024-01-18T17:24:40.000Z","diskSize":25,"health":{"lastUpdate":"2024-01-18T19:28:18.466435","status":"OK"},"hostID":4,"imageID":"45afea97-e991-41f4-8ef9-44d5e893ff45","maxmem":16,"maxproc":2,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["3de2f865-8726-43a3-8ee8-a385aa851adf"],"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/502106d8-d969-49df-9103-184c3ab97508/networks/3de2f865-8726-43a3-8ee8-a385aa851adf","ip":"127.0.0.186","ipAddress":"127.0.0.186","macAddress":"fa:46:3d:6b:a1:20","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"AIX
-        7.3, 7300-00-01-2148","osType":"aix","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.25,"pvmInstanceID":"502106d8-d969-49df-9103-184c3ab97508","serverName":"test-instance-aix-s922-shared-tier1","srcs":[[{"src":"00000000","timestamp":"2024-01-18T17:27:40Z"}]],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2024-01-18T17:24:40.000Z","virtualCores":{"assigned":1,"max":5,"min":1},"volumeIDs":["2e653913-14fe-4b3a-a4f3-c7396bed0862"]}
+      encoding: ASCII-8BIT
+      string: '{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/5d8393c6-b50c-4de4-98f0-a04222e9fbdc/networks/ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","ip":"127.0.0.168","ipAddress":"127.0.0.168","macAddress":"fa:16:3e:30:7b:3b","networkID":"ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","networkInterfaceID":"0729a7ee-5da4-4823-8dde-5746dc687635","networkName":"test-network-vlan","type":"fixed","version":4}],"creationDate":"2025-06-25T14:29:29.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:5d8393c6-b50c-4de4-98f0-a04222e9fbdc","diskSize":20,"health":{"lastUpdate":"2025-06-25T14:59:17.173520","status":"OK"},"hostID":79,"imageID":"e8891477-f9ce-4785-b1e5-7c374701b12b","maxmem":16,"maxproc":2,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["ff2f5ffc-0ced-4a10-83ac-79d8edfa8796"],"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/5d8393c6-b50c-4de4-98f0-a04222e9fbdc/networks/ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","ip":"127.0.0.168","ipAddress":"127.0.0.168","macAddress":"fa:16:3e:30:7b:3b","networkID":"ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","networkInterfaceID":"0729a7ee-5da4-4823-8dde-5746dc687635","networkName":"test-network-vlan","type":"fixed","version":4}],"operatingSystem":"AIX
+        7.3, 7300-03-00-2446","osType":"aix","pinPolicy":"none","placementGroup":"none","procType":"shared","processors":0.25,"pvmInstanceID":"5d8393c6-b50c-4de4-98f0-a04222e9fbdc","serverName":"test-instance-aix-s922-shared-tier1","srcs":[[{"src":"00000000","timestamp":"2025-06-25T15:15:40Z"}]],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"s922","updatedDate":"2025-06-25T14:29:29.000Z","virtualCores":{"assigned":1,"max":5,"min":1},"volumeIDs":["1f455cf4-c82c-4e1b-b84b-f1e86082aadf"]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:19 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:18 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/45afea97-e991-41f4-8ef9-44d5e893ff45
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/e8891477-f9ce-4785-b1e5-7c374701b12b
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '107'
+      X-Correlation-Id:
+      - 1adc31e1-01ce-4f30-a6e4-165cf28178ec
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"description":"image does not exist. ID: e8891477-f9ce-4785-b1e5-7c374701b12b","error":"image
+        not found"}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 14:59:21 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/stock-images/e8891477-f9ce-4785-b1e5-7c374701b12b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -786,30 +1162,40 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '424'
+      - '577'
+      X-Correlation-Id:
+      - 0b62b593-a120-40d9-9bc8-4c728ac28767
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"creationDate":"2023-12-12T20:13:32.000Z","imageID":"45afea97-e991-41f4-8ef9-44d5e893ff45","lastUpdateDate":"2023-12-12T20:19:11.000Z","name":"7300-00-01","servers":[],"size":25,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"aix"},"state":"active","storagePool":"","storageType":"","volumes":[]}
+      encoding: ASCII-8BIT
+      string: '{"creationDate":"2025-02-21T02:18:35.000Z","imageID":"e8891477-f9ce-4785-b1e5-7c374701b12b","lastUpdateDate":"2025-04-21T18:08:01.000Z","maxImageVolumeSize":20,"name":"7300-03-00","servers":[],"size":20,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"aix"},"state":"active","storagePool":"General-Flash-53","storageType":"tier3","volumes":[{"bootable":true,"name":"Imported
+        image volume","size":20,"volumeID":"b1580945-d0b4-47ca-8915-ae2826f2656a"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:20 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:29 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -823,30 +1209,39 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '945'
+      - '1645'
+      X-Correlation-Id:
+      - ce8838ad-b883-44a7-a5ec-53ba9bdfeebb
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"networks":[{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5","name":"test-network-pub-vlan","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","type":"pub-vlan","vlanID":2161},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3de2f865-8726-43a3-8ee8-a385aa851adf","name":"test-network-vlan","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","type":"vlan","vlanID":1182},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b","name":"test-network-pub-vlan-dns","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","type":"pub-vlan","vlanID":2171},{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/925c13aa-9579-43a3-86e1-150131906835","jumbo":true,"name":"test-network-vlan-jumbo","networkID":"925c13aa-9579-43a3-86e1-150131906835","type":"vlan","vlanID":424}]}
+      encoding: ASCII-8BIT
+      string: '{"networks":[{"crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:network:33d7228f-c6c8-40ea-a99f-351e042b0b4b","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/33d7228f-c6c8-40ea-a99f-351e042b0b4b","mtu":1450,"name":"test-network-pub-vlan","networkID":"33d7228f-c6c8-40ea-a99f-351e042b0b4b","type":"pub-vlan","vlanID":2134},{"crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:network:75a55a9f-1038-4495-9c3f-f7c113670c2e","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/75a55a9f-1038-4495-9c3f-f7c113670c2e","jumbo":true,"mtu":9000,"name":"test-network-vlan-jumbo","networkID":"75a55a9f-1038-4495-9c3f-f7c113670c2e","type":"vlan","vlanID":646},{"crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:network:fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","mtu":1450,"name":"test-network-pub-vlan-dns","networkID":"fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","type":"pub-vlan","vlanID":2149},{"crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:network:ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","mtu":1450,"name":"test-network-vlan","networkID":"ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","type":"vlan","vlanID":1098}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:20 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:31 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/33d7228f-c6c8-40ea-a99f-351e042b0b4b
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -860,30 +1255,39 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '456'
+      - '631'
+      X-Correlation-Id:
+      - 3e5bbef2-fd20-4b33-8ed7-bd8609aaa9b3
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"cidr":"127.0.0.40/29","dnsServers":["127.0.0.9"],"gateway":"127.0.0.41","ipAddressMetrics":{"available":3,"total":5,"used":2,"utilization":40},"ipAddressRanges":[{"endingIPAddress":"127.0.0.46","startingIPAddress":"127.0.0.42"}],"name":"test-network-pub-vlan","networkID":"11896394-64c5-4d6d-8a2f-a9ad829348c5","publicIPAddressRanges":[{"endingIPAddress":"127.0.0.46","startingIPAddress":"127.0.0.42"}],"type":"pub-vlan","vlanID":2161}
+      encoding: ASCII-8BIT
+      string: '{"cidr":"127.0.0.48/29","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:network:33d7228f-c6c8-40ea-a99f-351e042b0b4b","dnsServers":["127.0.0.9"],"gateway":"127.0.0.49","ipAddressMetrics":{"available":3,"total":5,"used":2,"utilization":40},"ipAddressRanges":[{"endingIPAddress":"127.0.0.54","startingIPAddress":"127.0.0.50"}],"mtu":1450,"name":"test-network-pub-vlan","networkID":"33d7228f-c6c8-40ea-a99f-351e042b0b4b","publicIPAddressRanges":[{"endingIPAddress":"127.0.0.86","startingIPAddress":"127.0.0.82"}],"type":"pub-vlan","vlanID":2134}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:20 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:32 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5/ports
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/33d7228f-c6c8-40ea-a99f-351e042b0b4b/ports
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -897,30 +1301,39 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1060'
+      - '1177'
+      X-Correlation-Id:
+      - 1e94a641-406b-4718-8941-847641e1dfb2
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"ports":[{"description":"","externalIP":"127.0.0.46","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5/ports/4e6d559a-1009-4920-a482-f2e40d9fb3a9","ipAddress":"127.0.0.46","macAddress":"fa:1a:90:7c:8a:21","portID":"4e6d559a-1009-4920-a482-f2e40d9fb3a9","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd","pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd"},"status":"ACTIVE"},{"description":"","externalIP":"127.0.0.45","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/11896394-64c5-4d6d-8a2f-a9ad829348c5/ports/43ac9d1e-a3b3-4796-a9a9-c07dacc82733","ipAddress":"127.0.0.45","macAddress":"fa:50:f2:44:d6:20","portID":"43ac9d1e-a3b3-4796-a9a9-c07dacc82733","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/1ea38460-b3ff-4abd-802b-0289983be590","pvmInstanceID":"1ea38460-b3ff-4abd-802b-0289983be590"},"status":"ACTIVE"}]}
+      encoding: ASCII-8BIT
+      string: '{"ports":[{"description":"netInterface-public-test-instance-sles-s922-shared-tier3","externalIP":"127.0.0.83","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/33d7228f-c6c8-40ea-a99f-351e042b0b4b/ports/7c25445c-c769-44b7-aa83-2a8cd322e9b4","ipAddress":"127.0.0.51","macAddress":"fa:16:3e:54:22:62","portID":"7c25445c-c769-44b7-aa83-2a8cd322e9b4","pvmInstance":{"href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb","pvmInstanceID":"c717671d-baae-4955-879f-0588ef5171bb"},"status":"ACTIVE"},{"description":"netInterface-public-test-instance-centos-e980-dedicated-tier3","externalIP":"127.0.0.84","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/33d7228f-c6c8-40ea-a99f-351e042b0b4b/ports/9506a5f9-b9d7-43b2-b17f-1808bdae10c7","ipAddress":"127.0.0.52","macAddress":"fa:16:3e:81:10:5d","portID":"9506a5f9-b9d7-43b2-b17f-1808bdae10c7","pvmInstance":{"href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/pvm-instances/c19f7546-323e-4e0b-bf97-5ad8668f0529","pvmInstanceID":"c19f7546-323e-4e0b-bf97-5ad8668f0529"},"status":"ACTIVE"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:20 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:34 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/3de2f865-8726-43a3-8ee8-a385aa851adf
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/75a55a9f-1038-4495-9c3f-f7c113670c2e
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -934,30 +1347,39 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '335'
+      - '609'
+      X-Correlation-Id:
+      - 0e65d75b-f789-4bd8-87fb-5eeeb8024759
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"cidr":"127.0.0.0/24","dnsServers":["127.0.0.1"],"gateway":"127.0.0.1","ipAddressMetrics":{"available":251,"total":253,"used":2,"utilization":0},"ipAddressRanges":[{"endingIPAddress":"127.0.0.254","startingIPAddress":"127.0.0.2"}],"name":"test-network-vlan","networkID":"3de2f865-8726-43a3-8ee8-a385aa851adf","type":"vlan","vlanID":1182}
+      encoding: ASCII-8BIT
+      string: '{"cidr":"127.0.0.0/25","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:network:75a55a9f-1038-4495-9c3f-f7c113670c2e","dnsServers":["127.0.0.10","127.0.0.11"],"gateway":"127.0.0.16","ipAddressMetrics":{"available":123,"total":125,"used":2,"utilization":1},"ipAddressRanges":[{"endingIPAddress":"127.0.0.15","startingIPAddress":"127.0.0.1"},{"endingIPAddress":"127.0.0.126","startingIPAddress":"127.0.0.17"}],"jumbo":true,"mtu":9000,"name":"test-network-vlan-jumbo","networkID":"75a55a9f-1038-4495-9c3f-f7c113670c2e","type":"vlan","vlanID":646}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:21 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:36 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/3de2f865-8726-43a3-8ee8-a385aa851adf/ports
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/75a55a9f-1038-4495-9c3f-f7c113670c2e/ports
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -971,30 +1393,39 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '996'
+      - '1091'
+      X-Correlation-Id:
+      - f3428844-90ff-4abb-abc1-fc4422d3c078
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"ports":[{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3de2f865-8726-43a3-8ee8-a385aa851adf/ports/1ba40a34-7b29-4893-a046-1c1762e745ca","ipAddress":"127.0.0.208","macAddress":"fa:1a:90:7c:8a:20","portID":"1ba40a34-7b29-4893-a046-1c1762e745ca","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/54e1f646-8ce4-4ee5-9355-e5d34166c4fd","pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd"},"status":"ACTIVE"},{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3de2f865-8726-43a3-8ee8-a385aa851adf/ports/a62e83af-8c0c-4f48-9c60-5d2985decf3e","ipAddress":"127.0.0.186","macAddress":"fa:46:3d:6b:a1:20","portID":"a62e83af-8c0c-4f48-9c60-5d2985decf3e","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/502106d8-d969-49df-9103-184c3ab97508","pvmInstanceID":"502106d8-d969-49df-9103-184c3ab97508"},"status":"ACTIVE"}]}
+      encoding: ASCII-8BIT
+      string: '{"ports":[{"description":"netInterface-test-instance-ibmi-s922-capped-tier1","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/75a55a9f-1038-4495-9c3f-f7c113670c2e/ports/3ba26bdf-adea-4fae-a99b-4dfbfadac1f1","ipAddress":"127.0.0.1","macAddress":"fa:16:3e:a1:4d:23","portID":"3ba26bdf-adea-4fae-a99b-4dfbfadac1f1","pvmInstance":{"href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/pvm-instances/04c9a30d-c8d5-46cb-849b-0f7fa5004b70","pvmInstanceID":"04c9a30d-c8d5-46cb-849b-0f7fa5004b70"},"status":"ACTIVE"},{"description":"netInterface-test-instance-rhcos-s922-shared-tier3","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/75a55a9f-1038-4495-9c3f-f7c113670c2e/ports/1c3e5c91-3c61-49f2-a55f-082958467a67","ipAddress":"127.0.0.8","macAddress":"fa:16:3e:c9:9f:58","portID":"1c3e5c91-3c61-49f2-a55f-082958467a67","pvmInstance":{"href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9","pvmInstanceID":"9317b826-3660-4cf9-aa93-6d42a4643ba9"},"status":"ACTIVE"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:21 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:37 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1008,30 +1439,39 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '466'
+      - '641'
+      X-Correlation-Id:
+      - 7f718702-10bb-4da8-880d-a445bfc1752d
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"cidr":"127.0.0.120/29","dnsServers":["127.0.0.9"],"gateway":"127.0.0.121","ipAddressMetrics":{"available":3,"total":5,"used":2,"utilization":40},"ipAddressRanges":[{"endingIPAddress":"127.0.0.126","startingIPAddress":"127.0.0.122"}],"name":"test-network-pub-vlan-dns","networkID":"3e0c10e1-7cca-44b4-865d-ebd369169a1b","publicIPAddressRanges":[{"endingIPAddress":"127.0.0.126","startingIPAddress":"127.0.0.122"}],"type":"pub-vlan","vlanID":2171}
+      encoding: ASCII-8BIT
+      string: '{"cidr":"127.0.0.168/29","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:network:fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","dnsServers":["127.0.0.9"],"gateway":"127.0.0.169","ipAddressMetrics":{"available":3,"total":5,"used":2,"utilization":40},"ipAddressRanges":[{"endingIPAddress":"127.0.0.174","startingIPAddress":"127.0.0.170"}],"mtu":1450,"name":"test-network-pub-vlan-dns","networkID":"fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7","publicIPAddressRanges":[{"endingIPAddress":"127.0.0.206","startingIPAddress":"127.0.0.202"}],"type":"pub-vlan","vlanID":2149}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:21 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:39 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b/ports
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7/ports
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1045,30 +1485,39 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1064'
+      - '1177'
+      X-Correlation-Id:
+      - 44be4e88-c48a-4661-8825-c29a9511149f
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"ports":[{"description":"","externalIP":"127.0.0.122","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b/ports/434c6948-4eb0-43df-9259-109b135c3c84","ipAddress":"127.0.0.122","macAddress":"fa:7f:f8:6b:9e:21","portID":"434c6948-4eb0-43df-9259-109b135c3c84","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8","pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8"},"status":"ACTIVE"},{"description":"","externalIP":"127.0.0.124","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/3e0c10e1-7cca-44b4-865d-ebd369169a1b/ports/f93f5be1-89a3-40a6-9f31-0ad01e7f5c9f","ipAddress":"127.0.0.124","macAddress":"fa:a0:0e:97:fe:20","portID":"f93f5be1-89a3-40a6-9f31-0ad01e7f5c9f","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","pvmInstanceID":"b9370d8d-8d73-4f0e-ad84-34f7fd52eb84"},"status":"ACTIVE"}]}
+      encoding: ASCII-8BIT
+      string: '{"ports":[{"description":"netInterface-public-test-instance-rhel-s922-shared-tier3","externalIP":"127.0.0.205","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7/ports/d29bdd12-2853-4adf-bead-ac95ef4eaed5","ipAddress":"127.0.0.173","macAddress":"fa:16:3e:1a:fb:62","portID":"d29bdd12-2853-4adf-bead-ac95ef4eaed5","pvmInstance":{"href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/pvm-instances/43a0b59a-f4d7-4150-8fb8-72b4e5452d02","pvmInstanceID":"43a0b59a-f4d7-4150-8fb8-72b4e5452d02"},"status":"ACTIVE"},{"description":"netInterface-public-test-instance-rhcos-s922-shared-tier3","externalIP":"127.0.0.203","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/fbace7a8-4fa7-48b9-a21f-3bee8f9ac1e7/ports/ef882de7-3959-4217-89c4-89db3edb6eff","ipAddress":"127.0.0.171","macAddress":"fa:16:3e:fd:c2:38","portID":"ef882de7-3959-4217-89c4-89db3edb6eff","pvmInstance":{"href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/pvm-instances/9317b826-3660-4cf9-aa93-6d42a4643ba9","pvmInstanceID":"9317b826-3660-4cf9-aa93-6d42a4643ba9"},"status":"ACTIVE"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:22 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:41 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/925c13aa-9579-43a3-86e1-150131906835
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/ff2f5ffc-0ced-4a10-83ac-79d8edfa8796
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1082,30 +1531,39 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '429'
+      - '526'
+      X-Correlation-Id:
+      - 6bf103e5-fc18-4962-a3ce-45ba3c4643ec
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"cidr":"127.0.0.0/25","dnsServers":["127.0.0.1"],"gateway":"127.0.0.16","ipAddressMetrics":{"available":123,"total":125,"used":2,"utilization":1},"ipAddressRanges":[{"endingIPAddress":"127.0.0.126","startingIPAddress":"127.0.0.17"},{"endingIPAddress":"127.0.0.15","startingIPAddress":"127.0.0.1"}],"jumbo":true,"mtu":9000,"name":"test-network-vlan-jumbo","networkID":"925c13aa-9579-43a3-86e1-150131906835","type":"vlan","vlanID":424}
+      encoding: ASCII-8BIT
+      string: '{"cidr":"127.0.0.0/24","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:network:ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","dnsServers":["127.0.0.10","127.0.0.11"],"gateway":"127.0.0.1","ipAddressMetrics":{"available":251,"total":253,"used":2,"utilization":0},"ipAddressRanges":[{"endingIPAddress":"127.0.0.254","startingIPAddress":"127.0.0.2"}],"mtu":1450,"name":"test-network-vlan","networkID":"ff2f5ffc-0ced-4a10-83ac-79d8edfa8796","type":"vlan","vlanID":1098}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:22 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:43 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/925c13aa-9579-43a3-86e1-150131906835/ports
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/networks/ff2f5ffc-0ced-4a10-83ac-79d8edfa8796/ports
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1119,30 +1577,39 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '994'
+      - '1093'
+      X-Correlation-Id:
+      - a8e1f2e7-827e-449d-a776-e8b9e0c6c8a0
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"ports":[{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/925c13aa-9579-43a3-86e1-150131906835/ports/268a6d4f-4461-4c71-8114-2aab5337654e","ipAddress":"127.0.0.10","macAddress":"fa:7f:f8:6b:9e:20","portID":"268a6d4f-4461-4c71-8114-2aab5337654e","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/d6a661a8-fed1-4a52-9d50-24fc9f9956b8","pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8"},"status":"ACTIVE"},{"description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/networks/925c13aa-9579-43a3-86e1-150131906835/ports/d3bbd78f-96c8-4981-b076-e8db416c96d9","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","portID":"d3bbd78f-96c8-4981-b076-e8db416c96d9","pvmInstance":{"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a","pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a"},"status":"ACTIVE"}]}
+      encoding: ASCII-8BIT
+      string: '{"ports":[{"description":"netInterface-test-instance-sles-s922-shared-tier3","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/ff2f5ffc-0ced-4a10-83ac-79d8edfa8796/ports/7428c137-e911-4a3e-b0b8-dcd9add53283","ipAddress":"127.0.0.222","macAddress":"fa:16:3e:18:d9:fc","portID":"7428c137-e911-4a3e-b0b8-dcd9add53283","pvmInstance":{"href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/pvm-instances/c717671d-baae-4955-879f-0588ef5171bb","pvmInstanceID":"c717671d-baae-4955-879f-0588ef5171bb"},"status":"ACTIVE"},{"description":"netInterface-test-instance-aix-s922-shared-tier1","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/networks/ff2f5ffc-0ced-4a10-83ac-79d8edfa8796/ports/0729a7ee-5da4-4823-8dde-5746dc687635","ipAddress":"127.0.0.168","macAddress":"fa:16:3e:30:7b:3b","portID":"0729a7ee-5da4-4823-8dde-5746dc687635","pvmInstance":{"href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/pvm-instances/5d8393c6-b50c-4de4-98f0-a04222e9fbdc","pvmInstanceID":"5d8393c6-b50c-4de4-98f0-a04222e9fbdc"},"status":"ACTIVE"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:22 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:45 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/tenants/1fdf5effc3f945688c021cd0a8b45c4d
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/tenants/1fdf5effc3f945688c021cd0a8b45c4d
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1155,13 +1622,22 @@ http_interactions:
     headers:
       Content-Type:
       - application/json
+      X-Correlation-Id:
+      - 86ecd2f9-3a00-4049-8222-85d7afeb0bed
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"cloudInstances":[{"capabilities":[],"cloudInstanceID":"1e2141a3a00f4ea09cb29ed55d090421","enabled":true,"href":"/pcloud/v1/cloud-instances/1e2141a3a00f4ea09cb29ed55d090421","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"97ce8888-250f-413c-9034-3131bce331f8","region":"mon01"},{"capabilities":[],"cloudInstanceID":"323a5df0f79146fa83bc470d9d6d83b4","enabled":true,"href":"/pcloud/v1/cloud-instances/323a5df0f79146fa83bc470d9d6d83b4","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"6aaf801e-6674-454e-ab77-646c28c0aaee","region":"lon06"},{"capabilities":[],"cloudInstanceID":"367781069c3f41a2a33af29e3daf43d5","enabled":true,"href":"/pcloud/v1/cloud-instances/367781069c3f41a2a33af29e3daf43d5","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"5a2f84d3-ee77-4c16-b554-f99fbccdb419","region":"tor01"},{"capabilities":[],"cloudInstanceID":"4361d240c3b54582876849a1e0d51c48","enabled":true,"href":"/pcloud/v1/cloud-instances/4361d240c3b54582876849a1e0d51c48","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d83592cf-c86e-47a3-a470-749d564de104","region":"tor01"},{"capabilities":[],"cloudInstanceID":"5818fde64f5d409b906226c5c0c27654","enabled":true,"href":"/pcloud/v1/cloud-instances/5818fde64f5d409b906226c5c0c27654","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"3ea904f1-67df-4ae0-960f-e13ffa469f12","region":"sao01"},{"capabilities":[],"cloudInstanceID":"58bd80b9c85a4264967ff25aac6ace0f","enabled":true,"href":"/pcloud/v1/cloud-instances/58bd80b9c85a4264967ff25aac6ace0f","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"33d26fea-f20b-47d5-a863-b5bbf41a7c57","region":"mon01"},{"capabilities":[],"cloudInstanceID":"60dd8ebe0aef4beca1efd210cd0174e4","enabled":true,"href":"/pcloud/v1/cloud-instances/60dd8ebe0aef4beca1efd210cd0174e4","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"37fda19e-c1fd-4a29-9a7c-7d16b7eac73a","region":"sao01"},{"capabilities":[],"cloudInstanceID":"616d723acd01463bbe71a293be63d88f","enabled":true,"href":"/pcloud/v1/cloud-instances/616d723acd01463bbe71a293be63d88f","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"c507194a-4bc8-4cc7-9d55-aac47c17ba06","region":"syd05"},{"capabilities":[],"cloudInstanceID":"633f13eef34344a2b1370ba98643bbf3","enabled":true,"href":"/pcloud/v1/cloud-instances/633f13eef34344a2b1370ba98643bbf3","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"df3fea77-b9b6-4d48-b29c-9b5146c055ab","region":"mon01"},{"capabilities":[],"cloudInstanceID":"64538eac23f64802850102654092ac82","enabled":true,"href":"/pcloud/v1/cloud-instances/64538eac23f64802850102654092ac82","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"851f82c2-034c-4c32-9764-94262d245a50","region":"mon01"},{"capabilities":[],"cloudInstanceID":"64c6cfbd9ddd49758a6e83afdcec83e9","enabled":true,"href":"/pcloud/v1/cloud-instances/64c6cfbd9ddd49758a6e83afdcec83e9","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"4ee5f231-5e89-44d1-ba57-69796d222853","region":"mon01"},{"capabilities":[],"cloudInstanceID":"6b88538cb7394fe8bb41be949c5fa8ee","enabled":true,"href":"/pcloud/v1/cloud-instances/6b88538cb7394fe8bb41be949c5fa8ee","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d4cc6d16-b80b-464b-8b09-dcf972f28b5f","region":"syd05"},{"capabilities":[],"cloudInstanceID":"8b77ae6ff945452d85e52447a3bfb41c","enabled":true,"href":"/pcloud/v1/cloud-instances/8b77ae6ff945452d85e52447a3bfb41c","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d68da88c-0624-44c5-a19b-8bc2df909e90","region":"syd04"},{"capabilities":[],"cloudInstanceID":"914b05caac05408694e562586a65478b","enabled":true,"href":"/pcloud/v1/cloud-instances/914b05caac05408694e562586a65478b","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"b9db6009-30fc-4718-98cb-16ba6fd37b82","region":"mon01"},{"capabilities":[],"cloudInstanceID":"a1a6d247e7f34df1bdcdac03fc45e443","enabled":true,"href":"/pcloud/v1/cloud-instances/a1a6d247e7f34df1bdcdac03fc45e443","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"63dce3d0-89b3-4e6a-b49c-d8a36db64106","region":"mad02"},{"capabilities":[],"cloudInstanceID":"ac6f36efacd9470d9859adbd153c8aea","enabled":true,"href":"/pcloud/v1/cloud-instances/ac6f36efacd9470d9859adbd153c8aea","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"20835aba-2926-407d-9a2a-3dcf07fec934","region":"mon01"},{"capabilities":[],"cloudInstanceID":"bd9dde6d07494018b6211b5066d92d9f","enabled":true,"href":"/pcloud/v1/cloud-instances/bd9dde6d07494018b6211b5066d92d9f","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"b7f1637d-96fe-46f0-9895-ce305d6e3865","region":"mon01"},{"capabilities":[],"cloudInstanceID":"bf368eaf05a8467091cbcb8e4bcc185c","enabled":true,"href":"/pcloud/v1/cloud-instances/bf368eaf05a8467091cbcb8e4bcc185c","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"8f3d13de-8503-4898-a313-f560343ce78a","region":"syd04"},{"capabilities":[],"cloudInstanceID":"c8d0ac7c30c944f0ac3288eb8bb74aaa","enabled":true,"href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"IBM_CLOUD_POWERVS_INSTANCE_ID","region":"mon01"},{"capabilities":[],"cloudInstanceID":"dd39bb389d9e4eddb3d4434d9db029aa","enabled":true,"href":"/pcloud/v1/cloud-instances/dd39bb389d9e4eddb3d4434d9db029aa","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"9e671060-3902-4eab-ab6f-10b64f354c1c","region":"mon01"},{"capabilities":[],"cloudInstanceID":"e75edc3d6b6348698960ec9a5d4e79e5","enabled":true,"href":"/pcloud/v1/cloud-instances/e75edc3d6b6348698960ec9a5d4e79e5","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"4587b311-5930-47fa-9e79-61296f714a06","region":"tok04"},{"capabilities":[],"cloudInstanceID":"e9f4c3fad00c4b20b3e4ede7133a80ba","enabled":true,"href":"/pcloud/v1/cloud-instances/e9f4c3fad00c4b20b3e4ede7133a80ba","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d0764634-2578-4d7d-a9a6-389dc8a7dca9","region":"osa21"},{"capabilities":[],"cloudInstanceID":"f7a5f0a3b1b94047a090ab097cbf8207","enabled":true,"href":"/pcloud/v1/cloud-instances/f7a5f0a3b1b94047a090ab097cbf8207","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"1f6e4394-4346-4dcb-be81-eeed2152c4b7","region":"mon01"}],"creationDate":"2019-06-17T13:00:30.592Z","enabled":true,"sshKeys":[{"creationDate":"2021-01-19T13:24:14.835Z","name":"jwcroppe-mac","sshKey":"ssh-rsa
+      encoding: ASCII-8BIT
+      string: '{"cloudInstances":[{"capabilities":[],"cloudInstanceID":"036dca1b65e14a8d9ea8bc7d25d098d7","enabled":true,"href":"/pcloud/v1/cloud-instances/036dca1b65e14a8d9ea8bc7d25d098d7","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"3a13c6df-bf24-44ce-a002-c69ceca9a4b8","region":"us-east12"},{"capabilities":[],"cloudInstanceID":"0dccd2712f7546d1bf9b5729b9b679a9","enabled":true,"href":"/pcloud/v1/cloud-instances/0dccd2712f7546d1bf9b5729b9b679a9","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"1da5cf28-c2a2-4c35-8799-966ea4f86d78","region":"us-east14"},{"capabilities":[],"cloudInstanceID":"1e2141a3a00f4ea09cb29ed55d090421","enabled":true,"href":"/pcloud/v1/cloud-instances/1e2141a3a00f4ea09cb29ed55d090421","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"97ce8888-250f-413c-9034-3131bce331f8","region":"mon01"},{"capabilities":[],"cloudInstanceID":"23379635744a4179bf3475b215cfbda5","enabled":true,"href":"/pcloud/v1/cloud-instances/23379635744a4179bf3475b215cfbda5","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"789b6cad-a024-4527-a076-f02253f58c32","region":"us-east10"},{"capabilities":[],"cloudInstanceID":"323a5df0f79146fa83bc470d9d6d83b4","enabled":true,"href":"/pcloud/v1/cloud-instances/323a5df0f79146fa83bc470d9d6d83b4","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"6aaf801e-6674-454e-ab77-646c28c0aaee","region":"lon06"},{"capabilities":[],"cloudInstanceID":"33f4a0df16cc47ffb712a3ec5be6948b","enabled":true,"href":"/pcloud/v1/cloud-instances/33f4a0df16cc47ffb712a3ec5be6948b","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"89446a5a-8242-47d8-98f0-ba3d6472edf0","region":"us-south"},{"capabilities":[],"cloudInstanceID":"367781069c3f41a2a33af29e3daf43d5","enabled":true,"href":"/pcloud/v1/cloud-instances/367781069c3f41a2a33af29e3daf43d5","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"5a2f84d3-ee77-4c16-b554-f99fbccdb419","region":"tor01"},{"capabilities":[],"cloudInstanceID":"4361d240c3b54582876849a1e0d51c48","enabled":true,"href":"/pcloud/v1/cloud-instances/4361d240c3b54582876849a1e0d51c48","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d83592cf-c86e-47a3-a470-749d564de104","region":"tor01"},{"capabilities":[],"cloudInstanceID":"575fcfa86cf94140bff50ccd85047195","enabled":true,"href":"/pcloud/v1/cloud-instances/575fcfa86cf94140bff50ccd85047195","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"7872439e-1b4e-4c8c-a023-ab98940bf1e3","region":"us-east10"},{"capabilities":[],"cloudInstanceID":"5818fde64f5d409b906226c5c0c27654","enabled":true,"href":"/pcloud/v1/cloud-instances/5818fde64f5d409b906226c5c0c27654","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"3ea904f1-67df-4ae0-960f-e13ffa469f12","region":"sao01"},{"capabilities":[],"cloudInstanceID":"60dd8ebe0aef4beca1efd210cd0174e4","enabled":true,"href":"/pcloud/v1/cloud-instances/60dd8ebe0aef4beca1efd210cd0174e4","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"37fda19e-c1fd-4a29-9a7c-7d16b7eac73a","region":"sao01"},{"capabilities":[],"cloudInstanceID":"64538eac23f64802850102654092ac82","enabled":true,"href":"/pcloud/v1/cloud-instances/64538eac23f64802850102654092ac82","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"851f82c2-034c-4c32-9764-94262d245a50","region":"mon01"},{"capabilities":[],"cloudInstanceID":"64c6cfbd9ddd49758a6e83afdcec83e9","enabled":true,"href":"/pcloud/v1/cloud-instances/64c6cfbd9ddd49758a6e83afdcec83e9","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"4ee5f231-5e89-44d1-ba57-69796d222853","region":"mon01"},{"capabilities":[],"cloudInstanceID":"6b88538cb7394fe8bb41be949c5fa8ee","enabled":true,"href":"/pcloud/v1/cloud-instances/6b88538cb7394fe8bb41be949c5fa8ee","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d4cc6d16-b80b-464b-8b09-dcf972f28b5f","region":"syd05"},{"capabilities":[],"cloudInstanceID":"804345438ffb4853939f400491d45a61","enabled":true,"href":"/pcloud/v1/cloud-instances/804345438ffb4853939f400491d45a61","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"da182091-93ac-437e-b64b-8fc72eda061c","region":"us-south"},{"capabilities":[],"cloudInstanceID":"8a91eb10a7de4b499d0868a26e2cea3f","enabled":true,"href":"/pcloud/v1/cloud-instances/8a91eb10a7de4b499d0868a26e2cea3f","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"97dd087c-e2cc-424a-b086-36106d7e9f76","region":"us-east10"},{"capabilities":[],"cloudInstanceID":"8b77ae6ff945452d85e52447a3bfb41c","enabled":true,"href":"/pcloud/v1/cloud-instances/8b77ae6ff945452d85e52447a3bfb41c","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d68da88c-0624-44c5-a19b-8bc2df909e90","region":"syd04"},{"capabilities":[],"cloudInstanceID":"9089686c4d6143a4bdcc72b197c7655d","enabled":true,"href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"IBM_CLOUD_POWERVS_INSTANCE_ID","region":"us-east10"},{"capabilities":[],"cloudInstanceID":"914b05caac05408694e562586a65478b","enabled":true,"href":"/pcloud/v1/cloud-instances/914b05caac05408694e562586a65478b","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"b9db6009-30fc-4718-98cb-16ba6fd37b82","region":"mon01"},{"capabilities":[],"cloudInstanceID":"93d6532f6c6e49edb190ab5ac9739db4","enabled":true,"href":"/pcloud/v1/cloud-instances/93d6532f6c6e49edb190ab5ac9739db4","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d883b9f7-a558-48e6-a74f-4be2eb48cad9","region":"eu-de-1"},{"capabilities":[],"cloudInstanceID":"a1a6d247e7f34df1bdcdac03fc45e443","enabled":true,"href":"/pcloud/v1/cloud-instances/a1a6d247e7f34df1bdcdac03fc45e443","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"63dce3d0-89b3-4e6a-b49c-d8a36db64106","region":"mad02"},{"capabilities":[],"cloudInstanceID":"bd9dde6d07494018b6211b5066d92d9f","enabled":true,"href":"/pcloud/v1/cloud-instances/bd9dde6d07494018b6211b5066d92d9f","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"b7f1637d-96fe-46f0-9895-ce305d6e3865","region":"mon01"},{"capabilities":[],"cloudInstanceID":"bf368eaf05a8467091cbcb8e4bcc185c","enabled":true,"href":"/pcloud/v1/cloud-instances/bf368eaf05a8467091cbcb8e4bcc185c","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"8f3d13de-8503-4898-a313-f560343ce78a","region":"syd04"},{"capabilities":[],"cloudInstanceID":"ccc5bd157bf04888be3ee0c2cef2714e","enabled":true,"href":"/pcloud/v1/cloud-instances/ccc5bd157bf04888be3ee0c2cef2714e","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"eda6a89f-4e1a-43bc-93b4-d1f68d4abaf4","region":"us-east10"},{"capabilities":[],"cloudInstanceID":"dd39bb389d9e4eddb3d4434d9db029aa","enabled":true,"href":"/pcloud/v1/cloud-instances/dd39bb389d9e4eddb3d4434d9db029aa","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"9e671060-3902-4eab-ab6f-10b64f354c1c","region":"mon01"},{"capabilities":[],"cloudInstanceID":"e0cda0ca625842d8ae200e2da74874a0","enabled":true,"href":"/pcloud/v1/cloud-instances/e0cda0ca625842d8ae200e2da74874a0","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d934dddd-cd0d-4edc-9c98-5fcedee52414","region":"eu-de-1"},{"capabilities":[],"cloudInstanceID":"e75edc3d6b6348698960ec9a5d4e79e5","enabled":true,"href":"/pcloud/v1/cloud-instances/e75edc3d6b6348698960ec9a5d4e79e5","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"4587b311-5930-47fa-9e79-61296f714a06","region":"tok04"},{"capabilities":[],"cloudInstanceID":"e9f4c3fad00c4b20b3e4ede7133a80ba","enabled":true,"href":"/pcloud/v1/cloud-instances/e9f4c3fad00c4b20b3e4ede7133a80ba","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"d0764634-2578-4d7d-a9a6-389dc8a7dca9","region":"osa21"},{"capabilities":[],"cloudInstanceID":"f1b86ccd4cc14fafa205b97d20afb914","enabled":true,"href":"/pcloud/v1/cloud-instances/f1b86ccd4cc14fafa205b97d20afb914","initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"2d6f12e5-7762-41ed-97f7-7b21ed9ef2ab","region":"osa21"}],"creationDate":"2019-06-17T13:00:30.592Z","enabled":true,"sshKeys":[{"creationDate":"2021-01-19T13:24:14.835Z","name":"jwcroppe-mac","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABAQDCv9DfTRHiHFqQMB+qNX0d9TyIP7TowEK2WWYrOLJPG7EJVyoTitXc/3Y5+/MLj28fyn52d9Ut+WZErjBMTlF30d180yVXlB2Gv6RztufC7sbSNM8w20E/DIHPVJS3E8fuIPft91T0HFH6OC+8YH/W72PSTraLFDVTq1U57338TdEexCmzFz2ABJ4Dzza1k9mHA372P1SQ8CgR9ipHXPE32Fvn2T8+3kDDhDdxpfkwxgX4p1JI9gfn2VMui8NsEhSetEQ5KuLtgNwC7S7DaOzgNsreJmWIiur9/ceCTHXZlMVS//tWcwrrvikXXn5cJhO+TJpcE88L0txiJG9KoI0/
         jwcroppe@jwcroppe-mac"},{"creationDate":"2021-02-12T17:53:34.397Z","name":"beta","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDm+dD4O+oqKCNyhpV0Qj5QRCerPBsCysunyw8WP14X/AwqG8iyg5z9C5k/gOc1zCN+FWanQO2T+A6JfW8PZU02qhYC3mEzjiYhyAyFvfx74FGcBLdtbI9QchjwNLt2sZGy387mkW50+uroTLujZtGoF6xfX4mwxqYeDNC74YSF+gzcqJGWwb7rTdKKSgWfXQFLiegC4GLFOuKNZ1DluUsQD/+dfrQ3SUzp484x/efDPf33hWEsqCbS210U1h/iUa7PQ489v4VC147oSxyiiWAHbEryZ8pW9JDDiPxaLM5LqSJFuJguPlTUsap8oL/zPiDDL7guCzswKzLUOOxWtSBwv7XoGdKlYXNXSDZtaGIGKTpU+cHjz18q4xfuoR57j+rsqQOIhyzDDt6KusKihMapRVceqJyz+HNunwN0mLJiFFvAtzOHoOneM7bYZAXXzY9YgAI+x6CHFhg0VsyXWEtpL0b2iGL/XA3dXh8zV3Kw0HRuUPjb02rhWJjuQLY3cpU=
@@ -1593,38 +2069,69 @@ http_interactions:
         AAAAB3NzaC1yc2EAAAADAQABAAACAQC9ZDmRlBpkjQvT1Ctp2mVuwYgjcZsuzmDvcJHIe3fGLqwnh30SxHDOFZwzg2pwQbk7SVwLK1Cb/+ZGfU8oMyHXYtbKBC7UuEbZ1wIXDinmzB+ATPMEIxbItIoDcCC4Bwv50RhZi/uxaDpZcBmg67LdroN7WdBXoJdHykmPRhdWUR4oPd/Ebsm7KFnhTTRO7f4kk1xE/KQR9nn/O7x7rddAKa550+mGbOdrafD7RsmW8gB0q1aQllbhgFH0XnAWUhkwLIN+3QWL5cuZdaS7p+j6YMsZly2D324xIQRhhcrlvRNaaZwDrZ+meO+OHQzMBBuJ+jzL/HG7gpGLJvN2xmfXltW6KsZF4giXXi5sjaiHHhu91gea4iRl0gqRNknoOcLghWu6+L3w42TCiVVj5hrmXzEA0RBY494onk3IemONobDjaM9yeZRDhABIbIPDshHRUZViUX8PfDspWhBg/16s4H47DczhBg4fAOHQRzwVErySdg+d5+XONR+E9L5884qOIP0eqcjzart1zHMshZWARDX/s9cq3VoZTuP5fGzObStctwcwzKWLfyrKMxw4kg7q1nHkRj5kRSK+k1rCLBInk9s+7Pep/gFZO7LOIhAqGCdQJ5qDJYHt36ltDmtrIc18V9N3WiPOQFekJImhsuo/u7dzUOkLeMV3xp5FHr7LeQ==
         paulbastide@pauls-mbp-2.lan\n"},{"creationDate":"2023-11-12T20:14:01.657Z","name":"mac-980b-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQC9ZDmRlBpkjQvT1Ctp2mVuwYgjcZsuzmDvcJHIe3fGLqwnh30SxHDOFZwzg2pwQbk7SVwLK1Cb/+ZGfU8oMyHXYtbKBC7UuEbZ1wIXDinmzB+ATPMEIxbItIoDcCC4Bwv50RhZi/uxaDpZcBmg67LdroN7WdBXoJdHykmPRhdWUR4oPd/Ebsm7KFnhTTRO7f4kk1xE/KQR9nn/O7x7rddAKa550+mGbOdrafD7RsmW8gB0q1aQllbhgFH0XnAWUhkwLIN+3QWL5cuZdaS7p+j6YMsZly2D324xIQRhhcrlvRNaaZwDrZ+meO+OHQzMBBuJ+jzL/HG7gpGLJvN2xmfXltW6KsZF4giXXi5sjaiHHhu91gea4iRl0gqRNknoOcLghWu6+L3w42TCiVVj5hrmXzEA0RBY494onk3IemONobDjaM9yeZRDhABIbIPDshHRUZViUX8PfDspWhBg/16s4H47DczhBg4fAOHQRzwVErySdg+d5+XONR+E9L5884qOIP0eqcjzart1zHMshZWARDX/s9cq3VoZTuP5fGzObStctwcwzKWLfyrKMxw4kg7q1nHkRj5kRSK+k1rCLBInk9s+7Pep/gFZO7LOIhAqGCdQJ5qDJYHt36ltDmtrIc18V9N3WiPOQFekJImhsuo/u7dzUOkLeMV3xp5FHr7LeQ==
-        paulbastide@pauls-mbp-2.lan\n"},{"creationDate":"2023-12-18T08:40:36.356Z","name":"rdr-acm-210-test-mon01-keypair","sshKey":"ssh-rsa
+        paulbastide@pauls-mbp-2.lan\n"},{"creationDate":"2024-01-23T10:34:00.704Z","name":"vinay-ssh","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDkSoLJhlBQ/bTTRaBy6IK4zhLaOcl/KRojsg3ajHZULoJ4TvbIkuebUyFB+S9I1UHdTLHvxXKLOdMVbYoBKkxsKS1AFiCR4sptItcwfcx2E0+COvRWzS3ytF7Y7PqTCJPFWnak63GmWcmzu6W/J+Z9SVUBHh5z9uWqXsWlg33AvLF2tS1ILYSliOkjhg5qzitrPDieKZW1ftECOoK/pn/D0V+QC8uf9Nfp/0d+IXelaRAomLX+8yXk3QJu8waEvkEhXKh1BCkjJ/Axoj5TTtB6pifcmFsLu5Xtu/b8wfW+0OmIbifbKmXIwaWRzenxiZurzLNe4DtOB1zLDhBuk4NxpBaUCRXfRYbYemRjSrAQANhyzPFlQ9p4m2hQaQZ14BIwRyHGzPAsIYsn92GuP1CRaz0fPoO8oCAwEuMZPNohJDwL3ctuWYqleWfX2IdPanKcU0bcKMNqxsU8g8WRQWOh3EN+lHD0EU9FXNwH1Gk6n7fk557XN6OPzYaYgRIfTmU=
-        gmx\\004ncn744@IBM-PF3XEKD9\r\n"},{"creationDate":"2024-01-10T07:20:55.683Z","name":"rdr-acm-210-train1-mon01-keypair","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAACAQDtKd5svnJLGfe7QB8ZkX/jtL9bNwtarIQ7NDThCBQuN5hZpKYJtaWjawjA6FtxklV+iVuDXQleFMVLp/NkNPP+DDv7LtLb9TaxR8pWenZBxzUfKA2iIGHoQdlA+Sobv0pzz2zDy7hcLmEc3ehB2QSuiNB/iGO8PaUpCcY2Vj6FaG8yD5zvfnffvDO6tEWaabDakOzlA3GMxtGJKaOgfhCgC2xAfJCXun1ssyGgao3dZWUUU2p1zq3Qeg69IQOUWOXshGHwsEHOR10E3HAgmqfL+tEdvoXo88OymtCqGnEZmbt9S2Oy/KRf+szNPeRHaRS8k2zwuDm3ojlQ13CtO+mj/MqdSntKfAEHZca1s11kSY/sxgn4n3wOnlVyjNMzbYt6Zs3SGe2LC9QWVvmOC03cABmLqBNg0HQr2ESaBtSuoSSG1aKFxgnEK0QWMqDBkJeOgMqc9jGmMLWVlyt0UKT2ZYMjtoKbNHO19XlNZbf8TH9JMEFJEY3dmyYrShYdNP4+kz1Lxs5PXuqh2PY/hVVh3GD4cdA9hH4WGYDsFPmQDAK7OvRicDzEjM+OxJoW//1+iHHepZkNB3PqeYt54myISRI8aMMufmFBEUrscApg5WPN7o+4SIlydj1WtTEyunwS5SZj1DYQ6D8EbCV38Vn2fpMX+yUjSHDStfeWQd8YkQ==
-        Niharika.Gurram1@ibm.com\n"},{"creationDate":"2024-01-16T09:02:43.713Z","name":"rdr-acm-210-man-mon01-keypair","sshKey":"ssh-rsa
+        gmx\\004ncn744@IBM-PF3XEKD9\n"},{"creationDate":"2024-02-09T20:17:16.990Z","name":"smullenmac","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCd80XHtNbyw8DD8euBLd2TGHCgr+/rQF1ODpuYVgrF5hfNzf8RKH4PI/bZ9bp/MUyCimZVQNDW8zutfcakI67lg/F6qRbS1Wlwn1z5er2TVJwBlkESXzeUlwXjjIcyFxv4qBUnAMogJ/M5s2rSDntcEKbOHEMAxqjqLX8g0kGWR0wYph3SJMMj0tThFRKCfwNAM4DGi6sAji91MtUwxreVBFTH7p5JhaRXT8lyPZAAklIgpBrApKNQE5BTDlw38GQdy038NNbU7zPI+gn80RzQFmPF9Rq8BSOMB8aorNcIJTUsNPxHwlNqW+M2pc11nqDNIeyGaSxZNz/3eCOHp4sttexf6d3v7pXJup18iTyCmqHC7d5pAS5jM6FrL0GHajcYAkSqnE5YgS3N4f/4MBTU4GcY8+b/PKLt1ET9TTY11pmRkYghn74Wqqs4SO7ILnIU4GWY6VPkw6P9PcmIo1Si28reTynqiRCEI0TK/deA2OB6jKqVYRL2FXHbpRtBsVu6A/kMjHlv9NlN9Xz26LkSQax09u2u+liUdQWr7d4yPQJW8BT6jHQPb+PAj4zgx3SQ/hyVPxe0EGGZZmljO6N52bn4e5Ds4WjuITVSRC7iViIHk6P9HXo9gAzg+ygLQOwifO3e2rzcSkVkBVTGn5pBFPFChp7l4pgBPI/8UYokuQ=="},{"creationDate":"2024-04-17T09:42:57.814Z","name":"rdr-415-hub211-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2024-05-08T11:21:10.173Z","name":"rdr-rhacm-ipi-hub-8mn7v-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2024-05-17T06:45:26.598Z","name":"vinay-ssh-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDkSoLJhlBQ/bTTRaBy6IK4zhLaOcl/KRojsg3ajHZULoJ4TvbIkuebUyFB+S9I1UHdTLHvxXKLOdMVbYoBKkxsKS1AFiCR4sptItcwfcx2E0+COvRWzS3ytF7Y7PqTCJPFWnak63GmWcmzu6W/J+Z9SVUBHh5z9uWqXsWlg33AvLF2tS1ILYSliOkjhg5qzitrPDieKZW1ftECOoK/pn/D0V+QC8uf9Nfp/0d+IXelaRAomLX+8yXk3QJu8waEvkEhXKh1BCkjJ/Axoj5TTtB6pifcmFsLu5Xtu/b8wfW+0OmIbifbKmXIwaWRzenxiZurzLNe4DtOB1zLDhBuk4NxpBaUCRXfRYbYemRjSrAQANhyzPFlQ9p4m2hQaQZ14BIwRyHGzPAsIYsn92GuP1CRaz0fPoO8oCAwEuMZPNohJDwL3ctuWYqleWfX2IdPanKcU0bcKMNqxsU8g8WRQWOh3EN+lHD0EU9FXNwH1Gk6n7fk557XN6OPzYaYgRIfTmU=
-        gmx\\004ncn744@IBM-PF3XEKD9\n"},{"creationDate":"2024-01-16T09:45:10.169Z","name":"rdr-acm-2-10-hub-mon01-keypair","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAACAQDtKd5svnJLGfe7QB8ZkX/jtL9bNwtarIQ7NDThCBQuN5hZpKYJtaWjawjA6FtxklV+iVuDXQleFMVLp/NkNPP+DDv7LtLb9TaxR8pWenZBxzUfKA2iIGHoQdlA+Sobv0pzz2zDy7hcLmEc3ehB2QSuiNB/iGO8PaUpCcY2Vj6FaG8yD5zvfnffvDO6tEWaabDakOzlA3GMxtGJKaOgfhCgC2xAfJCXun1ssyGgao3dZWUUU2p1zq3Qeg69IQOUWOXshGHwsEHOR10E3HAgmqfL+tEdvoXo88OymtCqGnEZmbt9S2Oy/KRf+szNPeRHaRS8k2zwuDm3ojlQ13CtO+mj/MqdSntKfAEHZca1s11kSY/sxgn4n3wOnlVyjNMzbYt6Zs3SGe2LC9QWVvmOC03cABmLqBNg0HQr2ESaBtSuoSSG1aKFxgnEK0QWMqDBkJeOgMqc9jGmMLWVlyt0UKT2ZYMjtoKbNHO19XlNZbf8TH9JMEFJEY3dmyYrShYdNP4+kz1Lxs5PXuqh2PY/hVVh3GD4cdA9hH4WGYDsFPmQDAK7OvRicDzEjM+OxJoW//1+iHHepZkNB3PqeYt54myISRI8aMMufmFBEUrscApg5WPN7o+4SIlydj1WtTEyunwS5SZj1DYQ6D8EbCV38Vn2fpMX+yUjSHDStfeWQd8YkQ==
-        Niharika.Gurram1@ibm.com\n"},{"creationDate":"2024-01-17T09:10:38.760Z","name":"rdr-acm-210-man2-mon01-keypair","sshKey":"ssh-rsa
+        gmx\\004ncn744@IBM-PF3XEKD9\n"},{"creationDate":"2024-05-28T11:43:36.910Z","name":"rdr-submariner-man1-7dn7j-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2024-06-21T07:45:01.715Z","name":"rdr-acm-demo-mon01-keypair","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQDkSoLJhlBQ/bTTRaBy6IK4zhLaOcl/KRojsg3ajHZULoJ4TvbIkuebUyFB+S9I1UHdTLHvxXKLOdMVbYoBKkxsKS1AFiCR4sptItcwfcx2E0+COvRWzS3ytF7Y7PqTCJPFWnak63GmWcmzu6W/J+Z9SVUBHh5z9uWqXsWlg33AvLF2tS1ILYSliOkjhg5qzitrPDieKZW1ftECOoK/pn/D0V+QC8uf9Nfp/0d+IXelaRAomLX+8yXk3QJu8waEvkEhXKh1BCkjJ/Axoj5TTtB6pifcmFsLu5Xtu/b8wfW+0OmIbifbKmXIwaWRzenxiZurzLNe4DtOB1zLDhBuk4NxpBaUCRXfRYbYemRjSrAQANhyzPFlQ9p4m2hQaQZ14BIwRyHGzPAsIYsn92GuP1CRaz0fPoO8oCAwEuMZPNohJDwL3ctuWYqleWfX2IdPanKcU0bcKMNqxsU8g8WRQWOh3EN+lHD0EU9FXNwH1Gk6n7fk557XN6OPzYaYgRIfTmU=
-        gmx\\004ncn744@IBM-PF3XEKD9\n"},{"creationDate":"2024-01-18T17:24:21.228Z","name":"test-ssh-key-no-comment","sshKey":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABgQCooZYGrwhEl5kCa0Pcdh2x0Xz/rOdru94tC8QI24bRFHPUAT88TKz48UciQE6/VaMdxxb9zrvA2eIU0/Td9lQU44B1LyEDLfILdxH1mHd2wehDM78V7804jvsxTMYXgNU8NEAJM+gyJ/K0rwvCReofL4jq/y4bbSEvVE+DxTnqzry2+SRCy0tEIfrHkJv2DMiB0oY680qEkZsAMZjE2JFrK8bN88kPhDb52x12llPMvUpppT4RBU3dDnweA50sxabV4SX0XVVJncw9nKh1EsUWrI4O7N3h8i8bLoiJvmGjIEpAQxE80ftvcbpJf0hPGsIr0BR+Qc+S6nBMdgpXj5RWlYS/ekxAVPe4xQsM01gMziwiX1RrcektajR8x/D3z28u7Nv1530b3rSqTMiydyXqcKMlTItqArpZVamo3UZ2CfuYRUdcpM+fbPCRsj0GH7pRxLqYag2klUIc9hZSgxQ85Yo5da+E7QjEvwxN5zxSyMy/ekRwsgWg6nDar9BFBV0="},{"creationDate":"2024-01-18T17:24:21.529Z","name":"test-ssh-key-with-comment","sshKey":"ssh-rsa
+        gmx\\004ncn744@IBM-PF3XEKD9\n"},{"creationDate":"2024-06-27T12:36:37.245Z","name":"rdr-acm-hub-416-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2024-06-27T14:32:10.137Z","name":"rdr-acm-man1-416-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2024-06-28T06:24:11.060Z","name":"rdr-acm-man2-416-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2024-07-09T11:17:52.724Z","name":"rdr-acm-211-fc-mon01-keypair","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDkSoLJhlBQ/bTTRaBy6IK4zhLaOcl/KRojsg3ajHZULoJ4TvbIkuebUyFB+S9I1UHdTLHvxXKLOdMVbYoBKkxsKS1AFiCR4sptItcwfcx2E0+COvRWzS3ytF7Y7PqTCJPFWnak63GmWcmzu6W/J+Z9SVUBHh5z9uWqXsWlg33AvLF2tS1ILYSliOkjhg5qzitrPDieKZW1ftECOoK/pn/D0V+QC8uf9Nfp/0d+IXelaRAomLX+8yXk3QJu8waEvkEhXKh1BCkjJ/Axoj5TTtB6pifcmFsLu5Xtu/b8wfW+0OmIbifbKmXIwaWRzenxiZurzLNe4DtOB1zLDhBuk4NxpBaUCRXfRYbYemRjSrAQANhyzPFlQ9p4m2hQaQZ14BIwRyHGzPAsIYsn92GuP1CRaz0fPoO8oCAwEuMZPNohJDwL3ctuWYqleWfX2IdPanKcU0bcKMNqxsU8g8WRQWOh3EN+lHD0EU9FXNwH1Gk6n7fk557XN6OPzYaYgRIfTmU=
+        gmx\\004ncn744@IBM-PF3XEKD9\r\n"},{"creationDate":"2024-08-14T08:25:17.633Z","name":"rdr-acm212-hub-trlzh-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2024-08-15T17:07:46.416Z","name":"rdr-acm212-man1-gm58d-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2024-09-04T08:12:55.017Z","name":"rdr-subhub-xhzrx-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2024-10-29T06:00:30.893Z","name":"vinay-lat-ssh","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDWOxMwiT1pXZ8WygM8Z57Ys3MKwDChWOj8+JP5NBWfRXfFyXwGIrMusNUw2sA+sCWYTtz+mNLVNOayJ9wedMmYgN1iILdvEjUfLUMdLpyZFTd0t/xJMHL+bm5W/jXjWsS9eNdUOS/FMgE67iZswBmGueI8yjqi057hmh1LxyLGb4jBv9qFXlWNiZocJESpQqB3CbjvCGDhMw+ttUQlVu0sWUMcdHtmRS/43ZgYtx3JBfjW2JZE0XKEwUPJ6af842qmS14orbW1XqM3IUGJeHRBwzCwh8RTs3FatOZRXwJj00wPHxdBtg/T1/x/OzeWIEbDVcLDqvFJciJCam6BWTh8gGRXo7VhbYxa3iBE6PBjpACDZj+Py2WHFhZVx0LSQGMRW0Hbx42gRgiFAthONhjHBOkU/2UGAXJF5/Gh20dr3b3r8fuoMVIv7pcyohUSQV2OTti17agswLezG2nTSyyH11BZ9DkdJ+edsxtIQOTqatokfB7qeRz67Yrr9ZVVL40=
+        azuread\\vinaykumarkombathula@IBM-PF3XJYW7\n"},{"creationDate":"2025-04-14T07:33:30.557Z","name":"rdr-acm214-bkhub-8pzmb-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2025-04-14T14:58:09.408Z","name":"rdr-acm214-bkman1-mvxwp-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2025-06-06T10:37:58.741Z","name":"rdr-subm14-hub-fhkmj-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2025-06-06T13:28:51.421Z","name":"rdr-subm14-man1-567nq-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2025-06-06T14:57:40.050Z","name":"rdr-subm14-man2-gmnwn-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAACAQCuIxuYEJLRW4rbWRaqR4KluxmhSR9sXhgPUD5DgLLzFbty+FG+XjoSNUmJnumDjf7Hsfy71CCNRI5NCk+GhOscPmCnvzdILu9JNwJq6XwLQiPw50g271dUhSv4tuLwg6VxmB2QajFdW+jxBQxVm2vcX/YGfZrY+z8smtiRFBeKLqBU76cseJZRfpcTSNGq2npLPr1M91hPDTVmm8Ko16eqwNOTBHZaMap8kl5YRSHu0TDPo9rui5EH4+KdX3fKLhS5gv7/CTD/a4+g/+fASDRD3pEqg/sbF2B9IcJPVMkvR9/gkW61iewvYuepo+NDTM7Q+hgrL93XeAp5LWeM3+FsvbdkNMUNxR3VKRMrqVwDW0k1OrfXdl+T/Hy997jYjl7JNM1tmSbk343zIfWPJ4wFMTxWbCxj2mo/o3OpERoq0wW81jc/FXe5BfrsLTZfgH+PLpWSJvCGdbc7XoEULIMI8uyGy79PiWHMMW6HKnrdM2oyEaEvy/GP8jmDoc4SIiZgmbRAWAYZYJLe5cQmCFgNr8TCNZglXY5YdZL3BC+gP8g63Z+DChL9Kz5v7rPDe4xsSTCIIvjZwt+e+guAFMsxhFGGvmMyJCjNi7EuXguyZ3M8vNWdarOgAPRIZWJ281wMinUvaSSH5iT1HKk68xiq59hNCCV6e2ohbG15rvgfUQ==
+        basheer@dhcp-9-239-8-250.c4p-in.ibmmobiledemo.com\n"},{"creationDate":"2025-06-10T22:15:08.720Z","name":"vj-powervs-ssh-key","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCrgMd0rejND4TUDzlENPfLujQDcsAg3X8diaicXKA2/2TS6hV70BXLlL7J2A3gh03ZPiNTjiXuFVmKcTDFhwxIMz4JB2mYGVVMn31Uoh99CnJi2wwuo7ZWqxYWxVyQ7/7rvC0cs7iW3St0pHfPZaUpYguC9OiEYlkLjufUG+TGq+4q4rObCxM3sGtGixQjIOIBidcz7xeHDOJbGWu4Qt417U0M1WOawgQjsalKLr1PmXhztRKV2EiYnNB3XWjUo2PJPn78TAVb/zwwdGEOtC5AOGVeogitjiTThn8vbFEJkIdO5a5+/q9aZeOqZqt2sopk7qYZc/+X8UleJqGJCaxv1aJmXA5seaj/E/L7b60Nl73kQ1oRU/6Pdba5jFSJhu3H1SXjPcwuiBmJZA54HB6jXRyuYiGyxRx5ZfCO4tpmLl94sFPxeEjHq3PfN38TAwBb4uQoDVn9VT8zBsw9wzKhwOwILRoJHeqgBYDzT356M+XZqNp1ZJDeBct7YhVj5xE=
+        vijayv@vijayvs-MacBook-Pro.local"},{"creationDate":"2025-06-25T14:28:32.494Z","name":"test-ssh-key-no-comment","sshKey":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQCooZYGrwhEl5kCa0Pcdh2x0Xz/rOdru94tC8QI24bRFHPUAT88TKz48UciQE6/VaMdxxb9zrvA2eIU0/Td9lQU44B1LyEDLfILdxH1mHd2wehDM78V7804jvsxTMYXgNU8NEAJM+gyJ/K0rwvCReofL4jq/y4bbSEvVE+DxTnqzry2+SRCy0tEIfrHkJv2DMiB0oY680qEkZsAMZjE2JFrK8bN88kPhDb52x12llPMvUpppT4RBU3dDnweA50sxabV4SX0XVVJncw9nKh1EsUWrI4O7N3h8i8bLoiJvmGjIEpAQxE80ftvcbpJf0hPGsIr0BR+Qc+S6nBMdgpXj5RWlYS/ekxAVPe4xQsM01gMziwiX1RrcektajR8x/D3z28u7Nv1530b3rSqTMiydyXqcKMlTItqArpZVamo3UZ2CfuYRUdcpM+fbPCRsj0GH7pRxLqYag2klUIc9hZSgxQ85Yo5da+E7QjEvwxN5zxSyMy/ekRwsgWg6nDar9BFBV0="},{"creationDate":"2025-06-25T14:28:32.920Z","name":"test-ssh-key-with-comment","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQCvyVUxkBtMlmTemse/JcMhSxI4kIK4SzpMqQaUBaon9X30x62fjOik7lnqxqg/BXWVYI15nslSI/t5IbQGPGPBzR9RplBn/dx/Yxzcfgq5U5YBkvP9yXRYdp5f51z17a5+wWKI8Dka7vrLmv62thB83pjgiTsgFvqdSx7aYC4U3GFpboYHX/tQjrEpNBHRiRTeB9Ux/O+/gzGULlR0jd4denrWpng9Nn9n+N1e+tAkkUjUY0xTnodZfjnpYO/qhWSPwCglZeP9i9KdZFLCKuGTHkWbmQ1SnehRYEnLJ9lZRkhMsYq6uW1SNzMn16bGs3T7c+RkZUzs2JxFEjBIpEkq/uVDwVyIYd6dKQMp1cC8MEHQB2G6udrcvzwOJkb9xYqcJVpp0MzWApeBPwXUYJjCaxIHwF4TciYT0tleaoyZep9of0Wnrfv0BAtmY1f9obyEuRXKBFYmFlIvXripuueCL38KlQfVgmLuhnpSxXTVeiTZ8qTCxUkrJc6DZXh/z90=
-        This is only a test!"},{"creationDate":"2024-01-18T17:24:21.796Z","name":"test-ssh-key-with-comment-line-breaks","sshKey":"ssh-rsa
+        This is only a test!"},{"creationDate":"2025-06-25T14:28:33.365Z","name":"test-ssh-key-with-comment-line-breaks","sshKey":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABgQD06A0pk378CjUm3LR5O9BW03ZNKgQPsB0IdMzdM4pBOyiPMubmcvOvItDz0XmtRIBJxqxRZftJAq01ej2ZSq+Fk+cbGtGQngEVceaz2GnrGNLasyF0zKG5mLXkoQsm3tofRdCuLecBFPSVN31yuxeVxsNCYKunGtwNejC/GIroptuRANJYVAv3TaVl99MYHfhkJCEvomdimYWZmi4eEML9bAhqr7LBK7j6rcivcp6Z8LpIg4LUP1+jniV0dXbhycJhYaAvQtKySBwnx70LiShyy9R2P31LL8g19Dn75NK1kWNV5mRrWFdyX+GJ8lnalOyBN4irZ7T1wAnbJfd/Vfs9PtYz2iR9IFEKYaxpEgNB5FQQY3UoP5gPezfRstG0ohmJ2zYxHC6PYuYQUpgp6xhf7jEtC+WHjWtmN5/LJ74k13BVPlhrSAduYrZJ8mCS29b4gjBuIirW8nByaGh5HBToyjbxdlBqDJS0+qMeWPqwSlZGK/jTulNpmvAibX7CawM=\nYes,
         placing line breaks in SSH public\nkey comments doesn''t break anything"}],"tenantID":"1fdf5effc3f945688c021cd0a8b45c4d"}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:24 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:48 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/placement-groups
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/placement-groups
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1639,29 +2146,38 @@ http_interactions:
       - application/json
       Content-Length:
       - '344'
+      X-Correlation-Id:
+      - 5bed9a18-5d70-4d4e-a100-3e745d6fa3e8
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"placementGroups":[{"id":"8334ba79-bd98-47af-ad25-6eb8a1c4c817","members":["e8cf72cf-7685-4bfb-a386-66422f71820a"],"name":"test-placement-group-affinity","policy":"affinity"},{"id":"f99c2fc5-73ba-4387-9736-61dc51f53471","members":["d6a661a8-fed1-4a52-9d50-24fc9f9956b8"],"name":"test-placement-group-anti-affinity","policy":"anti-affinity"}]}
+      encoding: ASCII-8BIT
+      string: '{"placementGroups":[{"id":"69ac6b47-912e-4346-8804-da768f4aa789","members":["04c9a30d-c8d5-46cb-849b-0f7fa5004b70"],"name":"test-placement-group-affinity","policy":"affinity"},{"id":"b52c11cb-b6bf-45a0-a376-242f4217ca6f","members":["9317b826-3660-4cf9-aa93-6d42a4643ba9"],"name":"test-placement-group-anti-affinity","policy":"anti-affinity"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:24 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:49 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/snapshots
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/snapshots
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1674,35 +2190,44 @@ http_interactions:
     headers:
       Content-Type:
       - application/json
+      X-Correlation-Id:
+      - f86366e5-c3dd-496d-851b-0abf6851dfd9
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"snapshots":[{"action":"snapshot","creationDate":"2024-01-18T19:14:39.000Z","description":"server
-        name: test-instance-ibmi-s922-capped-tier1","lastUpdateDate":"2024-01-18T19:14:49.000Z","name":"test-instance-ibmi-s922-capped-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a","snapshotID":"0e536300-ad93-40f3-92f9-f5153785d2ac","status":"available","volumeSnapshots":{"ed84f79b-b8d1-48c3-8766-2a92ff6a879b":"2ad97524-7d8e-48dc-ace4-f66c544e2775"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:53.000Z","description":"server
-        name: test-instance-sles-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:15:02.000Z","name":"test-instance-sles-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd","snapshotID":"2d3fa834-5212-4ea4-ac2a-d28a244041c2","status":"available","volumeSnapshots":{"ba26d663-1e76-4457-8732-9d9235df8019":"5c7be867-f103-4a83-87af-53ffa26b07be"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:57.000Z","description":"server
-        name: test-instance-rhcos-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:15:05.000Z","name":"test-instance-rhcos-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8","snapshotID":"9c6127c6-b71d-417d-8238-e4642cf3df83","status":"available","volumeSnapshots":{"7d6f53e6-4adf-4792-8b5f-07cc618dff78":"7fabb55d-38e4-40c0-bd0c-ba44e706135e"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:44.000Z","description":"server
-        name: test-instance-centos-e980-dedicated-tier3","lastUpdateDate":"2024-01-18T19:14:53.000Z","name":"test-instance-centos-e980-dedicated-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"1ea38460-b3ff-4abd-802b-0289983be590","snapshotID":"9f192329-1470-4532-b609-16b56914fad0","status":"available","volumeSnapshots":{"cdfebbb2-d64e-41e1-9834-4f6b5d249489":"563ac449-f811-4ff7-bd91-adb026c82562"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:48.000Z","description":"server
-        name: test-instance-rhel-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:14:58.000Z","name":"test-instance-rhel-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","snapshotID":"d5332d55-9d8f-4745-b26e-203387b59d55","status":"available","volumeSnapshots":{"984498df-5554-4685-a109-821d5e39b27b":"ccc567e7-63db-4441-ab3c-a206e41ff9b3"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:35.000Z","description":"server
-        name: test-instance-aix-s922-shared-tier1","lastUpdateDate":"2024-01-18T19:14:44.000Z","name":"test-instance-aix-s922-shared-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"502106d8-d969-49df-9103-184c3ab97508","snapshotID":"e47f1ab4-22eb-4262-9b8c-b670afcbf6ef","status":"available","volumeSnapshots":{"2e653913-14fe-4b3a-a4f3-c7396bed0862":"0d6df030-deb6-4fe4-8247-42a61d7c4cad"}}]}
+      encoding: ASCII-8BIT
+      string: '{"snapshots":[{"action":"snapshot","creationDate":"2025-06-25T14:46:56.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:0385f05f-b922-45f6-a9df-d6e8b6bd9111","description":"server
+        name: test-instance-rhcos-s922-shared-tier3","lastUpdateDate":"2025-06-25T14:47:04.000Z","name":"test-instance-rhcos-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"9317b826-3660-4cf9-aa93-6d42a4643ba9","snapshotID":"0385f05f-b922-45f6-a9df-d6e8b6bd9111","status":"available","volumeSnapshots":{"55eeb86d-80d4-4ef2-9267-0075bac0378d":"992f34ab-4503-4ec2-82a8-acbb69e751dc"}},{"action":"snapshot","creationDate":"2025-06-25T14:46:38.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:05247445-494e-4ac7-b1d6-1818a1c4f6e2","description":"server
+        name: test-instance-rhel-s922-shared-tier3","lastUpdateDate":"2025-06-25T14:46:50.000Z","name":"test-instance-rhel-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"43a0b59a-f4d7-4150-8fb8-72b4e5452d02","snapshotID":"05247445-494e-4ac7-b1d6-1818a1c4f6e2","status":"available","volumeSnapshots":{"ab68a4b6-921e-4149-a6d3-70c281349fcf":"8a55602d-8bfa-4c5f-bbce-bacb7579de26"}},{"action":"snapshot","creationDate":"2025-06-25T14:46:12.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:071468b4-41e8-443a-b589-c789ea31eee2","description":"server
+        name: test-instance-aix-s922-shared-tier1","lastUpdateDate":"2025-06-25T14:46:20.000Z","name":"test-instance-aix-s922-shared-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"5d8393c6-b50c-4de4-98f0-a04222e9fbdc","snapshotID":"071468b4-41e8-443a-b589-c789ea31eee2","status":"available","volumeSnapshots":{"1f455cf4-c82c-4e1b-b84b-f1e86082aadf":"d0b96d4d-8459-4348-81cf-0354a1d17265"}},{"action":"snapshot","creationDate":"2025-06-25T14:46:29.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:71bec2d4-6c61-4fbe-afd9-13a8c1f2c8fb","description":"server
+        name: test-instance-centos-e980-dedicated-tier3","lastUpdateDate":"2025-06-25T14:46:37.000Z","name":"test-instance-centos-e980-dedicated-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"c19f7546-323e-4e0b-bf97-5ad8668f0529","snapshotID":"71bec2d4-6c61-4fbe-afd9-13a8c1f2c8fb","status":"available","volumeSnapshots":{"4fdf9382-aa4c-435e-9352-de392a6ef278":"d9aa27fb-fdc0-454a-bc54-53a1fda20fb4"}},{"action":"snapshot","creationDate":"2025-06-25T14:46:47.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:bd5bcb88-d639-44f3-8aad-250b243288a1","description":"server
+        name: test-instance-sles-s922-shared-tier3","lastUpdateDate":"2025-06-25T14:47:00.000Z","name":"test-instance-sles-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"c717671d-baae-4955-879f-0588ef5171bb","snapshotID":"bd5bcb88-d639-44f3-8aad-250b243288a1","status":"available","volumeSnapshots":{"2b3477a2-5e5c-46fc-8906-bc2ef9166c37":"bd49d8f0-e5dd-4001-9132-5e22c9be06a7"}},{"action":"snapshot","creationDate":"2025-06-25T14:46:20.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:f5bc67a9-ed33-4ea0-92ee-881be8b90eb2","description":"server
+        name: test-instance-ibmi-s922-capped-tier1","lastUpdateDate":"2025-06-25T14:46:28.000Z","name":"test-instance-ibmi-s922-capped-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"04c9a30d-c8d5-46cb-849b-0f7fa5004b70","snapshotID":"f5bc67a9-ed33-4ea0-92ee-881be8b90eb2","status":"available","volumeSnapshots":{"b6a90aec-fce5-4640-9a99-140e8af2b103":"7baaad1a-d2f3-4dbb-816a-5bee06d0f559"}}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:24 GMT
+  recorded_at: Wed, 25 Jun 2025 14:59:50 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/shared-processor-pools
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/shared-processor-pools
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -1716,16 +2241,25 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '384'
+      - '563'
+      X-Correlation-Id:
+      - fd2cb658-d3d4-4bd6-bfb1-4e46a13f334e
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"sharedProcessorPools":[{"allocatedCores":0.5,"availableCores":0.5,"hostGroup":"s922","hostID":6,"id":"85029156-8753-4d06-9a56-d13e3bd4c27d","name":"test_pool","reservedCores":1,"sharedProcessorPoolPlacementGroups":[{"id":"bb252e11-c5f9-43fb-9801-2218058fe030","name":"test_spppg","policy":"affinity"}],"status":"active","statusDetail":"shared
+      encoding: ASCII-8BIT
+      string: '{"sharedProcessorPools":[{"allocatedCores":0.5,"availableCores":0.5,"crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:shared-processor-pool:85ba15e6-bbc0-469b-90b7-697876167cfc","hostGroup":"s922","hostID":58,"id":"85ba15e6-bbc0-469b-90b7-697876167cfc","name":"test_pool","reservedCores":1,"sharedProcessorPoolPlacementGroups":[{"id":"6101a596-8553-4792-8ce5-920c58bc929f","name":"test_spppg","policy":"affinity"}],"status":"active","statusDetail":"shared
         processor pool test_pool is active"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:28:25 GMT
-recorded_with: VCR 6.2.0
+  recorded_at: Wed, 25 Jun 2025 14:59:53 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr_cassettes/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher/vm_target.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/refresher/vm_target.yml
@@ -22,12 +22,10 @@ http_interactions:
     headers:
       X-Content-Type-Options:
       - nosniff
-      Transaction-Id:
-      - bXhmZmY-77039fb193cb401597e98f075c32b62a
-      X-Request-Id:
-      - 5303b21e-1445-428b-9249-2d30f0ba7d4b
+      Ibm-Cloud-Service-Name:
+      - iam-identity
       X-Correlation-Id:
-      - bXhmZmY-77039fb193cb401597e98f075c32b62a
+      - dGo0bW0-1639d4e275094f4e8507fdae06e63a23
       Cache-Control:
       - no-cache, no-store, must-revalidate
       Expires:
@@ -39,22 +37,20 @@ http_interactions:
       Content-Language:
       - en-US
       Content-Length:
-      - '1532'
+      - '1635'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Date:
-      - Thu, 18 Jan 2024 19:31:02 GMT
       Connection:
       - keep-alive
       Akamai-Grn:
-      - 0.b8f8cd17.1705606261.8547f8e
+      - 0.db17dd17.1750863764.5bb9d840
       X-Proxy-Upstream-Service-Time:
-      - '550'
+      - '327'
     body:
       encoding: ASCII-8BIT
-      string: '{"access_token":"IAMBEARERTOKEN","refresh_token":"not_supported","ims_user_id":7771420,"token_type":"Bearer","expires_in":3600,"expiration":1705609859,"scope":"ibm
+      string: '{"access_token":"ACCESS_TOKEN","refresh_token":"REFRESH_TOKEN","ims_user_id":"22222","token_type":"Bearer","expires_in":3600,"expiration":4102466400,"scope":"ibm
         openid"}'
-  recorded_at: Thu, 18 Jan 2024 19:31:02 GMT
+  recorded_at: Wed, 25 Jun 2025 15:02:44 GMT
 - request:
     method: get
     uri: https://resource-controller.cloud.ibm.com/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID
@@ -63,34 +59,31 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - ibm_cloud_resource_controller-ruby-sdk-2.0.2 x86_64-pc-linux-gnu ruby-3.1.4
+      - ibm_cloud_resource_controller-ruby-sdk-2.0.3 x86_64-pc-linux ruby-3.3.8
       X-Ibmcloud-Sdk-Analytics:
       - service_name=resource_controller;service_version=V2;operation_id=get_resource_instance
       Accept:
       - application/json
-      Authorization:
-      - Bearer IAMBEARERTOKEN
+      Authorization: Bearer xxxxxx
       Connection:
       - close
   response:
     status:
       code: 200
-      message: OK
+      message:
     headers:
       Content-Type:
       - application/json
       Request-Id:
-      - b40d3e24-5472-436c-a98d-a0185087f50c
+      - 626c-f8820bd51ed71007
       Retry-After:
       - '0'
       Strict-Transport-Security:
       - max-age=31536000;includeSubDomains
-      Transaction-Id:
-      - bss-835b50c7df234cf9
       X-Content-Type-Options:
       - nosniff
-      X-Global-Transaction-Id:
-      - bss-835b50c7df234cf9
+      X-Correlation-Id:
+      - 626c-e28cc28d2b280613
       X-Op-Completion-Time:
       - ''
       X-Ratelimit-Limit:
@@ -99,82 +92,37 @@ http_interactions:
       - '99'
       X-Ratelimit-Reset:
       - '0'
-      X-Request-Id:
-      - b40d3e24-5472-436c-a98d-a0185087f50c
-      X-Transaction-Id:
-      - bss-835b50c7df234cf9
-      X-Envoy-Upstream-Service-Time:
-      - '166'
-      Server:
-      - istio-envoy
       Content-Length:
-      - '2116'
+      - '2115'
       Expires:
-      - Thu, 18 Jan 2024 19:31:02 GMT
+      - Wed, 25 Jun 2025 15:02:45 GMT
       Cache-Control:
       - max-age=0, no-cache, no-store
       Pragma:
       - no-cache
-      Date:
-      - Thu, 18 Jan 2024 19:31:02 GMT
       Connection:
       - close
     body:
       encoding: UTF-8
-      string: '{"id":"crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","guid":"IBM_CLOUD_POWERVS_INSTANCE_ID","url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID","created_at":"2022-01-04T19:19:27.00879531Z","updated_at":"2022-05-28T10:58:12.563242645Z","deleted_at":null,"created_by":"IBMid-2700063YVN","updated_by":"IBMid-2700063YVN","deleted_by":"","scheduled_reclaim_at":null,"restored_at":null,"scheduled_reclaim_by":"","restored_by":"","name":"rdr-power.control.plane.test-hcm-mon01-miq-specs","region_id":"mon01","account_id":"1fdf5effc3f945688c021cd0a8b45c4d","reseller_channel_id":"","resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","resource_group_id":"2f9167fcfa9c4e2a951c5d8fa22bd01f","resource_group_crn":"crn:v1:bluemix:public:resource-controller::a/1fdf5effc3f945688c021cd0a8b45c4d::resource-group:2f9167fcfa9c4e2a951c5d8fa22bd01f","target_crn":"crn:v1:bluemix:public:globalcatalog::::deployment:f165dd34-3a40-423b-9d95-e90a23f724dd%3Amon0159210","allow_cleanup":false,"crn":"crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","state":"active","type":"service_instance","resource_id":"abd259f0-9990-11e8-acc8-b9f54a8f1661","dashboard_url":"https://power-iaas.cloud.ibm.com/authenticate","last_operation":{"type":"create","state":"succeeded","async":true,"description":"service
+      string: '{"id":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","guid":"IBM_CLOUD_POWERVS_INSTANCE_ID","url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID","created_at":"2025-05-22T13:44:28.57250562Z","updated_at":"2025-05-22T13:45:11.597828983Z","deleted_at":null,"created_by":"IBMid-2700063YVN","updated_by":"","deleted_by":"","scheduled_reclaim_at":null,"restored_at":null,"scheduled_reclaim_by":"","restored_by":"","name":"rdr-power.control.plane.test-hcm-miq-specs","region_id":"us-east10","account_id":"1fdf5effc3f945688c021cd0a8b45c4d","reseller_channel_id":"","resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","resource_group_id":"2f9167fcfa9c4e2a951c5d8fa22bd01f","resource_group_crn":"crn:v1:bluemix:public:resource-controller::a/1fdf5effc3f945688c021cd0a8b45c4d::resource-group:2f9167fcfa9c4e2a951c5d8fa22bd01f","target_crn":"crn:v1:bluemix:public:globalcatalog::::deployment:f165dd34-3a40-423b-9d95-e90a23f724dd%3Aus-east1084023","allow_cleanup":false,"crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::","state":"active","type":"composite_instance","resource_id":"abd259f0-9990-11e8-acc8-b9f54a8f1661","dashboard_url":null,"last_operation":{"type":"create","state":"succeeded","async":true,"description":"service
         instance IBM_CLOUD_POWERVS_INSTANCE_ID was provisioned successfully for account
-        1fdf5effc3f945688c021cd0a8b45c4d in region mon01","cancelable":false,"poll":false},"resource_aliases_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_aliases","resource_bindings_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_bindings","resource_keys_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_keys","plan_history":[{"resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","start_date":"2022-01-04T19:19:27.00879531Z","requestor_id":"IBMid-2700063YVN"}],"migrated":false,"controlled_by":"","locked":false}
+        1fdf5effc3f945688c021cd0a8b45c4d in region us-east10","cancelable":false,"poll":true},"resource_aliases_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_aliases","resource_bindings_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_bindings","resource_keys_url":"/v2/resource_instances/IBM_CLOUD_POWERVS_INSTANCE_ID/resource_keys","plan_history":[{"resource_plan_id":"f165dd34-3a40-423b-9d95-e90a23f724dd","start_date":"2025-05-22T13:44:28.57250562Z","requestor_id":"IBMid-2700063YVN"}],"migrated":false,"extensions":{"resourceCRNs":true},"controlled_by":"","locked":false,"onetime_credentials":false}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:31:02 GMT
+  recorded_at: Wed, 25 Jun 2025 15:02:45 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/system-pools
+    uri: https://us-east.power-iaas.cloud.ibm.com/v1/datacenters/us-east10
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"e980":{"capacity":{"cores":88,"memory":12564,"totalCores":null,"totalMemory":null},"coreMemoryRatio":64,"maxAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"maxCoresAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"maxMemoryAvailable":{"cores":59.5,"memory":11779,"totalCores":null,"totalMemory":null},"sharedCoreRatio":{"default":0.25,"max":1,"min":0.05},"systems":[{"cores":59.5,"id":1,"memory":11779,"totalCores":null,"totalMemory":null}],"type":"e980"},"s922":{"capacity":{"cores":15,"memory":935,"totalCores":null,"totalMemory":null},"coreMemoryRatio":64,"maxAvailable":{"cores":14.25,"memory":902,"totalCores":null,"totalMemory":null},"maxCoresAvailable":{"cores":14.25,"memory":897,"totalCores":null,"totalMemory":null},"maxMemoryAvailable":{"cores":6,"memory":902,"totalCores":null,"totalMemory":null},"sharedCoreRatio":{"default":0.25,"max":1,"min":0.05},"systems":[{"cores":14.25,"id":14,"memory":897,"totalCores":null,"totalMemory":null},{"cores":12.3,"id":25,"memory":895,"totalCores":null,"totalMemory":null},{"cores":11.75,"id":18,"memory":884,"totalCores":null,"totalMemory":null},{"cores":10.25,"id":12,"memory":849,"totalCores":null,"totalMemory":null},{"cores":9.5,"id":11,"memory":874,"totalCores":null,"totalMemory":null},{"cores":9,"id":15,"memory":880,"totalCores":null,"totalMemory":null},{"cores":8.25,"id":9,"memory":681,"totalCores":null,"totalMemory":null},{"cores":7.5,"id":8,"memory":843,"totalCores":null,"totalMemory":null},{"cores":6,"id":17,"memory":902,"totalCores":null,"totalMemory":null},{"cores":5.75,"id":23,"memory":598,"totalCores":null,"totalMemory":null},{"cores":4.5,"id":21,"memory":738,"totalCores":null,"totalMemory":null},{"cores":4.5,"id":5,"memory":728,"totalCores":null,"totalMemory":null},{"cores":4,"id":13,"memory":822,"totalCores":null,"totalMemory":null},{"cores":3.5,"id":10,"memory":624,"totalCores":null,"totalMemory":null},{"cores":1.5,"id":20,"memory":855,"totalCores":null,"totalMemory":null},{"cores":0.26,"id":19,"memory":397,"totalCores":null,"totalMemory":null},{"cores":0.26,"id":16,"memory":485,"totalCores":null,"totalMemory":null},{"cores":0.25,"id":24,"memory":519,"totalCores":null,"totalMemory":null},{"cores":0.01,"id":6,"memory":556,"totalCores":null,"totalMemory":null},{"cores":0,"id":22,"memory":455,"totalCores":null,"totalMemory":null},{"cores":0,"id":4,"memory":533,"totalCores":null,"totalMemory":null},{"cores":0,"id":7,"memory":320,"totalCores":null,"totalMemory":null}],"type":"s922"}}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:31:03 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -188,172 +136,40 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '752'
+      - '609'
+      X-Correlation-Id:
+      - 7cd415b3-b189-465b-963d-c8bc36236ebf
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"capabilities":["cloud-connections","direct-link-transit-gateway","ibmi-software-licenses","linux","pinning","rhel-sap","sap","snapshots","volume-clone","vpn-connections","shared-processor-pools"],"cloudInstanceID":"c8d0ac7c30c944f0ac3288eb8bb74aaa","enabled":true,"initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"IBM_CLOUD_POWERVS_INSTANCE_ID","openstackID":"07389ca7-2266-4303-afd3-5babc1cebe20","pvmInstances":[],"region":"mon01","tenantID":"1fdf5effc3f945688c021cd0a8b45c4d","usage":{"instances":0,"memory":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0,"storageStandard":0}}
+      encoding: ASCII-8BIT
+      string: '{"capabilities":{"cloud-connections":false,"dedicated-hosts":true,"disaster-recovery-site":true,"metrics":true,"network-security-groups":true,"power-edge-router":true,"power-vpn-connections":false},"capabilitiesDetails":{"disasterRecovery":{"asynchronousReplication":{"enabled":true,"targetLocations":[{"region":"wdc07","status":"active"}]}},"supportedSystems":{"dedicated":["s1022","s922"],"general":["e1080","s1022","e980","s922"]}},"location":{"region":"us-east10","regionDisplayName":"Dallas
+        10","type":"data-center","url":"https://us-south.power-iaas.cloud.ibm.com"},"status":"active","type":"off-premises"}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:31:03 GMT
+  recorded_at: Wed, 25 Jun 2025 15:11:03 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/sap
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"profiles":[{"certified":true,"cores":16,"memory":1600,"profileID":"bh1-16x1600","type":"balanced"},{"certified":true,"cores":20,"memory":2000,"profileID":"bh1-20x2000","type":"balanced"},{"certified":true,"cores":22,"memory":2200,"profileID":"bh1-22x2200","type":"balanced"},{"certified":true,"cores":25,"memory":2500,"profileID":"bh1-25x2500","type":"balanced"},{"certified":true,"cores":30,"memory":3000,"profileID":"bh1-30x3000","type":"balanced"},{"certified":true,"cores":35,"memory":3500,"profileID":"bh1-35x3500","type":"balanced"},{"certified":true,"cores":40,"memory":4000,"profileID":"bh1-40x4000","type":"balanced"},{"certified":true,"cores":50,"memory":5000,"profileID":"bh1-50x5000","type":"balanced"},{"certified":true,"cores":60,"memory":6000,"profileID":"bh1-60x6000","type":"balanced"},{"certified":true,"cores":70,"memory":7000,"profileID":"bh1-70x7000","type":"balanced"},{"certified":true,"cores":80,"memory":8000,"profileID":"bh1-80x8000","type":"balanced"},{"certified":true,"cores":100,"memory":10000,"profileID":"bh1-100x10000","type":"balanced"},{"certified":true,"cores":120,"memory":12000,"profileID":"bh1-120x12000","type":"balanced"},{"certified":true,"cores":140,"memory":14000,"profileID":"bh1-140x14000","type":"balanced"},{"certified":true,"cores":60,"memory":3000,"profileID":"ch1-60x3000","type":"compute"},{"certified":true,"cores":70,"memory":3500,"profileID":"ch1-70x3500","type":"compute"},{"certified":true,"cores":80,"memory":4000,"profileID":"ch1-80x4000","type":"compute"},{"certified":true,"cores":100,"memory":5000,"profileID":"ch1-100x5000","type":"compute"},{"certified":true,"cores":120,"memory":6000,"profileID":"ch1-120x6000","type":"compute"},{"certified":true,"cores":140,"memory":7000,"profileID":"ch1-140x7000","type":"compute"},{"certified":true,"cores":8,"memory":1440,"profileID":"mh1-8x1440","type":"memory"},{"certified":true,"cores":10,"memory":1800,"profileID":"mh1-10x1800","type":"memory"},{"certified":true,"cores":12,"memory":2160,"profileID":"mh1-12x2160","type":"memory"},{"certified":true,"cores":16,"memory":2880,"profileID":"mh1-16x2880","type":"memory"},{"certified":true,"cores":20,"memory":3600,"profileID":"mh1-20x3600","type":"memory"},{"certified":true,"cores":22,"memory":3960,"profileID":"mh1-22x3960","type":"memory"},{"certified":true,"cores":25,"memory":4500,"profileID":"mh1-25x4500","type":"memory"},{"certified":true,"cores":30,"memory":5400,"profileID":"mh1-30x5400","type":"memory"},{"certified":true,"cores":35,"memory":6300,"profileID":"mh1-35x6300","type":"memory"},{"certified":true,"cores":40,"memory":7200,"profileID":"mh1-40x7200","type":"memory"},{"certified":true,"cores":50,"memory":9000,"profileID":"mh1-50x9000","type":"memory"},{"certified":true,"cores":60,"memory":10800,"profileID":"mh1-60x10800","type":"memory"},{"certified":true,"cores":70,"memory":12600,"profileID":"mh1-70x12600","type":"memory"},{"certified":true,"cores":80,"memory":14400,"profileID":"mh1-80x14400","type":"memory"},{"certified":true,"cores":90,"memory":16200,"profileID":"mh1-90x16200","type":"memory"},{"certified":true,"cores":100,"memory":18000,"profileID":"mh1-100x18000","type":"memory"},{"certified":true,"cores":4,"memory":128,"profileID":"ush1-4x128","type":"small"},{"certified":true,"cores":4,"memory":256,"profileID":"ush1-4x256","type":"small"},{"certified":true,"cores":4,"memory":384,"profileID":"ush1-4x384","type":"small"},{"certified":true,"cores":4,"memory":512,"profileID":"ush1-4x512","type":"small"},{"certified":true,"cores":4,"memory":768,"profileID":"ush1-4x768","type":"small"},{"certified":true,"cores":4,"memory":960,"profileID":"umh-4x960","type":"ultra-memory"},{"certified":true,"cores":6,"memory":1440,"profileID":"umh-6x1440","type":"ultra-memory"},{"certified":true,"cores":8,"memory":1920,"profileID":"umh-8x1920","type":"ultra-memory"},{"certified":true,"cores":10,"memory":2400,"profileID":"umh-10x2400","type":"ultra-memory"},{"certified":true,"cores":12,"memory":2880,"profileID":"umh-12x2880","type":"ultra-memory"},{"certified":true,"cores":16,"memory":3840,"profileID":"umh-16x3840","type":"ultra-memory"},{"certified":true,"cores":20,"memory":4800,"profileID":"umh-20x4800","type":"ultra-memory"},{"certified":true,"cores":22,"memory":5280,"profileID":"umh-22x5280","type":"ultra-memory"},{"certified":true,"cores":25,"memory":6000,"profileID":"umh-25x6000","type":"ultra-memory"},{"certified":true,"cores":30,"memory":7200,"profileID":"umh-30x7200","type":"ultra-memory"},{"certified":true,"cores":35,"memory":8400,"profileID":"umh-35x8400","type":"ultra-memory"},{"certified":true,"cores":40,"memory":9600,"profileID":"umh-40x9600","type":"ultra-memory"},{"certified":true,"cores":50,"memory":12000,"profileID":"umh-50x12000","type":"ultra-memory"},{"certified":true,"cores":60,"memory":14400,"profileID":"umh-60x14400","type":"ultra-memory"},{"certified":false,"cores":1,"memory":128,"profileID":"np1-1x128","type":"non-production"}]}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:31:03 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/storage-capacity/storage-types
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"any"},"storageTypesCapacity":[{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier1"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier1","totalCapacity":390092}],"storageType":"tier1"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier3"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier3","totalCapacity":390092}],"storageType":"tier3"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier5k"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier5k","totalCapacity":390092}],"storageType":"tier5k"},{"maximumStorageAllocation":{"maxAllocationSize":285449,"storagePool":"General-Flash-72","storageType":"tier0"},"storagePoolsCapacity":[{"maxAllocationSize":280053,"poolName":"General-Flash-81","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":262973,"poolName":"General-Flash-78","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":282418,"poolName":"General-Flash-75","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092},{"maxAllocationSize":285449,"poolName":"General-Flash-72","replicationEnabled":false,"storageType":"tier0","totalCapacity":390092}],"storageType":"tier0"}]}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:31:04 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"consoleLanguage":{"code":"037","language":"037
-        English"},"creationDate":"2024-01-18T18:43:09.000Z","diskSize":100,"health":{"lastUpdate":"2024-01-18T19:31:05.494688","status":"OK"},"hostID":7,"imageID":"ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2","maxmem":16,"maxproc":2,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["925c13aa-9579-43a3-86e1-150131906835"],"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/e8cf72cf-7685-4bfb-a386-66422f71820a/networks/925c13aa-9579-43a3-86e1-150131906835","ip":"127.0.0.15","ipAddress":"127.0.0.15","macAddress":"fa:d7:46:29:3f:20","networkID":"925c13aa-9579-43a3-86e1-150131906835","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"V7R5M0
-        410 2","osType":"ibmi","pinPolicy":"none","placementGroup":"8334ba79-bd98-47af-ad25-6eb8a1c4c817","procType":"capped","processors":0.25,"pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a","serverName":"test-instance-ibmi-s922-capped-tier1","softwareLicenses":{"ibmiCSS":false,"ibmiDBQ":false,"ibmiPHA":false,"ibmiRDS":false},"srcs":[[{"src":"A6005008","timestamp":"2024-01-18T18:51:32Z"},{"src":"03B00061","timestamp":"2024-01-18T18:51:32Z"},{"src":"FFFF0000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"50070404","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"},{"src":"00000000","timestamp":"2024-01-18T18:51:32Z"}]],"status":"ACTIVE","storagePool":"General-Flash-72","storagePoolAffinity":true,"storageType":"tier1","sysType":"s922","updatedDate":"2024-01-18T18:43:09.000Z","virtualCores":{"assigned":1,"max":4,"min":1},"volumeIDs":["ed84f79b-b8d1-48c3-8766-2a92ff6a879b"]}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:31:08 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
-      Authorization: Bearer xxxxxx
-      Accept:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Content-Type:
-      - application/json
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-    body:
-      encoding: UTF-8
-      string: '{"images":[{"creationDate":"2022-11-15T22:45:40.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/8de97d73-95c0-46e9-a509-0b10be36eded","imageID":"8de97d73-95c0-46e9-a509-0b10be36eded","lastUpdateDate":"2023-06-07T01:38:14.000Z","name":"7300-00-01","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"aix"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-15T22:45:06.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/7da758c0-949b-4b11-a306-dc7dfc33919e","imageID":"7da758c0-949b-4b11-a306-dc7dfc33919e","lastUpdateDate":"2023-06-07T01:38:15.000Z","name":"CentOS-Stream-8","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2024-01-18T18:41:35.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/9eebf535-9b78-450e-bffd-e7cb4d3c9e94","imageID":"9eebf535-9b78-450e-bffd-e7cb4d3c9e94","lastUpdateDate":"2024-01-18T18:41:35.000Z","name":"IBMi-75-02-2984-1","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-15T22:42:20.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/10d7c4a5-32a7-44a9-b9e1-9a428a4da5d9","imageID":"10d7c4a5-32a7-44a9-b9e1-9a428a4da5d9","lastUpdateDate":"2023-06-07T01:38:17.000Z","name":"RHEL8-SP6","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-11-12T11:36:56.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/a0198511-c877-4f6f-b1c3-64312fcdb92c","imageID":"a0198511-c877-4f6f-b1c3-64312fcdb92c","lastUpdateDate":"2023-06-07T01:38:19.000Z","name":"SLES15-SP4","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock-fls","operatingSystem":"sles"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2022-01-28T22:32:39.000Z","description":"","href":"/pcloud/v1/cloud-instances/c8d0ac7c30c944f0ac3288eb8bb74aaa/images/032d72bf-89f2-44a9-bbc4-ab898dd93309","imageID":"032d72bf-89f2-44a9-bbc4-ab898dd93309","lastUpdateDate":"2023-12-14T21:46:24.000Z","name":"rhcos-4.8","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"import","operatingSystem":"rhel"},"state":"active","storagePool":"General-Flash-81","storageType":"tier3"}]}
-
-        '
-  recorded_at: Thu, 18 Jan 2024 19:31:09 GMT
-- request:
-    method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
-      Content-Type:
-      - application/json
-      Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -367,30 +183,39 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '433'
+      - '680'
+      X-Correlation-Id:
+      - fb24f333-78cb-4c67-b048-d4ab7e5c7ca6
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"creationDate":"2023-12-12T23:02:27.000Z","imageID":"ed8cb3ae-1a68-42c4-9c0a-fcec0c96f1c2","lastUpdateDate":"2023-12-12T23:15:20.000Z","name":"IBMi-75-02-2984-1","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"","storageType":"","volumes":[]}
+      encoding: ASCII-8BIT
+      string: '{"capabilities":["ibmi-software-licenses","linux","pinning","rhel-sap","sap","snapshots","volume-clone","shared-processor-pools"],"cloudInstanceID":"9089686c4d6143a4bdcc72b197c7655d","enabled":true,"initialized":false,"limits":{"instanceMemory":0,"instanceProcUnits":0,"instances":0,"memory":0,"peeringBandwidth":0,"peeringNetworks":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0},"name":"IBM_CLOUD_POWERVS_INSTANCE_ID","openstackID":"d4c477222576b7395a58a51fbee2937a","pvmInstances":[],"region":"us-east10","tenantID":"1fdf5effc3f945688c021cd0a8b45c4d","usage":{"instances":0,"memory":0,"procUnits":0,"processors":0,"storage":0,"storageSSD":0,"storageStandard":0}}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:31:10 GMT
+  recorded_at: Wed, 25 Jun 2025 15:11:03 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/sap
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -403,39 +228,320 @@ http_interactions:
     headers:
       Content-Type:
       - application/json
+      X-Correlation-Id:
+      - 7be367f1-4b20-4544-873f-2791246d16e7
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"volumes":[{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T19:02:29.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/7d6f53e6-4adf-4792-8b5f-07cc618dff78","ioThrottleRate":"360
-        iops","lastUpdateDate":"2024-01-18T19:13:21.000Z","name":"test-instance-d6a661a8-00030ebf-boot-0","pvmInstanceIDs":["d6a661a8-fed1-4a52-9d50-24fc9f9956b8"],"shareable":false,"size":120,"state":"in-use","volumeID":"7d6f53e6-4adf-4792-8b5f-07cc618dff78","volumePool":"General-Flash-81","volumeType":"Tier3-General-Flash-81","wwn":"60050768108002DAC800000000004AF4"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:49:45.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/ba26d663-1e76-4457-8732-9d9235df8019","ioThrottleRate":"300
-        iops","lastUpdateDate":"2024-01-18T19:00:43.000Z","name":"test-instance-54e1f646-00030ebe-boot-0","pvmInstanceIDs":["54e1f646-8ce4-4ee5-9355-e5d34166c4fd"],"shareable":false,"size":100,"state":"in-use","volumeID":"ba26d663-1e76-4457-8732-9d9235df8019","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C4"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:47:54.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/984498df-5554-4685-a109-821d5e39b27b","ioThrottleRate":"300
-        iops","lastUpdateDate":"2024-01-18T18:48:16.000Z","name":"test-instance-b9370d8d-00030ebb-boot-0","pvmInstanceIDs":["b9370d8d-8d73-4f0e-ad84-34f7fd52eb84"],"shareable":false,"size":100,"state":"in-use","volumeID":"984498df-5554-4685-a109-821d5e39b27b","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C3"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:45:07.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/cdfebbb2-d64e-41e1-9834-4f6b5d249489","ioThrottleRate":"360
-        iops","lastUpdateDate":"2024-01-18T18:45:34.000Z","name":"test-instance-1ea38460-00030eb6-boot-0","pvmInstanceIDs":["1ea38460-b3ff-4abd-802b-0289983be590"],"shareable":false,"size":120,"state":"in-use","volumeID":"cdfebbb2-d64e-41e1-9834-4f6b5d249489","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274C2"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T18:43:15.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/ed84f79b-b8d1-48c3-8766-2a92ff6a879b","ioThrottleRate":"1000
-        iops","lastUpdateDate":"2024-01-18T18:43:38.000Z","name":"test-instance-e8cf72cf-00030eb4-boot-0","pvmInstanceIDs":["e8cf72cf-7685-4bfb-a386-66422f71820a"],"shareable":false,"size":100,"state":"in-use","volumeID":"ed84f79b-b8d1-48c3-8766-2a92ff6a879b","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274C1"},{"bootVolume":false,"bootable":true,"creationDate":"2024-01-18T17:24:51.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/2e653913-14fe-4b3a-a4f3-c7396bed0862","ioThrottleRate":"250
-        iops","lastUpdateDate":"2024-01-18T17:25:13.000Z","name":"test-instance-502106d8-00030ea7-boot-0","pvmInstanceIDs":["502106d8-d969-49df-9103-184c3ab97508"],"shareable":false,"size":25,"state":"in-use","volumeID":"2e653913-14fe-4b3a-a4f3-c7396bed0862","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274BB"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:13.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/21f2d430-44fd-4f5e-af43-66076e6e9af7","ioThrottleRate":"150
-        iops","lastUpdateDate":"2024-01-18T17:24:14.000Z","name":"test-volume-15GB-tier1-notsharable","pvmInstanceIDs":[],"shareable":false,"size":15,"state":"available","volumeID":"21f2d430-44fd-4f5e-af43-66076e6e9af7","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274BA"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:07.000Z","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/5bb66445-1de3-4817-8590-42b35f21f9d8","ioThrottleRate":"30
-        iops","lastUpdateDate":"2024-01-18T17:24:08.000Z","name":"test-volume-3GB-tier1-notsharable","pvmInstanceIDs":[],"shareable":false,"size":3,"state":"available","volumeID":"5bb66445-1de3-4817-8590-42b35f21f9d8","volumePool":"General-Flash-72","volumeType":"Tier1-General-Flash-72","wwn":"60050768108101DAC0000000000274B9"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:24:03.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/f302fbf6-c2f7-4df2-b80c-c3c2e8055d77","ioThrottleRate":"30
-        iops","lastUpdateDate":"2024-01-18T17:24:04.000Z","name":"test-volume-10GB-tier3-sharable","pvmInstanceIDs":[],"shareable":true,"size":10,"state":"available","volumeID":"f302fbf6-c2f7-4df2-b80c-c3c2e8055d77","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274B8"},{"bootVolume":false,"bootable":false,"creationDate":"2024-01-18T17:23:57.000Z","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/46eef916-ea40-4aee-9e0c-df840da65867","ioThrottleRate":"3
-        iops","lastUpdateDate":"2024-01-18T17:23:58.000Z","name":"test-volume-1GB-tier3-sharable","pvmInstanceIDs":[],"shareable":true,"size":1,"state":"available","volumeID":"46eef916-ea40-4aee-9e0c-df840da65867","volumePool":"General-Flash-72","volumeType":"Tier3-General-Flash-72","wwn":"60050768108101DAC0000000000274B7"}]}
+      encoding: ASCII-8BIT
+      string: '{"profiles":[{"certified":true,"cores":16,"defaultSystem":"e980","fullSystemProfile":false,"memory":1600,"profileID":"bh1-16x1600","saps":96000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":20,"defaultSystem":"e980","fullSystemProfile":false,"memory":2000,"profileID":"bh1-20x2000","saps":120000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":22,"defaultSystem":"e980","fullSystemProfile":false,"memory":2200,"profileID":"bh1-22x2200","saps":132000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":25,"defaultSystem":"e980","fullSystemProfile":false,"memory":2500,"profileID":"bh1-25x2500","saps":150000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":30,"defaultSystem":"e980","fullSystemProfile":false,"memory":3000,"profileID":"bh1-30x3000","saps":180000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":35,"defaultSystem":"e1050","fullSystemProfile":false,"memory":3000,"profileID":"bh2-35x3000","saps":266000,"smtMode":8,"supportedSystems":["e1050"],"type":"balanced","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":35,"defaultSystem":"e980","fullSystemProfile":false,"memory":3500,"profileID":"bh1-35x3500","saps":210000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":35,"defaultSystem":"e1050","fullSystemProfile":false,"memory":3900,"profileID":"bh2-35x3900","saps":266000,"smtMode":8,"supportedSystems":["e1050"],"type":"balanced","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":40,"defaultSystem":"e980","fullSystemProfile":false,"memory":4000,"profileID":"bh1-40x4000","saps":240000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":50,"defaultSystem":"e980","fullSystemProfile":false,"memory":5000,"profileID":"bh1-50x5000","saps":300000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":60,"defaultSystem":"e980","fullSystemProfile":false,"memory":6000,"profileID":"bh1-60x6000","saps":360000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":70,"defaultSystem":"e980","fullSystemProfile":false,"memory":7000,"profileID":"bh1-70x7000","saps":420000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":80,"defaultSystem":"e980","fullSystemProfile":false,"memory":8000,"profileID":"bh1-80x8000","saps":480000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":100,"defaultSystem":"e980","fullSystemProfile":false,"memory":10000,"profileID":"bh1-100x10000","saps":600000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":120,"defaultSystem":"e980","fullSystemProfile":false,"memory":12000,"profileID":"bh1-120x12000","saps":720000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":140,"defaultSystem":"e980","fullSystemProfile":false,"memory":14000,"profileID":"bh1-140x14000","saps":840000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":["OLAP"]},{"certified":true,"cores":150,"defaultSystem":"e980","fullSystemProfile":false,"memory":15000,"profileID":"bh1-150x15000","saps":0,"smtMode":8,"supportedSystems":["e880","e980"],"type":"balanced","workloadTypes":[""]},{"certified":true,"cores":60,"defaultSystem":"e980","fullSystemProfile":false,"memory":3000,"profileID":"ch1-60x3000","saps":360000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":70,"defaultSystem":"e980","fullSystemProfile":false,"memory":3500,"profileID":"ch1-70x3500","saps":420000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":80,"defaultSystem":"e980","fullSystemProfile":false,"memory":4000,"profileID":"ch1-80x4000","saps":480000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":80,"defaultSystem":"e1050","fullSystemProfile":true,"memory":6144,"profileID":"ch2-80x6144","saps":608000,"smtMode":8,"supportedSystems":["e1050"],"type":"compute","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":6000,"profileID":"ch2-87x6000","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"compute","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":7000,"profileID":"ch2-87x7000","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"compute","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":7600,"profileID":"ch2-87x7600","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"compute","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":100,"defaultSystem":"e980","fullSystemProfile":false,"memory":5000,"profileID":"ch1-100x5000","saps":600000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":120,"defaultSystem":"e980","fullSystemProfile":false,"memory":6000,"profileID":"ch1-120x6000","saps":720000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":140,"defaultSystem":"e980","fullSystemProfile":false,"memory":7000,"profileID":"ch1-140x7000","saps":840000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":["OLAP"]},{"certified":true,"cores":150,"defaultSystem":"e980","fullSystemProfile":false,"memory":7500,"profileID":"ch1-150x7500","saps":0,"smtMode":8,"supportedSystems":["e880","e980"],"type":"compute","workloadTypes":[""]},{"certified":true,"cores":8,"defaultSystem":"e980","fullSystemProfile":false,"memory":1440,"profileID":"mh1-8x1440","saps":48000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":10,"defaultSystem":"e980","fullSystemProfile":false,"memory":1800,"profileID":"mh1-10x1800","saps":60000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":12,"defaultSystem":"e980","fullSystemProfile":false,"memory":2160,"profileID":"mh1-12x2160","saps":72000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":16,"defaultSystem":"e980","fullSystemProfile":false,"memory":2880,"profileID":"mh1-16x2880","saps":96000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":20,"defaultSystem":"e980","fullSystemProfile":false,"memory":3600,"profileID":"mh1-20x3600","saps":120000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":22,"defaultSystem":"e980","fullSystemProfile":false,"memory":3960,"profileID":"mh1-22x3960","saps":132000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":25,"defaultSystem":"e980","fullSystemProfile":false,"memory":4500,"profileID":"mh1-25x4500","saps":150000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":30,"defaultSystem":"e980","fullSystemProfile":false,"memory":5400,"profileID":"mh1-30x5400","saps":180000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":35,"defaultSystem":"e980","fullSystemProfile":false,"memory":6300,"profileID":"mh1-35x6300","saps":210000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":40,"defaultSystem":"e980","fullSystemProfile":false,"memory":7200,"profileID":"mh1-40x7200","saps":240000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":50,"defaultSystem":"e980","fullSystemProfile":false,"memory":9000,"profileID":"mh1-50x9000","saps":300000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":60,"defaultSystem":"e980","fullSystemProfile":false,"memory":10800,"profileID":"mh1-60x10800","saps":360000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":70,"defaultSystem":"e980","fullSystemProfile":false,"memory":12600,"profileID":"mh1-70x12600","saps":420000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":80,"defaultSystem":"e980","fullSystemProfile":false,"memory":14400,"profileID":"mh1-80x14400","saps":480000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":["OLAP"]},{"certified":true,"cores":90,"defaultSystem":"e980","fullSystemProfile":false,"memory":16200,"profileID":"mh1-90x16200","saps":0,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":[""]},{"certified":true,"cores":100,"defaultSystem":"e980","fullSystemProfile":false,"memory":18000,"profileID":"mh1-100x18000","saps":0,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":[""]},{"certified":true,"cores":125,"defaultSystem":"e980","fullSystemProfile":false,"memory":22500,"profileID":"mh1-125x22500","saps":0,"smtMode":8,"supportedSystems":["e880","e980"],"type":"memory","workloadTypes":[""]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sr2-7x256","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":384,"profileID":"sr2-7x384","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":950,"profileID":"sr2-12x950","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1450,"profileID":"sr2-12x1450","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":14,"defaultSystem":"s1022","fullSystemProfile":false,"memory":512,"profileID":"sr2-14x512","saps":84000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLTP"]},{"certified":true,"cores":14,"defaultSystem":"s1022","fullSystemProfile":false,"memory":740,"profileID":"sr2-14x740","saps":84000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":22,"defaultSystem":"e1080","fullSystemProfile":false,"memory":2950,"profileID":"sr2-22x2950","saps":132000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":24,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1024,"profileID":"sr2-24x1024","saps":144000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":24,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1536,"profileID":"sr2-24x1536","saps":144000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":25,"defaultSystem":"s1022","fullSystemProfile":true,"memory":1900,"profileID":"sr2-25x1900","saps":190000,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":35,"defaultSystem":"e1050","fullSystemProfile":false,"memory":3000,"profileID":"sr2-35x3000","saps":266000,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":35,"defaultSystem":"e1050","fullSystemProfile":false,"memory":3900,"profileID":"sr2-35x3900","saps":266000,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":35,"defaultSystem":"e1080","fullSystemProfile":false,"memory":4450,"profileID":"sr2-35x4450","saps":210000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":40,"defaultSystem":"e1080","fullSystemProfile":false,"memory":3072,"profileID":"sr2-40x3072","saps":240000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":64,"defaultSystem":"e1080","fullSystemProfile":false,"memory":6144,"profileID":"sr2-64x6144","saps":384000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":80,"defaultSystem":"e1050","fullSystemProfile":true,"memory":6144,"profileID":"sr2-80x6144","saps":608000,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":80,"defaultSystem":"e1080","fullSystemProfile":false,"memory":9216,"profileID":"sr2-80x9216","saps":480000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":80,"defaultSystem":"e1080","fullSystemProfile":false,"memory":12288,"profileID":"sr2-80x12288","saps":480000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":80,"defaultSystem":"e1080","fullSystemProfile":false,"memory":14400,"profileID":"sr2-80x14400","saps":480000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":6000,"profileID":"sr2-87x6000","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":7000,"profileID":"sr2-87x7000","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":87,"defaultSystem":"e1050","fullSystemProfile":true,"memory":7600,"profileID":"sr2-87x7600","saps":661200,"smtMode":8,"supportedSystems":["e1050"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":128,"defaultSystem":"e1080","fullSystemProfile":false,"memory":16000,"profileID":"sr2-128x16000","saps":768000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":128,"defaultSystem":"e1080","fullSystemProfile":false,"memory":18000,"profileID":"sr2-128x18000","saps":768000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":128,"defaultSystem":"e1080","fullSystemProfile":false,"memory":20000,"profileID":"sr2-128x20000","saps":768000,"smtMode":4,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":165,"defaultSystem":"e1080","fullSystemProfile":true,"memory":22000,"profileID":"sr2-165x22000","saps":1254000,"smtMode":8,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":165,"defaultSystem":"e1080","fullSystemProfile":true,"memory":24000,"profileID":"sr2-165x24000","saps":1254000,"smtMode":8,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":165,"defaultSystem":"e1080","fullSystemProfile":true,"memory":26000,"profileID":"sr2-165x26000","saps":1254000,"smtMode":8,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":165,"defaultSystem":"e1080","fullSystemProfile":true,"memory":28000,"profileID":"sr2-165x28000","saps":1254000,"smtMode":8,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":165,"defaultSystem":"e1080","fullSystemProfile":true,"memory":30500,"profileID":"sr2-165x30500","saps":1254000,"smtMode":8,"supportedSystems":["e1080"],"type":"sap-rise","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":2,"defaultSystem":"s1022","fullSystemProfile":false,"memory":32,"profileID":"sr2-2x32","saps":15200,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":3,"defaultSystem":"s1022","fullSystemProfile":false,"memory":64,"profileID":"sr2-3x64","saps":22800,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":64,"profileID":"sr2-4x64","saps":30400,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":6,"defaultSystem":"s1022","fullSystemProfile":false,"memory":128,"profileID":"sr2-6x128","saps":45600,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":8,"defaultSystem":"s1022","fullSystemProfile":false,"memory":128,"profileID":"sr2-8x128","saps":60800,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sr2-12x256","saps":91200,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":16,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sr2-16x256","saps":121600,"smtMode":8,"supportedSystems":["s1022"],"type":"sap-rise-app","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":128,"profileID":"ush1-4x128","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sh2-4x256","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":256,"profileID":"ush1-4x256","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":384,"profileID":"sh2-4x384","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":384,"profileID":"ush1-4x384","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":512,"profileID":"sh2-4x512","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":512,"profileID":"ush1-4x512","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":768,"profileID":"sh2-4x768","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":768,"profileID":"ush1-4x768","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1000,"profileID":"sh2-4x1000","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":4,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1500,"profileID":"sh2-4x1500","saps":24000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sh2-7x256","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":384,"profileID":"sh2-7x384","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":512,"profileID":"sh2-7x512","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":768,"profileID":"sh2-7x768","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1000,"profileID":"sh2-7x1000","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":7,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1500,"profileID":"sh2-7x1500","saps":42000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":8,"defaultSystem":"s1022","fullSystemProfile":true,"memory":1900,"profileID":"sh2-8x1900","saps":60800,"smtMode":8,"supportedSystems":["s1022"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":256,"profileID":"sh2-12x256","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":384,"profileID":"sh2-12x384","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":512,"profileID":"sh2-12x512","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":768,"profileID":"sh2-12x768","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1000,"profileID":"sh2-12x1000","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":12,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1500,"profileID":"sh2-12x1500","saps":72000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":16,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1000,"profileID":"sh2-16x1000","saps":96000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":16,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1500,"profileID":"sh2-16x1500","saps":96000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":16,"defaultSystem":"s1022","fullSystemProfile":true,"memory":1900,"profileID":"sh2-16x1900","saps":121600,"smtMode":8,"supportedSystems":["s1022"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":25,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1000,"profileID":"sh2-25x1000","saps":150000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":25,"defaultSystem":"s1022","fullSystemProfile":false,"memory":1500,"profileID":"sh2-25x1500","saps":150000,"smtMode":4,"supportedSystems":["s1022","e1080"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":33,"defaultSystem":"s1022","fullSystemProfile":true,"memory":1900,"profileID":"sh2-33x1900","saps":250800,"smtMode":8,"supportedSystems":["s1022"],"type":"small","workloadTypes":["OLAP/OLTP"]},{"certified":true,"cores":4,"defaultSystem":"e980","fullSystemProfile":false,"memory":960,"profileID":"umh-4x960","saps":24000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":6,"defaultSystem":"e980","fullSystemProfile":false,"memory":1440,"profileID":"umh-6x1440","saps":36000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":8,"defaultSystem":"e980","fullSystemProfile":false,"memory":1920,"profileID":"umh-8x1920","saps":48000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":10,"defaultSystem":"e980","fullSystemProfile":false,"memory":2400,"profileID":"umh-10x2400","saps":60000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":12,"defaultSystem":"e980","fullSystemProfile":false,"memory":2880,"profileID":"umh-12x2880","saps":72000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":16,"defaultSystem":"e980","fullSystemProfile":false,"memory":3840,"profileID":"umh-16x3840","saps":96000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":20,"defaultSystem":"e980","fullSystemProfile":false,"memory":4800,"profileID":"umh-20x4800","saps":120000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":22,"defaultSystem":"e980","fullSystemProfile":false,"memory":5280,"profileID":"umh-22x5280","saps":132000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":25,"defaultSystem":"e980","fullSystemProfile":false,"memory":6000,"profileID":"umh-25x6000","saps":150000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":30,"defaultSystem":"e980","fullSystemProfile":false,"memory":7200,"profileID":"umh-30x7200","saps":180000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":35,"defaultSystem":"e980","fullSystemProfile":false,"memory":8400,"profileID":"umh-35x8400","saps":210000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":40,"defaultSystem":"e980","fullSystemProfile":false,"memory":9600,"profileID":"umh-40x9600","saps":240000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":50,"defaultSystem":"e980","fullSystemProfile":false,"memory":12000,"profileID":"umh-50x12000","saps":300000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]},{"certified":true,"cores":60,"defaultSystem":"e980","fullSystemProfile":false,"memory":14400,"profileID":"umh-60x14400","saps":360000,"smtMode":8,"supportedSystems":["e880","e980"],"type":"ultra-memory","workloadTypes":["OLTP"]}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:31:10 GMT
+  recorded_at: Wed, 25 Jun 2025 15:11:04 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/placement-groups
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/storage-capacity/storage-types
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Correlation-Id:
+      - 6edd7963-42ba-4758-a06b-c59aec1780ba
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"maximumStorageAllocation":{"maxAllocationSize":184751,"storagePool":"General-Flash-53","storageType":"any"},"storageTypesCapacity":[{"maximumStorageAllocation":{"maxAllocationSize":184751,"storagePool":"General-Flash-53","storageType":"tier0"},"storagePoolsCapacity":[{"maxAllocationSize":184751,"poolName":"General-Flash-53","replicationEnabled":true,"storageHost":"ius-east10_tier3_1","storageType":"tier0","totalCapacity":512000},{"maxAllocationSize":150354,"poolName":"General-Flash-59","replicationEnabled":true,"storageHost":"ius-east10_tier3_2","storageType":"tier0","totalCapacity":512000},{"maxAllocationSize":148173,"poolName":"General-Flash-56","replicationEnabled":true,"storageHost":"ius-east10_tier1_2","storageType":"tier0","totalCapacity":512000},{"maxAllocationSize":106374,"poolName":"General-Flash-50","replicationEnabled":true,"storageHost":"ius-east10_tier1_1","storageType":"tier0","totalCapacity":512000}],"storageType":"tier0"},{"maximumStorageAllocation":{"maxAllocationSize":184751,"storagePool":"General-Flash-53","storageType":"tier1"},"storagePoolsCapacity":[{"maxAllocationSize":184751,"poolName":"General-Flash-53","replicationEnabled":true,"storageHost":"ius-east10_tier3_1","storageType":"tier1","totalCapacity":512000},{"maxAllocationSize":150354,"poolName":"General-Flash-59","replicationEnabled":true,"storageHost":"ius-east10_tier3_2","storageType":"tier1","totalCapacity":512000},{"maxAllocationSize":106374,"poolName":"General-Flash-50","replicationEnabled":true,"storageHost":"ius-east10_tier1_1","storageType":"tier1","totalCapacity":512000},{"maxAllocationSize":148173,"poolName":"General-Flash-56","replicationEnabled":true,"storageHost":"ius-east10_tier1_2","storageType":"tier1","totalCapacity":512000}],"storageType":"tier1"},{"maximumStorageAllocation":{"maxAllocationSize":184751,"storagePool":"General-Flash-53","storageType":"tier3"},"storagePoolsCapacity":[{"maxAllocationSize":148173,"poolName":"General-Flash-56","replicationEnabled":true,"storageHost":"ius-east10_tier1_2","storageType":"tier3","totalCapacity":512000},{"maxAllocationSize":106374,"poolName":"General-Flash-50","replicationEnabled":true,"storageHost":"ius-east10_tier1_1","storageType":"tier3","totalCapacity":512000},{"maxAllocationSize":150354,"poolName":"General-Flash-59","replicationEnabled":true,"storageHost":"ius-east10_tier3_2","storageType":"tier3","totalCapacity":512000},{"maxAllocationSize":184751,"poolName":"General-Flash-53","replicationEnabled":true,"storageHost":"ius-east10_tier3_1","storageType":"tier3","totalCapacity":512000}],"storageType":"tier3"},{"maximumStorageAllocation":{"maxAllocationSize":184751,"storagePool":"General-Flash-53","storageType":"tier5k"},"storagePoolsCapacity":[{"maxAllocationSize":184751,"poolName":"General-Flash-53","replicationEnabled":true,"storageHost":"ius-east10_tier3_1","storageType":"tier5k","totalCapacity":512000},{"maxAllocationSize":150354,"poolName":"General-Flash-59","replicationEnabled":true,"storageHost":"ius-east10_tier3_2","storageType":"tier5k","totalCapacity":512000},{"maxAllocationSize":148173,"poolName":"General-Flash-56","replicationEnabled":true,"storageHost":"ius-east10_tier1_2","storageType":"tier5k","totalCapacity":512000},{"maxAllocationSize":106374,"poolName":"General-Flash-50","replicationEnabled":true,"storageHost":"ius-east10_tier1_1","storageType":"tier5k","totalCapacity":512000}],"storageType":"tier5k"}]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 15:11:05 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/04c9a30d-c8d5-46cb-849b-0f7fa5004b70
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Correlation-Id:
+      - 0550ee98-ba31-4f2a-894b-13a736faa1eb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"addresses":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/04c9a30d-c8d5-46cb-849b-0f7fa5004b70/networks/75a55a9f-1038-4495-9c3f-f7c113670c2e","ip":"127.0.0.1","ipAddress":"127.0.0.1","macAddress":"fa:16:3e:a1:4d:23","networkID":"75a55a9f-1038-4495-9c3f-f7c113670c2e","networkInterfaceID":"3ba26bdf-adea-4fae-a99b-4dfbfadac1f1","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"consoleLanguage":{"code":"037","language":"037
+        English"},"creationDate":"2025-06-25T14:33:31.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:pvm-instance:04c9a30d-c8d5-46cb-849b-0f7fa5004b70","diskSize":100,"health":{"lastUpdate":"2025-06-25T15:11:07.672860","status":"OK"},"hostID":79,"imageID":"0e09362f-08dd-4fff-ae7b-c389b81ab7bd","maxmem":16,"maxproc":2,"memory":2,"migratable":false,"minmem":2,"minproc":0.25,"networkIDs":["75a55a9f-1038-4495-9c3f-f7c113670c2e"],"networks":[{"href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/pvm-instances/04c9a30d-c8d5-46cb-849b-0f7fa5004b70/networks/75a55a9f-1038-4495-9c3f-f7c113670c2e","ip":"127.0.0.1","ipAddress":"127.0.0.1","macAddress":"fa:16:3e:a1:4d:23","networkID":"75a55a9f-1038-4495-9c3f-f7c113670c2e","networkInterfaceID":"3ba26bdf-adea-4fae-a99b-4dfbfadac1f1","networkName":"test-network-vlan-jumbo","type":"fixed","version":4}],"operatingSystem":"V7R5M0
+        410 5","osType":"ibmi","pinPolicy":"soft","placementGroup":"69ac6b47-912e-4346-8804-da768f4aa789","procType":"capped","processors":0.25,"pvmInstanceID":"04c9a30d-c8d5-46cb-849b-0f7fa5004b70","serverName":"test-instance-ibmi-s922-capped-tier1","softwareLicenses":{"ibmiCSS":false,"ibmiDBQ":false,"ibmiPHA":false,"ibmiRDS":false},"srcs":[[{"src":"A6005008","timestamp":"2025-06-25T15:25:10Z"},{"src":"03B00061","timestamp":"2025-06-25T15:25:10Z"},{"src":"FFFF0000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"50070404","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"},{"src":"00000000","timestamp":"2025-06-25T15:25:10Z"}]],"status":"ACTIVE","storagePool":"General-Flash-53","storagePoolAffinity":true,"storageType":"any","sysType":"s922","updatedDate":"2025-06-25T14:33:31.000Z","virtualCores":{"assigned":1,"max":4,"min":1},"volumeIDs":["b6a90aec-fce5-4640-9a99-140e8af2b103"]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 15:11:21 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Correlation-Id:
+      - 4d119a4c-b662-4de3-b757-1324964ef06c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"images":[{"creationDate":"2025-06-12T13:30:49.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:05e43ffe-bf8e-4f4a-8dd8-2ebc747e9b33","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/05e43ffe-bf8e-4f4a-8dd8-2ebc747e9b33","imageID":"05e43ffe-bf8e-4f4a-8dd8-2ebc747e9b33","lastUpdateDate":"2025-06-12T13:30:49.000Z","name":"7300-03-00","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"aix"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2025-06-12T13:34:00.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:be0864af-8dda-465f-80e0-695715fb40f0","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/be0864af-8dda-465f-80e0-695715fb40f0","imageID":"be0864af-8dda-465f-80e0-695715fb40f0","lastUpdateDate":"2025-06-12T13:34:00.000Z","name":"CentOS-Stream-9","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2025-06-12T13:32:01.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:198a2763-0f16-4026-bc5d-77a3f6b8b5bc","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/198a2763-0f16-4026-bc5d-77a3f6b8b5bc","imageID":"198a2763-0f16-4026-bc5d-77a3f6b8b5bc","lastUpdateDate":"2025-06-12T13:32:01.000Z","name":"IBMi-75-05-2984-1","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2025-06-12T13:36:54.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:4c7f350e-218b-42c3-b11f-2e6eca8599d2","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/4c7f350e-218b-42c3-b11f-2e6eca8599d2","imageID":"4c7f350e-218b-42c3-b11f-2e6eca8599d2","lastUpdateDate":"2025-06-12T13:36:54.000Z","name":"RHEL9-SP4-BYOL","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"rhel"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2025-06-12T13:38:02.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:e3c7a731-aa96-493c-8390-1911269de574","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/e3c7a731-aa96-493c-8390-1911269de574","imageID":"e3c7a731-aa96-493c-8390-1911269de574","lastUpdateDate":"2025-06-12T13:38:02.000Z","name":"SLES15-SP6-BYOL","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"sles"},"state":"active","storagePool":"","storageType":""},{"creationDate":"2025-06-12T19:27:42.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:image:e6b94e6c-8c6a-4a05-9718-afef367b4af9","description":"","href":"/pcloud/v1/cloud-instances/9089686c4d6143a4bdcc72b197c7655d/images/e6b94e6c-8c6a-4a05-9718-afef367b4af9","imageID":"e6b94e6c-8c6a-4a05-9718-afef367b4af9","lastUpdateDate":"2025-06-12T19:29:23.000Z","name":"rhcos-416","specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"little-endian","hypervisorType":"phyp","imageType":"import","operatingSystem":"rhel"},"state":"active","storagePool":"General-Flash-53","storageType":"tier1"}]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 15:11:23 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/images/0e09362f-08dd-4fff-ae7b-c389b81ab7bd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '107'
+      X-Correlation-Id:
+      - e4a04434-c0b8-47e5-87d0-1eb099bd06ed
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"description":"image does not exist. ID: 0e09362f-08dd-4fff-ae7b-c389b81ab7bd","error":"image
+        not found"}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 15:11:27 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/stock-images/0e09362f-08dd-4fff-ae7b-c389b81ab7bd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '588'
+      X-Correlation-Id:
+      - a4803eea-6c9d-44bc-90cc-ce274cde7f81
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"creationDate":"2025-03-21T00:49:56.000Z","imageID":"0e09362f-08dd-4fff-ae7b-c389b81ab7bd","lastUpdateDate":"2025-04-18T21:42:07.000Z","maxImageVolumeSize":100,"name":"IBMi-75-05-2984-1","servers":[],"size":100,"specifications":{"architecture":"ppc64","containerFormat":"bare","diskFormat":"raw","endianness":"big-endian","hypervisorType":"phyp","imageType":"stock","operatingSystem":"ibmi"},"state":"active","storagePool":"General-Flash-53","storageType":"tier3","volumes":[{"bootable":true,"name":"Imported
+        image volume","size":100,"volumeID":"9e260cc3-9425-4f9e-b1a8-08181d96d604"}]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 15:11:39 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      Authorization: Bearer xxxxxx
+      Accept:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Correlation-Id:
+      - 43426491-7ebb-4968-96b3-7eb7f31c06a0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
+      Cf-Cache-Status:
+      - DYNAMIC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"volumes":[{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:44:07.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:55eeb86d-80d4-4ef2-9267-0075bac0378d","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/55eeb86d-80d4-4ef2-9267-0075bac0378d","ioThrottleRate":"360
+        iops","lastUpdateDate":"2025-06-25T14:44:25.000Z","name":"test-instance-9317b826-0002edc3-boot-0","pvmInstanceIDs":["9317b826-3660-4cf9-aa93-6d42a4643ba9"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":120,"state":"in-use","volumeID":"55eeb86d-80d4-4ef2-9267-0075bac0378d","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9C4"},{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:41:27.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:2b3477a2-5e5c-46fc-8906-bc2ef9166c37","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/2b3477a2-5e5c-46fc-8906-bc2ef9166c37","ioThrottleRate":"300
+        iops","lastUpdateDate":"2025-06-25T14:42:00.000Z","name":"test-instance-c717671d-0002edc0-boot-0","pvmInstanceIDs":["c717671d-baae-4955-879f-0588ef5171bb"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":100,"state":"in-use","volumeID":"2b3477a2-5e5c-46fc-8906-bc2ef9166c37","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9C3"},{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:39:01.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:ab68a4b6-921e-4149-a6d3-70c281349fcf","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/ab68a4b6-921e-4149-a6d3-70c281349fcf","ioThrottleRate":"300
+        iops","lastUpdateDate":"2025-06-25T14:39:25.000Z","name":"test-instance-43a0b59a-0002edba-boot-0","pvmInstanceIDs":["43a0b59a-f4d7-4150-8fb8-72b4e5452d02"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":100,"state":"in-use","volumeID":"ab68a4b6-921e-4149-a6d3-70c281349fcf","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9BE"},{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:36:25.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:4fdf9382-aa4c-435e-9352-de392a6ef278","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/4fdf9382-aa4c-435e-9352-de392a6ef278","ioThrottleRate":"360
+        iops","lastUpdateDate":"2025-06-25T14:36:57.000Z","name":"test-instance-c19f7546-0002edb7-boot-0","pvmInstanceIDs":["c19f7546-323e-4e0b-bf97-5ad8668f0529"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":120,"state":"in-use","volumeID":"4fdf9382-aa4c-435e-9352-de392a6ef278","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9BC"},{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:33:58.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:b6a90aec-fce5-4640-9a99-140e8af2b103","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/b6a90aec-fce5-4640-9a99-140e8af2b103","ioThrottleRate":"1000
+        iops","lastUpdateDate":"2025-06-25T14:34:24.000Z","name":"test-instance-04c9a30d-0002edb4-boot-0","pvmInstanceIDs":["04c9a30d-c8d5-46cb-849b-0f7fa5004b70"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":100,"state":"in-use","volumeID":"b6a90aec-fce5-4640-9a99-140e8af2b103","volumePool":"General-Flash-53","volumeType":"Tier1-General-Flash-53","wwn":"6005076813810212980000000000A9BB"},{"auxiliary":false,"bootable":true,"creationDate":"2025-06-25T14:29:52.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:1f455cf4-c82c-4e1b-b84b-f1e86082aadf","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/1f455cf4-c82c-4e1b-b84b-f1e86082aadf","ioThrottleRate":"200
+        iops","lastUpdateDate":"2025-06-25T14:30:23.000Z","name":"test-instance-5d8393c6-0002edb1-boot-0","pvmInstanceIDs":["5d8393c6-b50c-4de4-98f0-a04222e9fbdc"],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":20,"state":"in-use","volumeID":"1f455cf4-c82c-4e1b-b84b-f1e86082aadf","volumePool":"General-Flash-53","volumeType":"Tier1-General-Flash-53","wwn":"6005076813810212980000000000A9BA"},{"auxiliary":false,"bootable":false,"creationDate":"2025-06-25T14:27:46.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:b5da6f68-de2e-4594-a615-4f3625f33e3c","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/b5da6f68-de2e-4594-a615-4f3625f33e3c","ioThrottleRate":"150
+        iops","lastUpdateDate":"2025-06-25T14:27:51.000Z","name":"test-volume-15GB-tier1-notsharable","pvmInstanceIDs":[],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":15,"state":"available","volumeID":"b5da6f68-de2e-4594-a615-4f3625f33e3c","volumePool":"General-Flash-53","volumeType":"Tier1-General-Flash-53","wwn":"6005076813810212980000000000A9B8"},{"auxiliary":false,"bootable":false,"creationDate":"2025-06-25T14:27:39.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:1e279407-e554-491d-8ed3-a5094ce86ac0","diskType":"tier1","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/1e279407-e554-491d-8ed3-a5094ce86ac0","ioThrottleRate":"30
+        iops","lastUpdateDate":"2025-06-25T14:27:42.000Z","name":"test-volume-3GB-tier1-notsharable","pvmInstanceIDs":[],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":false,"size":3,"state":"available","volumeID":"1e279407-e554-491d-8ed3-a5094ce86ac0","volumePool":"General-Flash-53","volumeType":"Tier1-General-Flash-53","wwn":"6005076813810212980000000000A9B7"},{"auxiliary":false,"bootable":false,"creationDate":"2025-06-25T14:27:32.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:5d1d628d-95ab-4513-81e0-b95b784a7062","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/5d1d628d-95ab-4513-81e0-b95b784a7062","ioThrottleRate":"30
+        iops","lastUpdateDate":"2025-06-25T14:27:34.000Z","name":"test-volume-10GB-tier3-sharable","pvmInstanceIDs":[],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":true,"size":10,"state":"available","volumeID":"5d1d628d-95ab-4513-81e0-b95b784a7062","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9B6"},{"auxiliary":false,"bootable":false,"creationDate":"2025-06-25T14:27:24.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:volume:2ce11d4a-2c94-4742-bff4-0e802cf348f8","diskType":"tier3","href":"/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/volumes/2ce11d4a-2c94-4742-bff4-0e802cf348f8","ioThrottleRate":"3
+        iops","lastUpdateDate":"2025-06-25T14:27:26.000Z","name":"test-volume-1GB-tier3-sharable","pvmInstanceIDs":[],"replicationEnabled":false,"replicationStatus":"not-capable","shareable":true,"size":1,"state":"available","volumeID":"2ce11d4a-2c94-4742-bff4-0e802cf348f8","volumePool":"General-Flash-53","volumeType":"Tier3-General-Flash-53","wwn":"6005076813810212980000000000A9B5"}]}
+
+        '
+  recorded_at: Wed, 25 Jun 2025 15:11:42 GMT
+- request:
+    method: get
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/placement-groups
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0/ruby
+      Content-Type:
+      - application/json
+      Crn:
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -450,29 +556,38 @@ http_interactions:
       - application/json
       Content-Length:
       - '344'
+      X-Correlation-Id:
+      - 279d118d-20d9-4fbc-97e0-3e6c983f5417
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"placementGroups":[{"id":"8334ba79-bd98-47af-ad25-6eb8a1c4c817","members":["e8cf72cf-7685-4bfb-a386-66422f71820a"],"name":"test-placement-group-affinity","policy":"affinity"},{"id":"f99c2fc5-73ba-4387-9736-61dc51f53471","members":["d6a661a8-fed1-4a52-9d50-24fc9f9956b8"],"name":"test-placement-group-anti-affinity","policy":"anti-affinity"}]}
+      encoding: ASCII-8BIT
+      string: '{"placementGroups":[{"id":"69ac6b47-912e-4346-8804-da768f4aa789","members":["04c9a30d-c8d5-46cb-849b-0f7fa5004b70"],"name":"test-placement-group-affinity","policy":"affinity"},{"id":"b52c11cb-b6bf-45a0-a376-242f4217ca6f","members":["9317b826-3660-4cf9-aa93-6d42a4643ba9"],"name":"test-placement-group-anti-affinity","policy":"anti-affinity"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:31:10 GMT
+  recorded_at: Wed, 25 Jun 2025 15:11:43 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/snapshots
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/snapshots
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -485,35 +600,44 @@ http_interactions:
     headers:
       Content-Type:
       - application/json
+      X-Correlation-Id:
+      - f29a6511-3813-4df9-b03e-0b695f478e4d
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"snapshots":[{"action":"snapshot","creationDate":"2024-01-18T19:14:39.000Z","description":"server
-        name: test-instance-ibmi-s922-capped-tier1","lastUpdateDate":"2024-01-18T19:14:49.000Z","name":"test-instance-ibmi-s922-capped-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"e8cf72cf-7685-4bfb-a386-66422f71820a","snapshotID":"0e536300-ad93-40f3-92f9-f5153785d2ac","status":"available","volumeSnapshots":{"ed84f79b-b8d1-48c3-8766-2a92ff6a879b":"2ad97524-7d8e-48dc-ace4-f66c544e2775"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:53.000Z","description":"server
-        name: test-instance-sles-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:15:02.000Z","name":"test-instance-sles-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"54e1f646-8ce4-4ee5-9355-e5d34166c4fd","snapshotID":"2d3fa834-5212-4ea4-ac2a-d28a244041c2","status":"available","volumeSnapshots":{"ba26d663-1e76-4457-8732-9d9235df8019":"5c7be867-f103-4a83-87af-53ffa26b07be"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:57.000Z","description":"server
-        name: test-instance-rhcos-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:15:05.000Z","name":"test-instance-rhcos-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"d6a661a8-fed1-4a52-9d50-24fc9f9956b8","snapshotID":"9c6127c6-b71d-417d-8238-e4642cf3df83","status":"available","volumeSnapshots":{"7d6f53e6-4adf-4792-8b5f-07cc618dff78":"7fabb55d-38e4-40c0-bd0c-ba44e706135e"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:44.000Z","description":"server
-        name: test-instance-centos-e980-dedicated-tier3","lastUpdateDate":"2024-01-18T19:14:53.000Z","name":"test-instance-centos-e980-dedicated-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"1ea38460-b3ff-4abd-802b-0289983be590","snapshotID":"9f192329-1470-4532-b609-16b56914fad0","status":"available","volumeSnapshots":{"cdfebbb2-d64e-41e1-9834-4f6b5d249489":"563ac449-f811-4ff7-bd91-adb026c82562"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:48.000Z","description":"server
-        name: test-instance-rhel-s922-shared-tier3","lastUpdateDate":"2024-01-18T19:14:58.000Z","name":"test-instance-rhel-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"b9370d8d-8d73-4f0e-ad84-34f7fd52eb84","snapshotID":"d5332d55-9d8f-4745-b26e-203387b59d55","status":"available","volumeSnapshots":{"984498df-5554-4685-a109-821d5e39b27b":"ccc567e7-63db-4441-ab3c-a206e41ff9b3"}},{"action":"snapshot","creationDate":"2024-01-18T19:14:35.000Z","description":"server
-        name: test-instance-aix-s922-shared-tier1","lastUpdateDate":"2024-01-18T19:14:44.000Z","name":"test-instance-aix-s922-shared-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"502106d8-d969-49df-9103-184c3ab97508","snapshotID":"e47f1ab4-22eb-4262-9b8c-b670afcbf6ef","status":"available","volumeSnapshots":{"2e653913-14fe-4b3a-a4f3-c7396bed0862":"0d6df030-deb6-4fe4-8247-42a61d7c4cad"}}]}
+      encoding: ASCII-8BIT
+      string: '{"snapshots":[{"action":"snapshot","creationDate":"2025-06-25T14:46:56.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:0385f05f-b922-45f6-a9df-d6e8b6bd9111","description":"server
+        name: test-instance-rhcos-s922-shared-tier3","lastUpdateDate":"2025-06-25T14:47:04.000Z","name":"test-instance-rhcos-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"9317b826-3660-4cf9-aa93-6d42a4643ba9","snapshotID":"0385f05f-b922-45f6-a9df-d6e8b6bd9111","status":"available","volumeSnapshots":{"55eeb86d-80d4-4ef2-9267-0075bac0378d":"992f34ab-4503-4ec2-82a8-acbb69e751dc"}},{"action":"snapshot","creationDate":"2025-06-25T14:46:38.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:05247445-494e-4ac7-b1d6-1818a1c4f6e2","description":"server
+        name: test-instance-rhel-s922-shared-tier3","lastUpdateDate":"2025-06-25T14:46:50.000Z","name":"test-instance-rhel-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"43a0b59a-f4d7-4150-8fb8-72b4e5452d02","snapshotID":"05247445-494e-4ac7-b1d6-1818a1c4f6e2","status":"available","volumeSnapshots":{"ab68a4b6-921e-4149-a6d3-70c281349fcf":"8a55602d-8bfa-4c5f-bbce-bacb7579de26"}},{"action":"snapshot","creationDate":"2025-06-25T14:46:12.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:071468b4-41e8-443a-b589-c789ea31eee2","description":"server
+        name: test-instance-aix-s922-shared-tier1","lastUpdateDate":"2025-06-25T14:46:20.000Z","name":"test-instance-aix-s922-shared-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"5d8393c6-b50c-4de4-98f0-a04222e9fbdc","snapshotID":"071468b4-41e8-443a-b589-c789ea31eee2","status":"available","volumeSnapshots":{"1f455cf4-c82c-4e1b-b84b-f1e86082aadf":"d0b96d4d-8459-4348-81cf-0354a1d17265"}},{"action":"snapshot","creationDate":"2025-06-25T14:46:29.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:71bec2d4-6c61-4fbe-afd9-13a8c1f2c8fb","description":"server
+        name: test-instance-centos-e980-dedicated-tier3","lastUpdateDate":"2025-06-25T14:46:37.000Z","name":"test-instance-centos-e980-dedicated-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"c19f7546-323e-4e0b-bf97-5ad8668f0529","snapshotID":"71bec2d4-6c61-4fbe-afd9-13a8c1f2c8fb","status":"available","volumeSnapshots":{"4fdf9382-aa4c-435e-9352-de392a6ef278":"d9aa27fb-fdc0-454a-bc54-53a1fda20fb4"}},{"action":"snapshot","creationDate":"2025-06-25T14:46:47.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:bd5bcb88-d639-44f3-8aad-250b243288a1","description":"server
+        name: test-instance-sles-s922-shared-tier3","lastUpdateDate":"2025-06-25T14:47:00.000Z","name":"test-instance-sles-s922-shared-tier3-snapshot-1","percentComplete":100,"pvmInstanceID":"c717671d-baae-4955-879f-0588ef5171bb","snapshotID":"bd5bcb88-d639-44f3-8aad-250b243288a1","status":"available","volumeSnapshots":{"2b3477a2-5e5c-46fc-8906-bc2ef9166c37":"bd49d8f0-e5dd-4001-9132-5e22c9be06a7"}},{"action":"snapshot","creationDate":"2025-06-25T14:46:20.000Z","crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:snapshot:f5bc67a9-ed33-4ea0-92ee-881be8b90eb2","description":"server
+        name: test-instance-ibmi-s922-capped-tier1","lastUpdateDate":"2025-06-25T14:46:28.000Z","name":"test-instance-ibmi-s922-capped-tier1-snapshot-1","percentComplete":100,"pvmInstanceID":"04c9a30d-c8d5-46cb-849b-0f7fa5004b70","snapshotID":"f5bc67a9-ed33-4ea0-92ee-881be8b90eb2","status":"available","volumeSnapshots":{"b6a90aec-fce5-4640-9a99-140e8af2b103":"7baaad1a-d2f3-4dbb-816a-5bee06d0f559"}}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:31:11 GMT
+  recorded_at: Wed, 25 Jun 2025 15:11:44 GMT
 - request:
     method: get
-    uri: https://mon.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/shared-processor-pools
+    uri: https://us-east.power-iaas.cloud.ibm.com/pcloud/v1/cloud-instances/IBM_CLOUD_POWERVS_INSTANCE_ID/shared-processor-pools
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - OpenAPI-Generator/2.1.1/ruby
+      - OpenAPI-Generator/3.0.0/ruby
       Content-Type:
       - application/json
       Crn:
-      - 'crn:v1:bluemix:public:power-iaas:mon01:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
+      - 'crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::'
       Authorization: Bearer xxxxxx
       Accept:
       - application/json
@@ -527,16 +651,25 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '384'
+      - '563'
+      X-Correlation-Id:
+      - 651f4234-a3a6-4ec2-8134-231459d02bce
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Debug-Num:
+      - '221'
+      X-Debug-Downstream:
+      - crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID::|
+        -> private.us-south.power-iaas.cloud.ibm.com
+      X-Debug-Host-Header:
+      - private.us-south.power-iaas.cloud.ibm.com
       Cf-Cache-Status:
       - DYNAMIC
     body:
-      encoding: UTF-8
-      string: '{"sharedProcessorPools":[{"allocatedCores":0.5,"availableCores":0.5,"hostGroup":"s922","hostID":6,"id":"85029156-8753-4d06-9a56-d13e3bd4c27d","name":"test_pool","reservedCores":1,"sharedProcessorPoolPlacementGroups":[{"id":"bb252e11-c5f9-43fb-9801-2218058fe030","name":"test_spppg","policy":"affinity"}],"status":"active","statusDetail":"shared
+      encoding: ASCII-8BIT
+      string: '{"sharedProcessorPools":[{"allocatedCores":0.5,"availableCores":0.5,"crn":"crn:v1:bluemix:public:power-iaas:us-east10:a/1fdf5effc3f945688c021cd0a8b45c4d:IBM_CLOUD_POWERVS_INSTANCE_ID:shared-processor-pool:85ba15e6-bbc0-469b-90b7-697876167cfc","hostGroup":"s922","hostID":58,"id":"85ba15e6-bbc0-469b-90b7-697876167cfc","name":"test_pool","reservedCores":1,"sharedProcessorPoolPlacementGroups":[{"id":"6101a596-8553-4792-8ce5-920c58bc929f","name":"test_spppg","policy":"affinity"}],"status":"active","statusDetail":"shared
         processor pool test_pool is active"}]}
 
         '
-  recorded_at: Thu, 18 Jan 2024 19:31:12 GMT
-recorded_with: VCR 6.2.0
+  recorded_at: Wed, 25 Jun 2025 15:11:47 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
The PowerVS System Pools API has been deprecated and is no longer available. It was only used to get a list of available host types, which is also available in the Datacenters API.

Depends on:
 - [ ] https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/pull/75
 - [ ] Release [`ibm_cloud_power` v3.0.0 gem](https://rubygems.org/gems/ibm_cloud_power/versions)