### PR TITLE
add support for Power VS multi-vm provisioning

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -73,8 +73,13 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
       specs['sys_type']      = get_option_last(:sys_type)
     end
 
-    specs['placement_group'] = get_option(:placement_group) unless get_option(:placement_group).nil?
-    specs['shared_processor_pool'] = get_option(:shared_processor_pool) unless get_option(:shared_processor_pool).nil?
+    if get_option_last(:number_of_vms).to_i > 1
+      policy = get_option(:replicant_affinity_policy)
+      specs['placementGroupPolicy'] = policy if policy.present? && policy != 'none'
+    else
+      specs['placement_group'] = get_option(:placement_group) unless get_option(:placement_group).nil?
+      specs['shared_processor_pool'] = get_option(:shared_processor_pool) unless get_option(:shared_processor_pool).nil?
+    end
     user_script_text = options[:user_script_text]
     user_script_text64 = Base64.encode64(user_script_text) unless user_script_text.nil?
     specs['user_data'] = user_script_text64 unless user_script_text64.nil?

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -169,13 +169,14 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
 
       phase_context[:cloud_api_completion_time] = Time.zone.now.utc if all_done
 
-      if building.any?
-        status = "#{building.length} of #{ids.length} instance(s) still provisioning."
-      elsif all_done
-        status = "All #{ids.length} instance(s) provisioned and active."
-      else
-        status = "#{active.length} of #{ids.length} instance(s) active, waiting for full description."
-      end
+      status = if building.any?
+                "#{building.length} of #{ids.length} instance(s) still provisioning."
+               elsif all_done
+                "All #{ids.length} instance(s) provisioned and active."
+               else
+                _log.warn("Unknown server state received from the cloud API: '#{instance_state}'")
+                "#{active.length} of #{ids.length} instance(s) active, waiting for full description."
+               end
 
       return all_done, status
     end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -50,6 +50,8 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
   end
 
   def prepare_for_clone
