### PR TITLE
[TAL] Lockdown ibm_cloud_global_tagging gem

### DIFF
--- a/manageiq-providers-ibm_cloud.gemspec
+++ b/manageiq-providers-ibm_cloud.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ibm-cloud-sdk", "~> 0.1"
   spec.add_dependency "ibm_cloud_activity_tracker", "~> 0.1", ">= 0.1.2"
   spec.add_dependency "ibm_cloud_databases", "~> 0.1", ">= 0.1.1"
-  spec.add_dependency "ibm_cloud_global_tagging", "~> 0.1", ">= 0.1.2"
+  spec.add_dependency "ibm_cloud_global_tagging", "~> 0.1.0", ">= 0.1.2"
   spec.add_dependency "ibm_vpc", "~> 0.6", ">= 0.6.1"
   spec.add_dependency "prometheus-api-client", "~> 0.6"
   spec.add_dependency "rest-client", "~> 2.1"


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-providers-ibm_cloud/pull/569 updated IBM Cloud provider for the newer openapi generated ibm_cloud_global_tagging gem, but the gemspec version dependency was open enough to bring in the newer gem.

This keeps us on the same version as was in use before on this branch.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
