### PR TITLE
Update CloudTools for updated tagging gem

### DIFF
--- a/lib/manageiq/providers/ibm_cloud/cloud_tools/taggings.rb
+++ b/lib/manageiq/providers/ibm_cloud/cloud_tools/taggings.rb
@@ -12,12 +12,49 @@ module ManageIQ
 
         # CloudTools wrapper class to enhance the IBM Tagging SDK.
         class GlobalTag < Sdk::Branch
+          # Override client method to handle configuration for the new SDK
+          def client
+            sdk_client.tap do |client|
+              # Configure proxy if present
+              if @cloudtools.proxy.to_hash[:address]
+                proxy_hash = @cloudtools.proxy.to_hash
+                client.api_client.config.scheme = 'http'
+                client.api_client.config.host = "#{proxy_hash[:address]}:#{proxy_hash[:port]}"
+              end
+
+              # Configure timeout if present
+              timeout_hash = @cloudtools.timeout.to_hash
+              client.api_client.config.timeout = timeout_hash[:timeout] if timeout_hash[:timeout]
+            end
+          end
+
+          # Override request method to handle the new SDK's response format
+          # The new SDK returns model objects directly, not wrapped in a .result property
+          def request(call_back, **)
+            request = send_request(call_back, **)
+            return if request.nil?
+
+            # The new SDK returns the model object directly
+            # Convert it to a hash using to_hash if available, otherwise use JSON conversion
+            if request.respond_to?(:to_hash)
+              request.to_hash
+            else
+              JSON.parse(request.to_json, :symbolize_names => true)
+            end
+          end
+
           private
 
           # Return a GlobalTagging SDK instance. Requires an internet connection.
-          # @return [IbmCloudGlobalTagging::GlobalTaggingV1]
+          # @return [IbmCloudGlobalTagging::TagsApi]
           def sdk_client
-            IbmCloudGlobalTagging::GlobalTaggingV1.new(:authenticator => @cloudtools.authenticator)
+            # This is called by the parent's client method, but we override client
+            # so this won't be used. Keeping for compatibility.
+            config = IbmCloudGlobalTagging::Configuration.new
+            config.access_token = @cloudtools.authenticator.bearer_info[:token]
+
+            api_client = IbmCloudGlobalTagging::ApiClient.new(config)
+            IbmCloudGlobalTagging::TagsApi.new(api_client)
           end
 
           # Create a generator that removes the need for pagination.

--- a/manageiq-providers-ibm_cloud.gemspec
+++ b/manageiq-providers-ibm_cloud.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ibm-cloud-sdk", "~> 0.1"
   spec.add_dependency "ibm_cloud_activity_tracker", "~> 0.1", ">= 0.1.2"
   spec.add_dependency "ibm_cloud_databases", "~> 0.1", ">= 0.1.1"
-  spec.add_dependency "ibm_cloud_global_tagging", "~> 0.1", ">= 0.1.2"
+  spec.add_dependency "ibm_cloud_global_tagging", "~> 0.2"
   spec.add_dependency "ibm_vpc", "~> 0.6", ">= 0.6.1"
   spec.add_dependency "prometheus-api-client", "~> 0.6"
   spec.add_dependency "rest-client", "~> 2.1"

--- a/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_tools_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/vpc/cloud_tools_spec.rb
@@ -176,7 +176,7 @@ describe ManageIQ::Providers::IbmCloud::CloudTool, :vcr do
   # Test that the tagging client can get tags.
   it 'can get a Tagging client' do
     cloud_tool = described_class.new(:api_key => api_key)
-    expect(cloud_tool.tagging.client).to be_a(IbmCloudGlobalTagging::GlobalTaggingV1)
+    expect(cloud_tool.tagging.client).to be_a(IbmCloudGlobalTagging::TagsApi)
     tags = cloud_tool.tagging.request(:list_tags, :limit => 1)
     expect(tags).to be_a(Hash)
     expect(tags[:items]).to be_a(Array)


### PR DESCRIPTION
Use the auto-generated ibm_cloud_global_tagging gem https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/pull/85

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
