### PR TITLE
disable deleting snapshots when there are none

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -14,9 +14,6 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
   supports :revert_to_snapshot do
     _("Cannot revert to snapshot while VM is running") unless current_state == "off"
   end
-  supports :remove_snapshot
-  supports :remove_all_snapshots
-
   supports_not :suspend
 
   supports :publish do

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
@@ -42,6 +42,28 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm do
       let(:state) { :resize }
       include_examples "Vm operation is available when not powered on"
     end
+
+    context "with :remove_snapshot" do
+      it "is not supported when the VM has no snapshots" do
+        expect(vm.supports?(:remove_snapshot)).to be_falsey
+      end
+
+      it "is supported when the VM has at least one snapshot" do
+        FactoryBot.create(:snapshot, :vm_or_template => vm)
+        expect(vm.supports?(:remove_snapshot)).to be_truthy
+      end
+    end
+
+    context "with :remove_all_snapshots" do
+      it "is not supported when the VM has no snapshots" do
+        expect(vm.supports?(:remove_all_snapshots)).to be_falsey
+      end
+
+      it "is supported when the VM has at least one snapshot" do
+        FactoryBot.create(:snapshot, :vm_or_template => vm)
+        expect(vm.supports?(:remove_all_snapshots)).to be_truthy
+      end
+    end
   end
 
   context "supports VM console access?" do

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
@@ -42,28 +42,6 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm do
       let(:state) { :resize }
       include_examples "Vm operation is available when not powered on"
     end
-
-    context "with :remove_snapshot" do
-      it "is not supported when the VM has no snapshots" do
-        expect(vm.supports?(:remove_snapshot)).to be_falsey
-      end
-
-      it "is supported when the VM has at least one snapshot" do
-        FactoryBot.create(:snapshot, :vm_or_template => vm)
-        expect(vm.supports?(:remove_snapshot)).to be_truthy
-      end
-    end
-
-    context "with :remove_all_snapshots" do
-      it "is not supported when the VM has no snapshots" do
-        expect(vm.supports?(:remove_all_snapshots)).to be_falsey
-      end
-
-      it "is supported when the VM has at least one snapshot" do
-        FactoryBot.create(:snapshot, :vm_or_template => vm)
-        expect(vm.supports?(:remove_all_snapshots)).to be_truthy
-      end
-    end
   end
 
   context "supports VM console access?" do

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
@@ -42,6 +42,32 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm do
       let(:state) { :resize }
       include_examples "Vm operation is available when not powered on"
     end
+
+    context "with :remove_snapshot" do
+      before { EvmSpecHelper.local_miq_server }
+
+      it "is not supported when the VM has no snapshots" do
+        expect(vm.supports?(:remove_snapshot)).to be_falsey
+      end
+
+      it "is supported when the VM has at least one snapshot" do
+        FactoryBot.create(:snapshot, :vm_or_template => vm)
+        expect(vm.supports?(:remove_snapshot)).to be_truthy
+      end
+    end
+
+    context "with :remove_all_snapshots" do
+      before { EvmSpecHelper.local_miq_server }
+
+      it "is not supported when the VM has no snapshots" do
+        expect(vm.supports?(:remove_all_snapshots)).to be_falsey
+      end
+
+      it "is supported when the VM has at least one snapshot" do
+        FactoryBot.create(:snapshot, :vm_or_template => vm)
+        expect(vm.supports?(:remove_all_snapshots)).to be_truthy
+      end
+    end
   end
 
   context "supports VM console access?" do


### PR DESCRIPTION
manageiq-core has the correct guard-clauses that only lets you remove snapshot/s when they exist;
plugin overrides it and as a result displays these options in the UI even for those VMs with no snapshots.

Fixes https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/565