### PR TITLE
Add shutdown guest support for PowerVS VMs

### DIFF
--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -67,7 +67,7 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
     pcloud_pvminstances_action_post("start")
     update!(:raw_power_state => "ACTIVE")
   end
- 
+
   def raw_stop
     pcloud_pvminstances_action_post("immediate-shutdown")
     update!(:raw_power_state => "SHUTOFF")

--- a/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm.rb
@@ -9,6 +9,9 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
   supports :reset do
     _("The VM is not powered on") unless current_state == "on"
   end
+  supports :shutdown_guest do
+    _("The VM is not powered on") unless current_state == "on"
+  end
   supports :snapshots
   supports :snapshot_create
   supports :revert_to_snapshot do
@@ -64,8 +67,13 @@ class ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm < Man
     pcloud_pvminstances_action_post("start")
     update!(:raw_power_state => "ACTIVE")
   end
-
+ 
   def raw_stop
+    pcloud_pvminstances_action_post("immediate-shutdown")
+    update!(:raw_power_state => "SHUTOFF")
+  end
+
+  def raw_shutdown_guest
     pcloud_pvminstances_action_post("stop")
     update!(:raw_power_state => "SHUTOFF")
   end

--- a/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_cloud/power_virtual_servers/cloud_manager/vm_spec.rb
@@ -20,7 +20,7 @@ describe ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::Vm do
 
     context "with :shutdown_guest" do
       let(:state) { :shutdown_guest }
-      include_examples "Vm operation is not available"
+      include_examples "Vm operation is available when powered on"
     end
 
     context "with :standby_guest" do


### PR DESCRIPTION
## Summary

This change adds support for the Shutdown Guest action for PowerVS virtual machines.
Previously, users were only able to use the available power actions. With this update, users can also perform a guest shutdown, and a regular stop operation.

## Changes Made

- Added support for the Shutdown Guest action
- Updated the PowerVS VM implementation to handle the action appropriately

Associated UI PR link:https://github.com/ManageIQ/manageiq-ui-classic/pull/10235