+    replicants = get_option(:replicants)
+
     specs = {
       'image_id'   => get_option_last(:src_vm_id),
       'pin_policy' => get_option_last(:pin_policy),
@@ -62,20 +64,23 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
       specs['profile_id']   = get_option_last(:sys_type)
       specs['ssh_key_name'] = chosen_key_pair unless chosen_key_pair == 'None'
     else
-      specs['server_name']   = get_option(:vm_target_name)
-      specs['memory']        = get_option_last(:vm_memory).to_i
-      specs['processors']    = get_option_last(:entitled_processors).to_f
-      specs['proc_type']     = get_option_last(:instance_type)
-      specs['pin_policy']    = get_option_last(:pin_policy)
-      specs['replicants']    = 1 # TODO: we have to use this field instead of what 'MIQ' does
-      specs['key_pair_name'] = chosen_key_pair unless chosen_key_pair == 'None'
-      specs['storage_type']  = get_option_last(:storage_type)
-      specs['sys_type']      = get_option_last(:sys_type)
+      specs['server_name']             = get_option(:vm_target_name)
+      specs['memory']                  = get_option_last(:vm_memory).to_i
+      specs['processors']              = get_option_last(:entitled_processors).to_f
+      specs['proc_type']               = get_option_last(:instance_type)
+      specs['pin_policy']              = get_option_last(:pin_policy)
+      specs['replicant_naming_scheme'] = 'suffix' if replicants > 1
+      specs['key_pair_name']           = chosen_key_pair unless chosen_key_pair == 'None'
+      specs['storage_type']            = get_option_last(:storage_type)
+      specs['sys_type']                = get_option_last(:sys_type)
     end
-
-    if get_option_last(:number_of_vms).to_i > 1
+    # When the count of VMs is more than 1, treat it as a multi-VM provision request with replicas
+    # placement_group and shared_processor_pool fields are no longer relevant
+    # replicants and replicant_affinity_policy(defaults to none) fields are relevant
+    if replicants > 1
+      specs['replicants'] = replicants
       policy = get_option(:replicant_affinity_policy)
-      specs['placementGroupPolicy'] = policy if policy.present? && policy != 'none'
+      specs['replicant_affinity_policy'] = policy if policy.present? && policy != 'none'
     else
       specs['placement_group'] = get_option(:placement_group) unless get_option(:placement_group).nil?
       specs['shared_processor_pool'] = get_option(:shared_processor_pool) unless get_option(:shared_processor_pool).nil?
@@ -125,7 +130,8 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     source.with_provider_connection(:service => "PCloudPVMInstancesApi") do |api|
       body = IbmCloudPower::PVMInstanceCreate.new(clone_options)
       response = api.pcloud_pvminstances_post(cloud_instance_id, body)
-      response&.first&.pvm_instance_id
+      ids = response&.map(&:pvm_instance_id)&.compact
+      ids.length == 1 ? ids.first : ids
     end
   end
 
@@ -140,26 +146,39 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
   end
 
   def check_task_clone(clone_task_ref)
-    source.with_provider_connection(:service => "PCloudPVMInstancesApi") do |api|
-      instance = api.pcloud_pvminstances_get(cloud_instance_id, clone_task_ref)
-      instance_state = instance.status
-      stop = false
+    ids = Array(clone_task_ref)
 
-      case instance_state
-      when 'BUILD'
-        status = 'The server is being provisioned.'
-      when 'ACTIVE'
-        stop = (instance.processors.to_f > 0) && (instance.memory.to_f > 0)
-        phase_context[:cloud_api_completion_time] = Time.zone.now.utc if stop
-        status = "The server has been provisioned.; #{stop ? 'Server description available.' : 'Waiting for server description.'}"
-      when 'ERROR'
-        raise MiqException::MiqProvisionError, _("An error occurred while provisioning the instance.")
-      else
-        status = "Unknown server state received from the cloud API: '#{instance_state}'"
-        _log.warn(status)
+    source.with_provider_connection(:service => "PCloudPVMInstancesApi") do |api|
+      statuses = ids.map do |id|
+        begin
+          instance = api.pcloud_pvminstances_get(cloud_instance_id, id)
+          [id, instance.status, instance.processors.to_f, instance.memory.to_f]
+        rescue IbmCloudPower::ApiError => e
+          # The instance may not be queryable immediately after creation (transient
+          # 500s are common in the first few seconds).  Treat it as still building.
+          _log.warn("Transient error polling instance #{id}: #{e.message}. Will retry.")
+          [id, 'BUILD', 0, 0]
+        end
       end
 
-      return stop, status
+      errored = statuses.select { |_, state, _, _| state == 'ERROR' }
+      raise MiqException::MiqProvisionError, _("An error occurred while provisioning the instance.") if errored.any?
+
+      building = statuses.select { |_, state, _, _| state == 'BUILD' }
+      active   = statuses.select { |_, state, cpus, mem| state == 'ACTIVE' && cpus > 0 && mem > 0 }
+      all_done = building.empty? && active.length == ids.length
+
+      phase_context[:cloud_api_completion_time] = Time.zone.now.utc if all_done
+
+      if building.any?
+        status = "#{building.length} of #{ids.length} instance(s) still provisioning."
+      elsif all_done
+        status = "All #{ids.length} instance(s) provisioned and active."
+      else
+        status = "#{active.length} of #{ids.length} instance(s) active, waiting for full description."
+      end
+
+      return all_done, status
     end
   end
 end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/cloning.rb
@@ -130,8 +130,7 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     source.with_provider_connection(:service => "PCloudPVMInstancesApi") do |api|
       body = IbmCloudPower::PVMInstanceCreate.new(clone_options)
       response = api.pcloud_pvminstances_post(cloud_instance_id, body)
-      ids = response&.map(&:pvm_instance_id)&.compact
-      ids.length == 1 ? ids.first : ids
+      response&.map(&:pvm_instance_id)&.compact
     end
   end
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
@@ -9,6 +9,46 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
     end
   end
 
+  # Override the core cloud state machine's poll_clone_complete to handle the
+  # case where make_request_clone returned an array of pvm_instance_ids
+  # (replicants > 1).  For a single VM the behaviour is identical to core.
+  def poll_clone_complete
+    clone_status, status_message = do_clone_task_check(phase_context[:clone_task_ref])
+
+    status_message = "completed; post provision work queued" if clone_status
+    message = "Clone of #{clone_direction} is #{status_message}"
+    _log.info(message)
+    update_and_notify_parent(:message => message)
+
+    if clone_status
+      clone_task_ref = phase_context.delete(:clone_task_ref)
+      ids = Array(clone_task_ref)
+
+      # Store the first ID as new_vm_ems_ref so the core poll_destination_in_vmdb
+      # machinery can locate the destination VM after inventory refresh lands.
+      phase_context[:new_vm_ems_ref] = ids.first
+
+      manager = source.ext_management_system
+
+      if manager.allow_targeted_refresh?
+        ids.each do |id|
+          target = InventoryRefresh::Target.new(
+            :manager     => manager,
+            :association => :vms,
+            :manager_ref => {:ems_ref => id}
+          )
+          EmsRefresh.queue_refresh(target)
+        end
+      else
+        EmsRefresh.queue_refresh(manager)
+      end
+
+      signal :poll_destination_in_vmdb
+    else
+      requeue_phase
+    end
+  end
+
   def prepare_volumes_and_networks
     new_volumes = options[:new_volumes]
     phase_context[:new_volumes] = []

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision/state_machine.rb
@@ -31,14 +31,9 @@ module ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisi
       manager = source.ext_management_system
 
       if manager.allow_targeted_refresh?
-        ids.each do |id|
-          target = InventoryRefresh::Target.new(
-            :manager     => manager,
-            :association => :vms,
-            :manager_ref => {:ems_ref => id}
-          )
-          EmsRefresh.queue_refresh(target)
-        end
+        target_collection = InventoryRefresh::TargetCollection.new(:manager => manager)
+        ids.each { |id| target_collection.add_target(:association => :vms, :manager_ref => {:ems_ref => id}) }
+        EmsRefresh.queue_refresh(target_collection)
       else
         EmsRefresh.queue_refresh(manager)
       end

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -135,7 +135,15 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
   end
 
   def set_request_values(values)
-    values[:new_volumes] = parse_new_volumes_fields(values)
+    values[:new_volumes]    = parse_new_volumes_fields(values)
+
+    # Power VS creates all replicas in a single API call (replicants field).
+    # Store the real count under :replicants so the provision task can pass it
+    # to the SDK, then clamp :number_of_vms to 1 so core only creates one task.
+    number_of_vms           = get_value(values[:number_of_vms]).to_i
+    values[:replicants]     = number_of_vms
+    values[:number_of_vms]  = [1, "1"]
+
     super
   end
 

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/provision_workflow.rb
@@ -216,6 +216,20 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Provisio
     _('Invalid processor pool - incompatible machine type (host)') unless valid
   end
 
+  def update_field_visibility
+    multi_vm = get_value(@values[:number_of_vms]).to_i > 1
+
+    if multi_vm
+      show_fields(:hide,   [:placement_group, :shared_processor_pool])
+      show_fields(:edit,   [:replicant_affinity_policy])
+    else
+      show_fields(:edit,   [:placement_group, :shared_processor_pool])
+      show_fields(:hide,   [:replicant_affinity_policy])
+    end
+
+    super
+  end
+
   private
 
   def ar_ems

--- a/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_powervs_dialogs_template.yaml
@@ -41,6 +41,16 @@
           :display: :edit
           :auto_select_single: false
           :data_type: :string
+        :replicant_affinity_policy:
+          :values:
+            none: None
+            affinity: Affinity (same host)
+            anti-affinity: Anti-affinity (different hosts)
+          :description: Colocation Policy
+          :required: false
+          :display: :hide
+          :default: none
+          :data_type: :string
         :pin_policy:
           :values:
             1: "none"


### PR DESCRIPTION
Add support for multi-vm provisioning, a capability native to Power VS. This is done using the **replicants** field.
As the **number_of_vms** goes beyond 1, its value is copied into the hidden **replicants** field and the former is reset to 1 to avoid core fan-out of ProvisionTasks.
Visibility of certain fields that are no longer relevant are toggled off while other fields that are, are rendered.

Related:
* https://github.com/ManageIQ/manageiq-ui-classic/pull/10227